### PR TITLE
define iterator_t only if it's referenced

### DIFF
--- a/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -282,12 +282,12 @@ struct grammar_definition
 #if !defined(BOOST_SPIRIT_SINGLE_GRAMMAR_INSTANCE)
         typedef impl::grammar_helper_base<GrammarT> helper_base_t;
         typedef grammar_helper_list<GrammarT> helper_list_t;
-        typedef typename helper_list_t::vector_t::reverse_iterator iterator_t;
 
         helper_list_t&  helpers =
         grammartract_helper_list::do_(self);
 
 # if defined(BOOST_INTEL_CXX_VERSION)
+        typedef typename helper_list_t::vector_t::reverse_iterator iterator_t;
         for (iterator_t i = helpers.rbegin(); i != helpers.rend(); ++i)
             (*i)->undefine(self);
 # else


### PR DESCRIPTION
I keep getting this unused typedef warning when compiling QuickBook.
