### PR TITLE
Fix assignment basic_hold_any::operator= #35 (c++11)

### DIFF
--- a/include/boost/spirit/home/support/detail/hold_any.hpp
+++ b/include/boost/spirit/home/support/detail/hold_any.hpp
@@ -298,6 +298,13 @@ namespace boost { namespace spirit
         }
 
         // assignment operator
+#ifdef BOOST_HAS_RVALUE_REFS
+        template <typename T>
+        basic_hold_any& operator=(T&& x)
+        {
+            return assign(std::forward<T>(x));
+        }
+#else
         template <typename T>
         basic_hold_any& operator=(T& x)
         {
@@ -309,6 +316,7 @@ namespace boost { namespace spirit
         {
             return assign(x);
         }
+#endif
 
         // utility functions
         basic_hold_any& swap(basic_hold_any& x)


### PR DESCRIPTION
The template version would not be used because the compiler-generated
one was a closer match. The implicit assignment, however, broke the
ownership semantics.

See also Pull Request #35 (wrong branch, not C++11 safe)
