### PR TITLE
X3: Eliminate two more hidden cases of get_result.

### DIFF
--- a/include/boost/spirit/home/x3/support/subcontext.hpp
+++ b/include/boost/spirit/home/x3/support/subcontext.hpp
@@ -25,12 +25,6 @@ namespace boost { namespace spirit { namespace x3
         subcontext(Context const& /*context*/)
         {}
         
-        template <typename ID_, typename Unused = void>
-        struct get_result
-        {
-            typedef unused_type type;
-        };
-
         template <typename ID_>
         unused_type
         get(ID_) const

--- a/include/boost/spirit/home/x3/support/unused.hpp
+++ b/include/boost/spirit/home/x3/support/unused.hpp
@@ -60,9 +60,6 @@ namespace boost { namespace spirit { namespace x3
         // unused_type can also masquerade as an empty context (see context.hpp)
 
         template <typename ID>
-        struct get_result : mpl::identity<unused_type> {};
-
-        template <typename ID>
         unused_type get(ID) const
         {
             return {};


### PR DESCRIPTION
This is a follow-up to 6ede5f7c8129c4fbcfb09d8762f26e0cbd64b1c6.