### PR TITLE
Improve QString integration in custom_string.cpp

### DIFF
--- a/example/qi/custom_string.cpp
+++ b/example/qi/custom_string.cpp
@@ -34,6 +34,26 @@ namespace boost { namespace spirit { namespace traits
             return true;
         }
     };
+    
+    // Test if a QString is empty (required for debug)
+    template <>
+    struct is_empty_container<QString>
+    {
+        static bool call(QString const& c)
+        {
+            return c.isEmpty();
+        }
+    };
+
+    // Define how to stream a QString (required for debug)
+    template <typename Out, typename Enable>
+    struct print_attribute_debug<Out, QString, Enable>
+    {
+        static void call(Out& out, QString const& val)
+        {
+            out << val.toStdString();
+        }
+    };
 
     // Test if a QString is empty (required for debug)
     template <>


### PR DESCRIPTION
There is an example of how to use Qi with Qt's QString as a custom string.
This is very helpful but it doesn't work in conjunction with the debug facilities.
The following patch fixes this by adding a couple of template specialisations.

Patch originally submitted as https://svn.boost.org/trac/boost/ticket/8846
