### PR TITLE
Check for first == last before dereferencing first

### DIFF
--- a/include/boost/spirit/home/qi/numeric/real_policies.hpp
+++ b/include/boost/spirit/home/qi/numeric/real_policies.hpp
@@ -116,7 +116,7 @@ namespace boost { namespace spirit { namespace qi
             // nan[(...)] ?
             if (detail::string_parse("nan", "NAN", first, last, unused))
             {
-                if (*first == '(')
+                if (first != last && *first == '(')
                 {
                     // skip trailing (...) part
                     Iterator i = first;


### PR DESCRIPTION
Trac ticket [#6955](https://svn.boost.org/trac/boost/ticket/6955) describes an issue with dereferencing the past-the-end iterator in `parse_nan`. For details see https://svn.boost.org/trac/boost/ticket/6955. This pull request fixes this issue by checking `first != last` before dereferencing the `first` iterator.
