### PR TITLE
Remove redundant decls which already appear in previous header.

### DIFF
--- a/example/x3/calc8/expression_def.hpp
+++ b/example/x3/calc8/expression_def.hpp
@@ -23,13 +23,11 @@ namespace client { namespace parser
     using x3::lexeme;
     using namespace x3::ascii;
     
-    struct expression_class;
     struct additive_expr_class;
     struct multiplicative_expr_class;
     struct unary_expr_class;
     struct primary_expr_class;
     
-    typedef x3::rule<expression_class, ast::expression> expression_type;
     typedef x3::rule<additive_expr_class, ast::expression> additive_expr_type;
     typedef x3::rule<multiplicative_expr_class, ast::expression> multiplicative_expr_type;
     typedef x3::rule<unary_expr_class, ast::operand> unary_expr_type;

--- a/example/x3/calc8/statement_def.hpp
+++ b/example/x3/calc8/statement_def.hpp
@@ -22,13 +22,11 @@ namespace client { namespace parser
     using x3::lexeme;
     using namespace x3::ascii;
     
-    struct statement_class;
     struct statement_list_class;
     struct variable_declaration_class;
     struct assignment_class;
     struct variable_class;
     
-    typedef x3::rule<statement_class, ast::statement_list> statement_type;
     typedef x3::rule<statement_list_class, ast::statement_list> statement_list_type;
     typedef x3::rule<variable_declaration_class, ast::variable_declaration> variable_declaration_type;
     typedef x3::rule<assignment_class, ast::assignment> assignment_type;

--- a/example/x3/calc9/expression_def.hpp
+++ b/example/x3/calc9/expression_def.hpp
@@ -90,7 +90,6 @@ namespace client { namespace parser
     // Main expression grammar
     ////////////////////////////////////////////////////////////////////////////
     
-    struct expression_class;
     struct equality_expr_class;
     struct relational_expr_class;
     struct logical_expr_class;
@@ -99,7 +98,6 @@ namespace client { namespace parser
     struct unary_expr_class;
     struct primary_expr_class;
     
-    typedef x3::rule<expression_class, ast::expression> expression_type;
     typedef x3::rule<equality_expr_class, ast::expression> equality_expr_type;
     typedef x3::rule<relational_expr_class, ast::expression> relational_expr_type;
     typedef x3::rule<logical_expr_class, ast::expression> logical_expr_type;

--- a/example/x3/calc9/statement_def.hpp
+++ b/example/x3/calc9/statement_def.hpp
@@ -22,13 +22,11 @@ namespace client { namespace parser
     using x3::lexeme;
     using namespace x3::ascii;
     
-    struct statement_class;
     struct statement_list_class;
     struct variable_declaration_class;
     struct assignment_class;
     struct variable_class;
     
-    typedef x3::rule<statement_class, ast::statement_list> statement_type;
     typedef x3::rule<statement_list_class, ast::statement_list> statement_list_type;
     typedef x3::rule<variable_declaration_class, ast::variable_declaration> variable_declaration_type;
     typedef x3::rule<assignment_class, ast::assignment> assignment_type;


### PR DESCRIPTION
{expression,statement}_{class,type} are already declared in {expression,statement}.hpp.
No need to repeat ourselves in {expression,statement}_def.hpp.
