### PR TITLE
X3: Avoid copying the arguments to {unary,binary}_parser, sequence and alternative.

### DIFF
--- a/include/boost/spirit/home/x3/core/parser.hpp
+++ b/include/boost/spirit/home/x3/core/parser.hpp
@@ -77,7 +77,7 @@ namespace boost { namespace spirit { namespace x3
         typedef Subject subject_type;
         static bool const has_action = Subject::has_action;
 
-        unary_parser(Subject subject)
+        unary_parser(Subject const& subject)
             : subject(subject) {}
 
         unary_parser const& get_unary() const { return *this; }
@@ -94,7 +94,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_action =
             left_type::has_action || right_type::has_action;
 
-        binary_parser(Left left, Right right)
+        binary_parser(Left const& left, Right const& right)
             : left(left), right(right) {}
 
         binary_parser const& get_binary() const { return *this; }

--- a/include/boost/spirit/home/x3/operator/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/alternative.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef binary_parser<Left, Right, alternative<Left, Right>> base_type;
 
-        alternative(Left left, Right right)
+        alternative(Left const& left, Right const& right)
             : base_type(left, right) {}
 
         template <typename Iterator, typename Context, typename RContext>

--- a/include/boost/spirit/home/x3/operator/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/sequence.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef binary_parser<Left, Right, sequence<Left, Right>> base_type;
 
-        sequence(Left left, Right right)
+        sequence(Left const& left, Right const& right)
             : base_type(left, right) {}
 
         template <typename Iterator, typename Context, typename RContext>


### PR DESCRIPTION
For consistency with the rest.  Apparently, this brings the executable size of
an X3 grammar of mine down from 440936 to 420000.  It also reduces compilation
time a bit, which was rather unexpected (18.3s to 17.8s).