### PR TITLE
Allow rule.hpp to be included independently.

### DIFF
--- a/example/x3/rexpr/rexpr_full/rexpr/rexpr.hpp
+++ b/example/x3/rexpr/rexpr_full/rexpr/rexpr.hpp
@@ -7,8 +7,9 @@
 #if !defined(BOOST_SPIRIT_X3_REXPR_HPP)
 #define BOOST_SPIRIT_X3_REXPR_HPP
 
-#include <boost/spirit/home/x3.hpp>
 #include "ast.hpp"
+
+#include <boost/spirit/home/x3.hpp>
 
 namespace rexpr
 {

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -11,7 +11,10 @@
 #pragma once
 #endif
 
+#include <boost/spirit/home/x3/auxiliary/guard.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
+#include <boost/spirit/home/x3/core/skip_over.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 #include <boost/spirit/home/x3/support/traits/make_attribute.hpp>
 #include <boost/spirit/home/x3/support/utility/sfinae.hpp>
 #include <boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp>


### PR DESCRIPTION
Have rexpr include rule.hpp independently as a check.