### PR TITLE
use BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES to select variadic macro...

### DIFF
--- a/include/boost/spirit/home/qi/detail/pass_container.hpp
+++ b/include/boost/spirit/home/qi/detail/pass_container.hpp
@@ -198,7 +198,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     // We pass through the container attribute if at least one of the embedded 
     // types in the variant requires to pass through the attribute
 
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && defined(BOOST_VARIANT_USE_VARIADIC_TEMPLATES)
+#if !defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
     template <typename Container, typename ValueType, typename Sequence
       , typename T>
     struct pass_through_container<Container, ValueType, boost::variant<T>

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -202,7 +202,7 @@ namespace boost { namespace spirit { namespace traits
     struct is_weak_substitute<T, optional<Expected> >
       : is_weak_substitute<T, Expected> {};
 
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && defined(BOOST_VARIANT_USE_VARIADIC_TEMPLATES)
+#if !defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
     template <typename T, typename Expected>
     struct is_weak_substitute<boost::variant<T>, Expected>
       : is_weak_substitute<T, Expected>

--- a/include/boost/spirit/home/support/container.hpp
+++ b/include/boost/spirit/home/support/container.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace spirit { namespace traits
       : is_container<T>
     {};
 
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && defined(BOOST_VARIANT_USE_VARIADIC_TEMPLATES)
+#if !defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
     template<typename T>
     struct is_container<boost::variant<T> >
       : is_container<T>

--- a/include/boost/spirit/home/support/detail/as_variant.hpp
+++ b/include/boost/spirit/home/support/detail/as_variant.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace spirit { namespace detail
     template <int size>
     struct as_variant_impl;
 
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && defined(BOOST_VARIANT_USE_VARIADIC_TEMPLATES)
+#if !defined(BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES)
 #else
     template <>
     struct as_variant_impl<0>


### PR DESCRIPTION
Boost.Variant now has BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES. So use this to enable variadic macro support. instead of using own checks.
