### PR TITLE
Fix for #8537: Qi `skip` fails when nested under two or more levels of `...

### DIFF
--- a/include/boost/spirit/home/qi/detail/unused_skipper.hpp
+++ b/include/boost/spirit/home/qi/detail/unused_skipper.hpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <boost/spirit/home/support/unused.hpp>
+#include <boost/mpl/bool.hpp>
 
 namespace boost { namespace spirit { namespace qi { namespace detail
 {
@@ -26,12 +27,24 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         unused_skipper& operator= (unused_skipper const&);
     };
 
+    template <typename Skipper>
+    struct is_unused_skipper
+      : mpl::false_ {};
+
+    template <typename Skipper>
+    struct is_unused_skipper<unused_skipper<Skipper>>
+      : mpl::true_ {};
+
+    template <>
+    struct is_unused_skipper<unused_type>
+      : mpl::true_ {};
+
     // If a surrounding lexeme[] directive was specified, the current
-    // skipper is of the type unused_skipper. In this case we 
+    // skipper is of the type unused_skipper. In this case we
     // re-activate the skipper which was active before the skip[]
     // directive.
     template <typename Skipper>
-    inline Skipper const& 
+    inline Skipper const&
     get_skipper(unused_skipper<Skipper> const& u)
     {
         return u.skipper;
@@ -39,7 +52,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
     // If no surrounding lexeme[] directive was specified we keep what we got.
     template <typename Skipper>
-    inline Skipper const& 
+    inline Skipper const&
     get_skipper(Skipper const& u)
     {
         return u;

--- a/include/boost/spirit/home/qi/directive/lexeme.hpp
+++ b/include/boost/spirit/home/qi/directive/lexeme.hpp
@@ -20,6 +20,7 @@
 #include <boost/spirit/home/qi/detail/attributes.hpp>
 #include <boost/spirit/home/support/info.hpp>
 #include <boost/spirit/home/support/handles_container.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace boost { namespace spirit
 {
@@ -55,13 +56,26 @@ namespace boost { namespace spirit { namespace qi
 
         template <typename Iterator, typename Context
           , typename Skipper, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
+        typename disable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
           , Context& context, Skipper const& skipper
           , Attribute& attr_) const
         {
             qi::skip_over(first, last, skipper);
             return subject.parse(first, last, context
               , detail::unused_skipper<Skipper>(skipper), attr_);
+        }
+        template <typename Iterator, typename Context
+          , typename Skipper, typename Attribute>
+        typename enable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
+          , Context& context, Skipper const& skipper
+          , Attribute& attr_) const
+        {
+            //  no need to pre-skip if skipper is unused
+            //- qi::skip_over(first, last, skipper);
+            return subject.parse(first, last, context
+              , skipper, attr_);
         }
 
         template <typename Context>

--- a/include/boost/spirit/home/qi/directive/no_skip.hpp
+++ b/include/boost/spirit/home/qi/directive/no_skip.hpp
@@ -22,6 +22,7 @@
 #include <boost/spirit/home/support/info.hpp>
 #include <boost/spirit/home/support/has_semantic_action.hpp>
 #include <boost/spirit/home/support/handles_container.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace boost { namespace spirit
 {
@@ -58,12 +59,23 @@ namespace boost { namespace spirit { namespace qi
 
         template <typename Iterator, typename Context
           , typename Skipper, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
+        typename disable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
           , Context& context, Skipper const& skipper
           , Attribute& attr_) const
         {
             return subject.parse(first, last, context
               , detail::unused_skipper<Skipper>(skipper), attr_);
+        }
+        template <typename Iterator, typename Context
+          , typename Skipper, typename Attribute>
+        typename enable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
+          , Context& context, Skipper const& skipper
+          , Attribute& attr_) const
+        {
+            return subject.parse(first, last, context
+              , skipper, attr_);
         }
 
         template <typename Context>

--- a/include/boost/spirit/home/qi/directive/skip.hpp
+++ b/include/boost/spirit/home/qi/directive/skip.hpp
@@ -26,6 +26,7 @@
 #include <boost/spirit/home/support/handles_container.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/vector.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace boost { namespace spirit
 {
@@ -75,12 +76,23 @@ namespace boost { namespace spirit { namespace qi
 
         template <typename Iterator, typename Context
           , typename Skipper, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
+        typename enable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
           , Context& context, Skipper const& u // --> The skipper is reintroduced
           , Attribute& attr_) const
         {
             return subject.parse(first, last, context
               , detail::get_skipper(u), attr_);
+        }
+        template <typename Iterator, typename Context
+          , typename Skipper, typename Attribute>
+        typename disable_if<detail::is_unused_skipper<Skipper>, bool>::type
+        parse(Iterator& first, Iterator const& last
+          , Context& context, Skipper const& skipper
+          , Attribute& attr_) const
+        {
+            return subject.parse(first, last, context
+              , skipper, attr_);
         }
 
         template <typename Context>

--- a/test/qi/skip.cpp
+++ b/test/qi/skip.cpp
@@ -39,6 +39,10 @@ main()
         BOOST_TEST((test("ab c d", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));
         BOOST_TEST((test("abcd", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));
         BOOST_TEST(!(test("a bcd", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));
+        
+        BOOST_TEST((test("ab c d", lexeme[lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']]], space)));
+        BOOST_TEST((test("abcd", lexeme[lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']]], space)));
+        BOOST_TEST(!(test("a bcd", lexeme[lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']]], space)));
     }
 
     { // lazy skip


### PR DESCRIPTION
...lexeme`
