### PR TITLE
Updated the check-for-self in x3::variant

### DIFF
--- a/include/boost/spirit/home/x3/support/ast/variant.hpp
+++ b/include/boost/spirit/home/x3/support/ast/variant.hpp
@@ -14,6 +14,7 @@
 #include <boost/variant.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace x3
@@ -126,17 +127,25 @@ namespace boost { namespace spirit { namespace x3
         // tell spirit that this is an adapted variant
         struct adapted_variant_tag;
 
-        typedef boost::variant<Types...> variant_type;
-        typedef mpl::list<typename detail::remove_forward<Types>::type...> types;
-        typedef variant<Types...> base_type;
+        using variant_type = boost::variant<Types...>;
+        using types        = mpl::list<typename detail::remove_forward<Types>::type...>;
+        using base_type    = variant; // The current instantiation
+
+        template<typename T>
+        using non_self_t // used only for SFINAE checks below
+            = std::enable_if_t<!(std::is_base_of<base_type
+                                                ,std::remove_reference_t<T>
+                                                >
+                                                ::value)
+                              >;
 
         variant() : var() {}
 
-        template <typename T, typename disable_if<is_base_of<base_type, T>>::type>
+        template <typename T, class = non_self_t<T>>
         explicit variant(T const& rhs)
             : var(rhs) {}
 
-        template <typename T, typename disable_if<is_base_of<base_type, T>>::type>
+        template <typename T, class = non_self_t<T>>
         explicit variant(T&& rhs)
             : var(std::forward<T>(rhs)) {}
 
@@ -161,16 +170,14 @@ namespace boost { namespace spirit { namespace x3
             return *this;
         }
 
-        template <typename T>
-        //typename disable_if<is_base_of<base_type, T>, variant&>::type
+        template <typename T, class = non_self_t<T>>
         variant& operator=(T const& rhs)
         {
             var = rhs;
             return *this;
         }
 
-        template <typename T>
-        //typename disable_if<is_base_of<base_type, T>, variant&>::type
+        template <typename T, class = non_self_t<T>>
         variant& operator=(T&& rhs)
         {
             var = std::forward<T>(rhs);


### PR DESCRIPTION
I ran into some compile-time errors when trying to copy an object of a type derived from x3::variant.

The root of the issue seems to be the SFINAE check on the members operator=; namely: when variant's move-assignment operator template is considered during overload resolution, it deduces 'A&' for template parameter T, and then reference-collapsing transforms 'variant& &&' into 'variant&', and thus the template ends up being a better choice than the implicitly-declared copy-assignment operator. This leads to a nice tall error message.

It seems like we just need a test for "self" as part of the SFINAE check on that operator template---which we used to have, but it appears to have been commented out at some point (for reasons not immediately clear to me).

In this commit, four of the member templates now use the same compact SFINAE check in the same way (as a default template argument). It seems to do the right thing for me.
