### PR TITLE
Fix assignment basic_hold_any::operator=

### DIFF
--- a/include/boost/spirit/home/support/detail/hold_any.hpp
+++ b/include/boost/spirit/home/support/detail/hold_any.hpp
@@ -299,6 +299,12 @@ namespace boost { namespace spirit
 
         // assignment operator
         template <typename T>
+        basic_hold_any& operator=(T& x)
+        {
+            return assign(x);
+        }
+
+        template <typename T>
         basic_hold_any& operator=(T const& x)
         {
             return assign(x);


### PR DESCRIPTION
The template version would not be used because the compiler-generated
one was a closer match. The implicit assignment, however, broke the
ownership semantics.

This case was inspired by this SO question: http://stackoverflow.com/q/24065769/85371

A smaller reproducer is here:

```
#include <iostream>
#include <string>
#include <boost/spirit/home/support/detail/hold_any.hpp>
typedef boost::spirit::hold_any any;

int main()
{
    any b;
    {
        any a;
        a = std::string("test_test_test");
        b = a;
    }

    std::cout << "b: " << b << '\n';
}
```

This crashes with gcc/clang regardless of c++03/c++11 modes. It doesn't crash and runs valngrind-clean after the patch.
