### PR TITLE
fix another unused local typedef

### DIFF
--- a/include/boost/spirit/home/lex/argument.hpp
+++ b/include/boost/spirit/home/lex/argument.hpp
@@ -93,16 +93,6 @@ namespace boost { namespace spirit { namespace lex
         template <typename Env>
         void eval(Env const& env) const
         {
-            typedef
-                typename remove_reference<
-                   typename remove_const<
-                        typename mpl::at_c<typename Env::args_type, 4>::type
-                    >::type
-                >::type
-            context_type;
-
-            typedef typename context_type::state_name_type string;
-
             fusion::at_c<4>(env.args()).set_state_name(
                 traits::get_c_string(actor_.eval(env)));
         }


### PR DESCRIPTION
Found another -Wunused-local-typedefs:
```
/home/tabe/isopt/boost_1_58_0/include/boost/spirit/home/lex/argument.hpp: In member function ‘void boost::spirit::lex::state_setter< <template-parameter-1-1> >::eval(const Env&) const’:
/home/tabe/isopt/boost_1_58_0/include/boost/spirit/home/lex/argument.hpp:104:60: warning: typedef ‘string’ locally defined but not used [-Wunused-local-typedefs]
             typedef typename context_type::state_name_type string;
                                                            ^
```
