### PR TITLE
Fixed bug with null-termination and string containers.

### DIFF
--- a/include/boost/spirit/home/karma/detail/string_generate.hpp
+++ b/include/boost/spirit/home/karma/detail/string_generate.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         typedef typename traits::container_iterator<Container const>::type 
             iterator;
 
-        iterator end = boost::end(c);
+        const iterator end = boost::end(c);
         for (iterator it = boost::begin(c); it != end; ++it)
         {
             *sink = filter(*it);
@@ -74,14 +74,6 @@ namespace boost { namespace spirit { namespace karma { namespace detail
     inline bool string_generate(OutputIterator& sink, Char const* str)
     {
         return string_generate(sink, str, pass_through_filter());
-    }
-
-    template <typename OutputIterator, typename Char, typename Traits
-      , typename Allocator>
-    inline bool string_generate(OutputIterator& sink
-      , std::basic_string<Char, Traits, Allocator> const& str)
-    {
-        return string_generate(sink, str.c_str(), pass_through_filter());
     }
 
     template <typename OutputIterator, typename Container>
@@ -103,17 +95,6 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         return string_generate(sink, str, encoding_filter<CharEncoding, Tag>());
     }
 
-    template <typename OutputIterator, typename Char
-      , typename CharEncoding, typename Tag
-      , typename Traits, typename Allocator>
-    inline bool string_generate(OutputIterator& sink
-      , std::basic_string<Char, Traits, Allocator> const& str
-      , CharEncoding, Tag)
-    {
-        return string_generate(sink, str.c_str()
-          , encoding_filter<CharEncoding, Tag>());
-    }
-
     template <typename OutputIterator, typename Container
       , typename CharEncoding, typename Tag>
     inline bool 
@@ -130,16 +111,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
       , Char const* str
       , unused_type, unused_type)
     {
-        return string_generate(sink, str, pass_through_filter());
-    }
-
-    template <typename OutputIterator, typename Char, typename Traits
-      , typename Allocator>
-    inline bool string_generate(OutputIterator& sink
-      , std::basic_string<Char, Traits, Allocator> const& str
-      , unused_type, unused_type)
-    {
-        return string_generate(sink, str.c_str(), pass_through_filter());
+        return string_generate(sink, str);
     }
 
     template <typename OutputIterator, typename Container>
@@ -147,7 +119,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
       , Container const& c
       , unused_type, unused_type)
     {
-        return string_generate(sink, c, pass_through_filter());
+        return string_generate(sink, c);
     }
 
 }}}}

--- a/test/karma/lit.cpp
+++ b/test/karma/lit.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2001-2011 Hartmut Kaiser
-// 
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying 
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/config/warning_disable.hpp>
@@ -100,6 +100,25 @@ main()
 
         BOOST_TEST(test(L"abc", string, "abc"));
         BOOST_TEST(!test(L"abcd", string, "abc"));
+    }
+
+    {
+        using namespace boost::spirit::karma;
+
+        const char test_data[] = "abc\x00s";
+        const std::string str(test_data, sizeof(test_data) - 1);
+
+        BOOST_TEST(test(str, lit(str)));
+        BOOST_TEST(!test("abc", lit(str)));
+
+        BOOST_TEST(test(str, string(str)));
+        BOOST_TEST(!test("abc", string(str)));
+
+        BOOST_TEST(test(str, string, str));
+        BOOST_TEST(!test("abc", string, str));
+
+        BOOST_TEST(test(str, str));
+        BOOST_TEST(!test("abc", str));
     }
 
     {


### PR DESCRIPTION
This patch is for the issue posted on the [mailing list](http://boost.2283326.n4.nabble.com/karma-lit-and-karma-string-failure-td4666182.html). The fix was to have std::string use the existing interface for STL containers. All karma v2 tests pass.
