### PR TITLE
Feature/x3 confix

### DIFF
--- a/include/boost/spirit/home/x3/extensions.hpp
+++ b/include/boost/spirit/home/x3/extensions.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #endif
 
+#include <boost/spirit/home/x3/extensions/confix.hpp>
 #include <boost/spirit/home/x3/extensions/seek.hpp>
 #include <boost/spirit/home/x3/extensions/repeat.hpp>
 

--- a/include/boost/spirit/home/x3/extensions/confix.hpp
+++ b/include/boost/spirit/home/x3/extensions/confix.hpp
@@ -1,0 +1,83 @@
+/*=============================================================================
+    Copyright (c) 2009 Chris Hoeppler
+    Copyright (c) 2014 Lee Clagett
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#if !defined(BOOST_SPIRIT_X3_CONFIX_MAY_30_2014_1819PM)
+#define BOOST_SPIRIT_X3_CONFIX_MAY_30_2014_1819PM
+
+#include <boost/spirit/home/x3/core/parser.hpp>
+
+namespace boost { namespace spirit { namespace x3
+{
+    template<typename Prefix, typename Subject, typename Postfix>
+    struct confix_directive :
+        unary_parser<Subject, confix_directive<Prefix, Subject, Postfix>>
+    {
+        typedef unary_parser<
+            Subject, confix_directive<Prefix, Subject, Postfix>> base_type;
+        static bool const is_pass_through_unary = true;
+        static bool const handles_container = Subject::handles_container;
+
+        confix_directive(Prefix const& prefix
+                         , Subject const& subject
+                         , Postfix const& postfix) :
+            base_type(subject),
+            prefix(prefix),
+            postfix(postfix)
+        {
+        }
+
+        template<typename Iterator, typename Context
+                 , typename RContext, typename Attribute>
+        bool parse(
+            Iterator& first, Iterator const& last
+            , Context& context, RContext& rcontext, Attribute& attr) const
+        {
+            Iterator save = first;
+
+            if (!(prefix.parse(first, last, context, rcontext, unused) &&
+                  this->subject.parse(first, last, context, rcontext, attr) &&
+                  postfix.parse(first, last, context, rcontext, unused)))
+            {
+                first = save;
+                return false;
+            }
+
+            return true;
+        }
+
+        Prefix prefix;
+        Postfix postfix;
+    };
+
+    template<typename Prefix, typename Postfix>
+    struct confix_gen
+    {
+        template<typename Subject>
+        confix_directive<
+            Prefix, typename extension::as_parser<Subject>::value_type, Postfix>
+        operator[](Subject const& subject) const
+        {
+            return {prefix, as_parser(subject), postfix};
+        }
+
+        Prefix prefix;
+        Postfix postfix;
+    };
+
+
+    template<typename Prefix, typename Postfix>
+    confix_gen<typename extension::as_parser<Prefix>::value_type,
+               typename extension::as_parser<Postfix>::value_type>
+    confix(Prefix const& prefix, Postfix const& postfix)
+    {
+        return {as_parser(prefix), as_parser(postfix)};
+    }
+
+}}}
+
+#endif

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -167,8 +167,9 @@ rule compile-fail ( sources + : requirements * : target-name ? )
     ###########################################################################
     test-suite spirit_v3/qi/x3_extensions :
 
-     [ run extensions/seek.cpp       : : : : x3_seek ]
+     [ run extensions/confix.cpp       : : : : x3_confix ]
      [ run extensions/repeat.cpp     : : : : x3_repeat ]
+     [ run extensions/seek.cpp       : : : : x3_seek ]
 
     ;
 }

--- a/test/x3/extensions/confix.cpp
+++ b/test/x3/extensions/confix.cpp
@@ -1,0 +1,84 @@
+/*=============================================================================
+    Copyright (c) 2009 Chris Hoeppler
+    Copyright (c) 2014 Lee Clagett
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/detail/lightweight_test.hpp>
+
+#include <boost/spirit/home/x3/char.hpp>
+#include <boost/spirit/home/x3/core.hpp>
+#include <boost/spirit/home/x3/numeric.hpp>
+#include <boost/spirit/home/x3/operator.hpp>
+#include <boost/spirit/home/x3/string.hpp>
+#include <boost/spirit/home/x3/extensions/confix.hpp>
+
+#include "../test.hpp"
+
+int main()
+{
+    namespace x3 = boost::spirit::x3;
+    using namespace spirit_test;
+
+    {
+        const auto comment = x3::confix("/*", "*/");
+
+        BOOST_TEST(test_failure("/abcdef*/", comment["abcdef"]));
+        BOOST_TEST(test_failure("/* abcdef*/", comment["abcdef"]));
+        BOOST_TEST(test_failure("/*abcdef */", comment["abcdef"]));
+        BOOST_TEST(test("/*abcdef*/", comment["abcdef"]));
+
+        {
+            unsigned value = 0;
+            BOOST_TEST(
+                test_attr(" /* 123 */ ", comment[x3::uint_], value, x3::space));
+            BOOST_TEST(value == 123);
+
+            value = 0;
+            const auto lambda = [&value](auto& ctx ){ value = x3::_attr(ctx) + 1; };
+            BOOST_TEST(test_attr("/*123*/", comment[x3::uint_][lambda], value));
+            BOOST_TEST(value == 124);
+        }
+    }
+    {
+        const auto array = x3::confix('[', ']');
+
+        {
+            std::vector<unsigned> values;
+            
+            BOOST_TEST(test("[0,2,4,6,8]", array[x3::uint_ % ',']));
+            BOOST_TEST(test_attr("[0,2,4,6,8]", array[x3::uint_ % ','], values));
+            BOOST_TEST(
+                values.size() == 5 && 
+                values[0] == 0 && 
+                values[1] == 2 && 
+                values[2] == 4 &&
+                values[3] == 6 &&
+                values[4] == 8);
+        }
+        {
+            std::vector<std::vector<unsigned>> values;
+            BOOST_TEST(
+                test("[[1,3,5],[0,2,4]]", array[array[x3::uint_ % ','] % ',']));
+            BOOST_TEST(
+                test_attr(
+                    "[[1,3,5],[0,2,4]]", 
+                    array[array[x3::uint_ % ','] % ','],
+                    values));
+            BOOST_TEST(
+                values.size() == 2 &&
+                values[0].size() == 3 &&
+                values[0][0] == 1 &&
+                values[0][1] == 3 &&
+                values[0][2] == 5 &&
+                values[1].size() == 3 &&
+                values[1][0] == 0 &&
+                values[1][1] == 2 &&
+                values[1][2] == 4);
+        }
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Ported the confix parser. Seems like it could be pretty useful now that auto can be used.

I also used `#include "test.hpp"` like I did with the seek test (seek.cpp). Tongari thought it should be `#include <test.hpp>` since the file is one up one directory and is being included via the `-I` switch. Let me know what the preferred style is for that.
