### PR TITLE
fix unused parameter

### DIFF
--- a/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
@@ -168,7 +168,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             std::size_t get_state() const { return 0; }
             void set_state(std::size_t) {}
 
-            void set_end(Iterator const& it) {}
+            void set_end(Iterator const&) {}
 
             Iterator& get_first() { return first_; }
             Iterator const& get_first() const { return first_; }

--- a/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
@@ -168,7 +168,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             std::size_t get_state() const { return 0; }
             void set_state(std::size_t) {}
 
-            void set_end(Iterator const&) {}
+            void set_end(Iterator const& /*it*/) {}
 
             Iterator& get_first() { return first_; }
             Iterator const& get_first() const { return first_; }


### PR DESCRIPTION
This avoids a warning like:
```
/some/path/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp:171:42: warning: unused parameter ‘it’ [-Wunused-parameter]
             void set_end(Iterator const& it) {}
                                          ^
```