### PR TITLE
Bugfix/raw handles container

### DIFF
--- a/include/boost/spirit/home/qi/directive/raw.hpp
+++ b/include/boost/spirit/home/qi/directive/raw.hpp
@@ -105,7 +105,7 @@ namespace boost { namespace spirit { namespace traits
         , typename Iterator>
     struct handles_container<qi::raw_directive<Subject>, Attribute
         , Context, Iterator>
-      : unary_handles_container<Subject, Attribute, Context, Iterator> {};
+    : boost::mpl::true_ {};
 }}}
 
 #endif

--- a/test/qi/raw.cpp
+++ b/test/qi/raw.cpp
@@ -5,10 +5,13 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
-#include <boost/spirit/include/qi_directive.hpp>
-#include <boost/spirit/include/qi_char.hpp>
-#include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_auxiliary.hpp>
+#include <boost/spirit/include/qi_char.hpp>
+#include <boost/spirit/include/qi_directive.hpp>
+#include <boost/spirit/include/qi_lit.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
+#include <boost/spirit/include/qi_uint.hpp>
+
 
 #include <iostream>
 #include <string>
@@ -20,8 +23,9 @@ main()
     using spirit_test::test;
     using spirit_test::test_attr;
     using namespace boost::spirit::ascii;
-    using boost::spirit::qi::raw;
     using boost::spirit::qi::eps;
+    using boost::spirit::qi::raw;
+    using boost::spirit::qi::uint_;
 
     {
         boost::iterator_range<char const*> range;
@@ -29,7 +33,7 @@ main()
         BOOST_TEST((test_attr("spirit_test_123", raw[alpha >> *(alnum | '_')], range)));
         BOOST_TEST((std::string(range.begin(), range.end()) == "spirit_test_123"));
         BOOST_TEST((test_attr("  spirit", raw[*alpha], range, space)));
-        BOOST_TEST((range.size() == 6));
+        BOOST_TEST((std::string(range.begin(), range.end()) == "spirit"));
     }
 
     {
@@ -42,7 +46,22 @@ main()
         boost::iterator_range<char const*> range;
         BOOST_TEST((test("x", raw[alpha])));
         BOOST_TEST((test_attr("x", raw[alpha], range)));
-        //~ BOOST_TEST((test_attr("x", raw[alpha] >> eps, range)));
+        BOOST_TEST((std::string(range.begin(), range.end()) == "x"));
+        BOOST_TEST((test_attr("x", raw[alpha] >> eps, range)));
+        BOOST_TEST((std::string(range.begin(), range.end()) == "x"));
+    }
+    {
+        std::vector<boost::iterator_range<const char*> > ranges;
+        std::vector<std::string> strings;
+        BOOST_TEST((test("number: 124number: 344", *("number: " >> raw[uint_]))));
+        BOOST_TEST((test_attr("number: 124number: 344", *("number: " >> raw[uint_]), ranges)));
+        BOOST_TEST((
+            ranges.size() == 2 && 
+            std::string(ranges[0].begin(), ranges[0].end()) == "124" &&
+            std::string(ranges[1].begin(), ranges[1].end()) == "344"));
+        BOOST_TEST((test_attr("number: 124number: 344", *("number: " >> raw[uint_]), strings)));
+        BOOST_TEST((
+        strings.size() == 2 && strings[0] == "124" && strings[1] == "344"));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
I think you wanted handles_container for the raw directive to return mpl::false_, but I thought differently (it wouldn't work without changes to the sequence operator). Please read the lengthy commit message, it explains most of it. I also added a few more tests, which hopefully remove any doubt for this decision.

This probably isn't the right place but - changing is_container to return false_ with the iterator_range type seems iffy for spirit x2. I'm going to investigate its usage more, but its likely that the investigation will result in recommendations for x3 but no changes for x2.
