### PR TITLE
use std::string as a container for char

### DIFF
--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/spirit/home/x3/support/unused.hpp>
 #include <boost/detail/iterator.hpp>
+#include <boost/fusion/include/deque.hpp>
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/mpl/bool.hpp>
 #include <vector>
@@ -303,6 +304,9 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     struct build_container : mpl::identity<std::vector<T>> {};
+
+    template <typename T>
+    struct build_container<boost::fusion::deque<T> > : build_container<T> {};
 
     template <>
     struct build_container<unused_type> : mpl::identity<unused_type> {};


### PR DESCRIPTION
That is what normally users would pass, so in some situations it
can avoid copying data.
