### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/classic/test/scanner_tests.cpp
+++ b/classic/test/scanner_tests.cpp
@@ -29,12 +29,12 @@ struct to_upper_iter_policy : public iteration_policy {
 
 inline bool test_isspace(char c)
 {
-    using namespace std; return isspace(c);
+    using namespace std; return isspace(c) != 0;
 }
 
 inline bool test_islower(char c)
 {
-    using namespace std; return islower(c);
+    using namespace std; return islower(c) != 0;
 }
 
 struct skip_white_iter_policy : public iteration_policy {

--- a/include/boost/spirit/home/support/detail/lexer/generator.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/generator.hpp
@@ -186,10 +186,10 @@ protected:
         while (regex_iter_ != regex_iter_end_)
         {
             // re-declare var, otherwise we perform an assignment..!
-            const typename rules::string &regex_ = *regex_iter_;
+            const typename rules::string &regex2_ = *regex_iter_;
 
-            root_ = parser::parse (regex_.c_str (),
-                regex_.c_str () + regex_.size (), *ids_iter_,
+            root_ = parser::parse (regex2_.c_str (),
+                regex2_.c_str () + regex2_.size (), *ids_iter_,
                 *unique_ids_iter_, *states_iter_, rules_.flags (),
                 rules_.locale (), node_ptr_vector_, macromap_, token_map_,
                 internals_._seen_BOL_assertion,
@@ -337,16 +337,16 @@ protected:
                         equiv_end_ = equivset_->_index_vector.end ();
                         equiv_iter_ != equiv_end_; ++equiv_iter_)
                     {
-                        const std::size_t index_ = *equiv_iter_;
+                        const std::size_t equiv_index_ = *equiv_iter_;
 
-                        if (index_ == bol_token)
+                        if (equiv_index_ == bol_token)
                         {
                             if (ptr_[eol_index] == 0)
                             {
                                 ptr_[bol_index] = transition_;
                             }
                         }
-                        else if (index_ == eol_token)
+                        else if (equiv_index_ == eol_token)
                         {
                             if (ptr_[bol_index] == 0)
                             {
@@ -355,7 +355,7 @@ protected:
                         }
                         else
                         {
-                            ptr_[index_ + dfa_offset] = transition_;
+                            ptr_[equiv_index_ + dfa_offset] = transition_;
                         }
                     }
                 }


### PR DESCRIPTION
This fixes the following warnings on Microsoft Visual C++:
"warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)"
"warning C4456: declaration of 'regex' hides previous local declaration"
"warning C4456: declaration of 'index_' hides previous local declaration"
The first one occurs in all versions, the shadowing warnings are new in MSVC 14.
