### PR TITLE
Fix for classic phoenix tests with modern standard libraries

### DIFF
--- a/classic/phoenix/test/binders_tests.cpp
+++ b/classic/phoenix/test/binders_tests.cpp
@@ -16,7 +16,8 @@
 #include <boost/spirit/include/phoenix1_binders.hpp>
 
 using namespace phoenix;
-using namespace std;
+using std::cout;
+using std::endl;
 
     ///////////////////////////////////////////////////////////////////////////////
     struct print_ { // a typical STL style monomorphic functor

--- a/classic/phoenix/test/tuples_tests.cpp
+++ b/classic/phoenix/test/tuples_tests.cpp
@@ -11,10 +11,11 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/phoenix1_tuples.hpp>
 
-using namespace std;
-using namespace phoenix;
 using namespace phoenix;
 using namespace phoenix::tuple_index_names;
+using std::cout;
+using std::endl;
+using std::string;
 
 int
 main()


### PR DESCRIPTION
Fix compile errors in classic phoenix tests with modern standard libraries because of ambiguous symbols in std and phoenix namespaces.
