### PR TITLE
Added method to the position_policy to get the current line and column i...

### DIFF
--- a/include/boost/spirit/home/karma/detail/output_iterator.hpp
+++ b/include/boost/spirit/home/karma/detail/output_iterator.hpp
@@ -79,6 +79,18 @@ namespace boost { namespace spirit { namespace karma { namespace detail
             return track_position_data.get_count();
         }
 
+	// return the current line in the output
+	std::size_t get_out_line() const
+	{
+	    return track_position_data.get_line();
+	}
+
+	// return the current column in the output
+	std::size_t get_out_column() const
+	{
+	    return track_position_data.get_column();
+	}
+
     private:
         position_sink track_position_data;            // for position tracking
     };

--- a/include/boost/spirit/home/karma/detail/output_iterator.hpp
+++ b/include/boost/spirit/home/karma/detail/output_iterator.hpp
@@ -80,13 +80,13 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         }
 
 	// return the current line in the output
-	std::size_t get_out_line() const
+	std::size_t get_line() const
 	{
 	    return track_position_data.get_line();
 	}
 
 	// return the current column in the output
-	std::size_t get_out_column() const
+	std::size_t get_column() const
 	{
 	    return track_position_data.get_column();
 	}


### PR DESCRIPTION
...n the output.

By forwarding these methodes from the position_sink, someone can access the current line and column of the output_iterator when creating a new terminal.
This is implemented as announce in the mailing list by @daminetreg and myself.