### PR TITLE
X3: Add support for custom character filters on the symbols parser

### DIFF
--- a/include/boost/spirit/home/x3/string/symbols.hpp
+++ b/include/boost/spirit/home/x3/string/symbols.hpp
@@ -36,11 +36,22 @@
 
 namespace boost { namespace spirit { namespace x3
 {
+    template < typename Encoding >
+    struct get_default_symbol_filter
+    {
+        template <typename Context>
+        static auto get(Context const& context) -> decltype(get_case_compare<Encoding>(context))
+        {
+            return {};
+        }
+    };
+
     template <
         typename Encoding
       , typename T = unused_type
+      , typename GetFilter = get_default_symbol_filter<Encoding>
       , typename Lookup = tst<typename Encoding::char_type, T> >
-    struct symbols_parser : parser<symbols_parser<Encoding, T, Lookup>>
+    struct symbols_parser : parser<symbols_parser<Encoding, T, GetFilter, Lookup>>
     {
         typedef typename Encoding::char_type char_type; // the character type
         typedef Encoding encoding;
@@ -220,7 +231,7 @@ namespace boost { namespace spirit { namespace x3
             x3::skip_over(first, last, context);
 
             if (value_type* val_ptr
-                = lookup->find(first, last, get_case_compare<Encoding>(context)))
+                = lookup->find(first, last, GetFilter::get(context)))
             {
                 x3::traits::move_to(*val_ptr, attr);
                 return true;

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -126,6 +126,7 @@ rule compile-fail ( sources + : requirements * : target-name ? )
      [ run symbols1.cpp         : : : : x3_symbols1 ]
      [ run symbols2.cpp         : : : : x3_symbols2 ]
      [ run symbols3.cpp         : : : : x3_symbols3 ]
+     [ run symbols4.cpp         : : : : x3_symbols4 ]
      #~ [ run terminal_ex.cpp      : : : : x3_terminal_ex ]
      [ run tst.cpp
        $(BOOST_ROOT)/libs/system/build//boost_system

--- a/test/x3/symbols4.cpp
+++ b/test/x3/symbols4.cpp
@@ -1,0 +1,60 @@
+/*=============================================================================
+    Copyright (c) 2015 Thomas Bernard
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/spirit/home/x3.hpp>
+
+#include "test.hpp"
+
+
+#include <boost/spirit/home/x3.hpp>
+
+ namespace braille {
+      namespace encoding {
+          struct dots
+          {
+              using char_type = char32_t;
+          };
+      }
+
+      template <typename Encoding>
+      struct dots_compare
+      {
+          int32_t operator()(
+                typename Encoding::char_type const lc
+              , typename Encoding::char_type const rc) const
+          {
+              // do magic here
+              return lc - rc;
+          }
+
+      };
+
+      struct get_dots_compare
+      {
+          template <typename Context>
+           static dots_compare<encoding::dots> get(Context const& context)
+           {
+               return {};
+           }
+      };
+ }
+
+ namespace braille {
+      template<typename T = boost::spirit::x3::unused_type>
+      using symbols = boost::spirit::x3::symbols_parser<braille::encoding::dots, T, get_dots_compare>;
+ }
+
+ int main()
+ {
+    using spirit_test::test;
+    {
+      braille::symbols<> syms;
+      syms.add(U"\u2800");
+      BOOST_TEST((test(U"\u2800", syms)));
+    }
+    return boost::report_errors();
+ }


### PR DESCRIPTION
Just added an additional template parameter to the symbols parser as in qi, except it's not the filter directly, only a helper struct to get hold of the correct filter. This was necessary to continue to support case insensitive parsing.
