### PR TITLE
Fix compilation with MSVC 12+

### DIFF
--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -208,11 +208,11 @@ namespace boost { namespace spirit { namespace traits
       : is_weak_substitute<T, Expected>
     {};
 
-    template <typename T0, typename ...TN, typename Expected>
-    struct is_weak_substitute<boost::variant<T0, TN...>,
+    template <typename T0, typename T1, typename ...TN, typename Expected>
+    struct is_weak_substitute<boost::variant<T0, T1, TN...>,
             Expected>
       : mpl::bool_<is_weak_substitute<T0, Expected>::type::value &&
-            is_weak_substitute<boost::variant<TN...>, Expected>::type::value>
+            is_weak_substitute<boost::variant<T1, TN...>, Expected>::type::value>
     {};
 #else
 #define BOOST_SPIRIT_IS_WEAK_SUBSTITUTE(z, N, _)                              \

--- a/include/boost/spirit/home/support/container.hpp
+++ b/include/boost/spirit/home/support/container.hpp
@@ -65,10 +65,10 @@ namespace boost { namespace spirit { namespace traits
       : is_container<T>
     {};
 
-    template<typename T0, typename ...TN>
-    struct is_container<boost::variant<T0, TN...> >
+    template<typename T0, typename T1, typename ...TN>
+    struct is_container<boost::variant<T0, T1, TN...> >
       : mpl::bool_<is_container<T0>::value ||
-            is_container<boost::variant<TN...> >::value>
+            is_container<boost::variant<T1, TN...> >::value>
     {};
 
 #else


### PR DESCRIPTION
Visual C++ wrongly always chooses the variadic template version of a function if there are variadic and non-variadic template versions:
https://connect.microsoft.com/VisualStudio/feedback/details/806150/vc-12-variadic-template-function-preferred-over-non-variadic-template-function

This affects at least Visual C++ 2013 RTM and Update 1, the November 2013 CTP and Visual C++ 14 CTP1.

This commit works around that bug by only enabling the variadic template version of is_weak_substitute and is_container for 2+ template arguments.
