### PR TITLE
Update what's new documentation.

### DIFF
--- a/doc/what_s_new.qbk
+++ b/doc/what_s_new.qbk
@@ -9,6 +9,18 @@
 [section What's New]
 
 [/////////////////////////////////////////////////////////////////////////////]
+[section:spirit_2_5_3 Spirit V2.5.3]
+
+[heading What's changed from V2.5.2 (Boost V1.49.0) to V2.5.3 (Boost V1.50.0)]
+
+* The support of __boost_phoenix__ (V3) is now mature. To enable it you need to
+define the following preprocessor constant for your builds (before including
+any of Spirit's include files):
+
+    #define BOOST_SPIRIT_USE_PHOENIX_V3 1
+
+[endsect]
+[/////////////////////////////////////////////////////////////////////////////]
 [section:spirit_2_5_2 Spirit V2.5.2]
 
 [heading What's changed from V2.5.1 (Boost V1.48.0) to V2.5.2 (Boost V1.49.0)]


### PR DESCRIPTION
"what's new" contained outdated documentation about the support of
boost::phoenix v3 and was not updated when the version of spirit was
bumped.
