### PR TITLE
Compilation Issue

### DIFF
--- a/include/boost/spirit/home/x3/core/action.hpp
+++ b/include/boost/spirit/home/x3/core/action.hpp
@@ -21,6 +21,7 @@
 
 namespace boost { namespace spirit { namespace x3
 {
+    struct raw_attribute_type;
     struct rule_context_tag;
 
     namespace detail
@@ -157,7 +158,7 @@ namespace boost { namespace spirit { namespace x3
         // attr==raw_attribute_type, action wants iterator_range (see raw.hpp)
         template <typename Iterator, typename Context>
         bool parse(Iterator& first, Iterator const& last
-          , Context const& context, raw_attribute_type, mpl::false_) const
+          , Context const& context, raw_attribute_type const&, mpl::false_) const
         {
             boost::iterator_range<Iterator> rng;
             // synthesize the attribute since one is not supplied

--- a/include/boost/spirit/home/x3/directive/raw.hpp
+++ b/include/boost/spirit/home/x3/directive/raw.hpp
@@ -7,7 +7,9 @@
 #if !defined(SPIRIT_X3_RAW_APRIL_9_2007_0912AM)
 #define SPIRIT_X3_RAW_APRIL_9_2007_0912AM
 
+#include <boost/spirit/home/x3/core/skip_over.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
+#include <boost/spirit/home/x3/support/traits/move_to.hpp>
 #include <boost/range/iterator_range.hpp>
 
 namespace boost { namespace spirit { namespace x3


### PR DESCRIPTION
Caught this while re-merging code for the extensions seek parser. Including x3/core.hpp will result in compilation issue because raw_attribute_type is not declared. Including x3/directive.hpp will result in compilation issue because several headers in raw directive were not included.

I don't know if this is the desired way to fix the missing symbol, so nudge me in the proper direction if necessary.
