### PR TITLE
fix unused local typedef

### DIFF
--- a/include/boost/spirit/home/lex/lexer/string_token_def.hpp
+++ b/include/boost/spirit/home/lex/lexer/string_token_def.hpp
@@ -101,7 +101,6 @@ namespace boost { namespace spirit { namespace lex
 
             token_state_ = state_id;
 
-            typedef typename LexerDef::id_type id_type;
             if (IdType(~0) == id_)
                 id_ = IdType(lexdef.get_next_id());
 


### PR DESCRIPTION
g++ 4.9.2 generates -Wunused-local-typedefs as follows;
```
/home/tabe/isopt/boost_1_58_0/include/boost/spirit/home/lex/lexer/string_token_def.hpp: In member function ‘void boost::spirit::lex::string_token_def<String, IdType, CharEncoding>::collect(LexerDef&, const String_&, const String_&) const’:
/home/tabe/isopt/boost_1_58_0/include/boost/spirit/home/lex/lexer/string_token_def.hpp:104:48: warning: typedef ‘id_type’ locally defined but not used [-Wunused-local-typedefs]
             typedef typename LexerDef::id_type id_type;
                                                ^
```