### PR TITLE
Suppress MSVC 'conditional expression is constant' warnings

### DIFF
--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -42,6 +42,7 @@
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
+# pragma warning(disable: 4127) // conditional expression is constant
 # pragma warning(disable: 4355) // 'this' : used in base member initializer list warning
 #endif
 

--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -32,6 +32,11 @@
 #include <boost/mpl/and.hpp>
 #include <boost/limits.hpp>
 
+#if defined(BOOST_MSVC)
+# pragma warning(push)
+# pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 #if !defined(SPIRIT_NUMERICS_LOOP_UNROLL)
 # define SPIRIT_NUMERICS_LOOP_UNROLL 3
 #endif
@@ -502,5 +507,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         }
     };
 }}}}
+
+#if defined(BOOST_MSVC)
+# pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/spirit/home/support/char_class.hpp
+++ b/include/boost/spirit/home/support/char_class.hpp
@@ -26,6 +26,7 @@
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
+# pragma warning(disable: 4127) // conditional expression is constant
 # pragma warning(disable: 4800) // 'int' : forcing value to bool 'true' or 'false' warning
 #endif
 


### PR DESCRIPTION
These changes allow to compile against Boost.Spirit cleanly at level 4 warnings.
