### PR TITLE
Add the missing comparison for 'goto_state'

### DIFF
--- a/include/boost/spirit/home/support/detail/lexer/state_machine.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/state_machine.hpp
@@ -82,7 +82,7 @@ public:
                     bol_index == rhs_.bol_index &&
                     eol_index == rhs_.eol_index &&
                     token == rhs_.token &&
-                    transition == rhs_.transition;
+                    goto_state == rhs_.goto_state;
             }
         };
 


### PR DESCRIPTION
``` C++
return dfa == rhs_.dfa &&
states == rhs_.states &&
state == rhs_.state &&
transitions == rhs_.transitions &&
transition == rhs_.transition &&    // <===
 end_state == rhs_.end_state &&
id == rhs_.id &&
unique_id == rhs_.unique_id &&
goto_dfa == rhs_.goto_dfa &&
bol_index == rhs_.bol_index &&
eol_index == rhs_.eol_index &&
token == rhs_.token &&
transition == rhs_.transition;      // <===
```
