### PR TITLE
Compliant fusion::result_of::make_map changes with variadic map.

### DIFF
--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -414,7 +414,11 @@ namespace boost { namespace spirit { namespace repository { namespace karma
 
             // create Defs map with only one entry: (ID -> def)
             typedef typename
+#ifndef BOOST_FUSION_HAS_VARIADIC_MAP
                 fusion::result_of::make_map<id_type, def_type>::type
+#else
+                fusion::result_of::make_map<id_type>::template apply<def_type>::type
+#endif
             defs_type;
 
             typedef subrule_group<defs_type> type;

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -440,7 +440,11 @@ namespace boost { namespace spirit { namespace repository { namespace qi
 
             // create Defs map with only one entry: (ID -> def)
             typedef typename
+#ifndef BOOST_FUSION_HAS_VARIADIC_MAP
                 fusion::result_of::make_map<id_type, def_type>::type
+#else
+                fusion::result_of::make_map<id_type>::template apply<def_type>::type
+#endif
             defs_type;
 
             typedef subrule_group<defs_type> type;


### PR DESCRIPTION
fusion::result_of::make_map was changed with variadic map.
`fusion::result_of::make_map<Key..., Value...>::type`
v.s.
`fusion::result_of::make_map<Key...>::apply<Value...>::type`
