### PR TITLE
Kill duplicated code in annotation.hpp.

### DIFF
--- a/example/x3/calc/calc8/annotation.hpp
+++ b/example/x3/calc/calc8/annotation.hpp
@@ -33,12 +33,10 @@ namespace client { namespace parser
         on_success(Iterator const& first, Iterator const& last
           , ast::operand& ast, Context const& context)
         {
-            auto& error_handler = x3::get<error_handler_tag>(context).get();
-            auto annotate = [&](auto& node)
+            ast.apply_visitor(x3::make_lambda_visitor<void>([&](auto& node)
             {
-                error_handler.tag(node, first, last);
-            };
-            ast.apply_visitor(x3::make_lambda_visitor<void>(annotate));
+                this->on_success(first, last, node, context);
+            }));
         }
 
         template <typename T, typename Iterator, typename Context>

--- a/example/x3/calc/calc9/annotation.hpp
+++ b/example/x3/calc/calc9/annotation.hpp
@@ -33,12 +33,10 @@ namespace client { namespace parser
         on_success(Iterator const& first, Iterator const& last
           , ast::operand& ast, Context const& context)
         {
-            auto& error_handler = x3::get<error_handler_tag>(context).get();
-            auto annotate = [&](auto& node)
+            ast.apply_visitor(x3::make_lambda_visitor<void>([&](auto& node)
             {
-                error_handler.tag(node, first, last);
-            };
-            ast.apply_visitor(x3::make_lambda_visitor<void>(annotate));
+                this->on_success(first, last, node, context);
+            }));
         }
 
         template <typename T, typename Iterator, typename Context>

--- a/example/x3/rexpr/rexpr_full/rexpr/annotation.hpp
+++ b/example/x3/rexpr/rexpr_full/rexpr/annotation.hpp
@@ -35,16 +35,10 @@ namespace rexpr { namespace parser
         void on_success(Iterator const& first, Iterator const& last
           , ast::rexpr_value& ast, Context const& context)
         {
-            auto& error_handler
-                = x3::get<error_handler_tag>(context).get();
-
-            auto annotate = [&](auto& node)
+            ast.apply_visitor(x3::make_lambda_visitor<void>([&](auto& node)
             {
-                error_handler.tag(node, first, last);
-            };
-
-            ast.apply_visitor(
-                x3::make_lambda_visitor<void>(annotate));
+                this->on_success(first, last, node, context);
+            }));
         }
 
         template <typename T, typename Iterator, typename Context>


### PR DESCRIPTION
There is no need fetch the error_handler and call its tag method twice.