### PR TITLE
attribute type specification used `basic_string`

### DIFF
--- a/doc/qi/string.qbk
+++ b/doc/qi/string.qbk
@@ -87,7 +87,7 @@ not defined in __primitive_parser_concept__.
     [[Expression]       [Attribute]]
     [[`s`]              [__unused__]]
     [[`lit(s)`]         [__unused__]]
-    [[`ns::string(s)`]  [`std::basic_string<T>` where `T`
+    [[`ns::string(s)`]  [`std::vector<T>` where `T`
                         is the underlying character type
                         of `s`.]]
 ]


### PR DESCRIPTION
It was [brought to my attention](http://stackoverflow.com/questions/11421430/string-parser-with-boost-variant-recursive-wrapper/11422737?noredirect=1#comment49970878_11422737) on SO that the documentation seems to be (confusingly) in error.

I admit I get more questions about "why can't I assign the synthesized attribute to a `std::string`" than I could explain. So I guess this should be fixed.
