### PR TITLE
Macro to remove filesystem dependency

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -7,7 +7,10 @@
 #if !defined(BOOST_SPIRIT_X3_ERROR_REPORTING_MAY_19_2014_00405PM)
 #define BOOST_SPIRIT_X3_ERROR_REPORTING_MAY_19_2014_00405PM
 
+#ifndef BOOST_SPIRIT_X3_NO_FILESYSTEM
 #include <boost/filesystem/path.hpp>
+#endif
+
 #include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
 #include <ostream>
 
@@ -78,11 +81,14 @@ namespace boost { namespace spirit { namespace x3
     template <typename Iterator>
     void error_handler<Iterator>::print_file_line(std::size_t line) const
     {
-        namespace fs = boost::filesystem;
-
-        if (file != "")
+        if (file != ""){
+#ifdef BOOST_SPIRIT_X3_NO_FILESYSTEM
+            err_out << "In file " << file << ", ";
+#else
+            namespace fs = boost::filesystem;
             err_out << "In file " << fs::path(file).generic_string() << ", ";
-        else
+#endif
+        } else 
             err_out << "In ";
 
         err_out << "line " << line << ':' << std::endl;


### PR DESCRIPTION
This patch adds the BOOST_SPIRIT_X3_NO_FILESYSTEM macro which removes the dependency on boost filesystem when enabled. 

There is only one line in X3 that depends on filesystem, so I think that it is a good feature to let the user disable it if it doesn't want the dependency.
