### PR TITLE
X3: Use decltype instead of result_of.

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/is_callable.hpp
+++ b/include/boost/spirit/home/x3/support/utility/is_callable.hpp
@@ -7,21 +7,17 @@
 #ifndef BOOST_SPIRIT_X3_IS_CALLABLE_HPP_INCLUDED
 #define BOOST_SPIRIT_X3_IS_CALLABLE_HPP_INCLUDED
 
-#include <boost/utility/result_of.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/spirit/home/x3/support/utility/sfinae.hpp>
-
 
 namespace boost { namespace spirit { namespace x3 { namespace detail
 {
     template <typename Sig, typename Enable = void>
-    struct is_callable_impl
-      : mpl::false_
-    {};
+    struct is_callable_impl : mpl::false_ {};
 
     template <typename F, typename... A>
     struct is_callable_impl<F(A...), typename disable_if_substitution_failure<
-        typename result_of<F(A...)>::type>::type>
+        decltype(std::declval<F>()(std::declval<A>()...))>::type>
       : mpl::true_
     {};
 }}}}
@@ -32,9 +28,7 @@ namespace boost { namespace spirit { namespace x3
     struct is_callable;
 
     template <typename F, typename... A>
-    struct is_callable<F(A...)>
-      : detail::is_callable_impl<F(A...)>
-    {};
+    struct is_callable<F(A...)> : detail::is_callable_impl<F(A...)> {};
 }}}
 
 


### PR DESCRIPTION
boost/utility/result_of.hpp is rather expensive to include. Using decltype
here makes the compile time go down by almost half a sec.