### PR TITLE
Fix for a type conversion warning

### DIFF
--- a/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
@@ -104,7 +104,7 @@ namespace boost { namespace spirit { namespace karma
                     long exp = traits::truncate_to_long::call(-dim);
                     if (exp != -dim)
                         ++exp;
-                    dim = -exp;
+                    dim = static_cast<U>(-exp);
                     n *= spirit::traits::pow10<U>(exp);
                 }
             }


### PR DESCRIPTION
This change fixes a C4244 compiler warning issued by MSVC 12.0.