### PR TITLE
Improvement/test parse failure

### DIFF
--- a/test/x3/extensions/seek.cpp
+++ b/test/x3/extensions/seek.cpp
@@ -88,5 +88,10 @@ int main()
         );
     }
 
+    // test failure rollback
+    {
+        BOOST_TEST(test_failure("abcdefg", x3::seek[x3::int_]));
+    }
+
     return boost::report_errors();
 }

--- a/test/x3/test.hpp
+++ b/test/x3/test.hpp
@@ -38,6 +38,17 @@ namespace spirit_test
             && (!full_match || (in == last));
     }
 
+    template <typename Char, typename Parser>
+    bool test_failure(Char const* in, Parser const& p)
+    {
+        char const * const start = in;
+        Char const* last = in;
+        while (*last)
+            last++;
+
+        return !boost::spirit::x3::parse(in, last, p) && (in == start);
+    }
+
     //~ template <typename Char, typename Parser>
     //~ bool binary_test(Char const* in, std::size_t size, Parser const& p,
         //~ bool full_match = true)


### PR DESCRIPTION
After seeing the mistake Thomas made in repeat parser, I realized seek and other parsers didn't have a check that verified the iterator position on failure. I have added such a function, and a test to seek. If this seems useful, I will start using this function in tests for other parsers. Or perhaps I missed this sort of utility somewhere else?
