### PR TITLE
X3: Add another missing const&.

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const force_attribute =
             force_attribute_;
 
-        rule_definition(RHS rhs, char const* name)
+        rule_definition(RHS const& rhs, char const* name)
           : rhs(rhs), name(name) {}
 
         template <typename Iterator, typename Context, typename Attribute_>


### PR DESCRIPTION
A tiny change which results in 7kb less binary size and 17.8s to 17.2s compile
time reduction (GCC).