### PR TITLE
Corrected the v2 seek parser documentation.

### DIFF
--- a/repository/doc/qi/seek.qbk
+++ b/repository/doc/qi/seek.qbk
@@ -12,7 +12,6 @@
 [heading Description]
 
 The `seek[]` parser-directive skips all input until the subject parser matches.
-On failure, the current position is the end of the input.
 
 [heading Header]
 


### PR DESCRIPTION
This was discussed on the mailing list, the v2 seek documentation incorrectly says that the iterator position will be at the end of input on failure. It actually behaves like every other parser.

There are no "failure" tests for v2 seek - I can add a test if desired. x3 already has some failure tests.
