### PR TITLE
Allow retrieval of the iterator_range of a position_tagged.

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -53,6 +53,11 @@ namespace boost { namespace spirit { namespace x3
             return pos_cache.annotate(ast, first, last);
         }
 
+        boost::iterator_range<Iterator> position_of(position_tagged pos) const
+        {
+            return pos_cache.position_of(pos);
+        }
+
     private:
 
         void print_file_line(std::size_t line) const;


### PR DESCRIPTION
position_cache allows to retrieve the iterator_range of a position tagged AST
type.  However, pos_cache in error_handler<Iterator> is private, so the
iterator_range can not be retrieved from client code. It would be useful for a
"late raw" and for testing purposes. This patch adds
error_handler<Iterator>::position_of(position_tagged).