### PR TITLE
Fixed modifier bug with karma::left_align

### DIFF
--- a/include/boost/spirit/home/karma/directive/left_alignment.hpp
+++ b/include/boost/spirit/home/karma/directive/left_alignment.hpp
@@ -275,10 +275,10 @@ namespace boost { namespace spirit { namespace karma
 
         template <typename Terminal>
         result_type operator()(Terminal const& term, Subject const& subject
-          , unused_type) const
+          , Modifiers const& modifiers) const
         {
             return result_type(subject
-              , compile<karma::domain>(fusion::at_c<1>(term.args))
+              , compile<karma::domain>(fusion::at_c<1>(term.args), modifiers)
               , fusion::at_c<0>(term.args));
         }
     };

--- a/test/karma/center_alignment.cpp
+++ b/test/karma/center_alignment.cpp
@@ -11,6 +11,7 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
+#include <boost/spirit/include/karma_upper_lower_case.hpp>
 
 #include <string>
 #include <iterator>
@@ -37,6 +38,9 @@ main()
         BOOST_TEST(test("*****x****", center(10, char_('*'))[char_('x')]));
         BOOST_TEST(test("*****x****", center(10, '*')[char_], 'x'));
         BOOST_TEST(test("*****x****", center(10, '*')['x']));
+        BOOST_TEST(test("aaaaaxaaaa", lower[center(10, 'A')['X']]));
+        BOOST_TEST(test("AAAAAXAAAA", upper[center(10, 'a')['x']]));
+
 
         BOOST_TEST(test("*****x****", center(char_('*'))[char_('x')]));
         BOOST_TEST(test("*****x****", center(char_('*'))[char_], 'x'));

--- a/test/karma/left_alignment.cpp
+++ b/test/karma/left_alignment.cpp
@@ -11,6 +11,7 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
+#include <boost/spirit/include/karma_upper_lower_case.hpp>
 
 #include "test.hpp"
 
@@ -34,6 +35,8 @@ main()
         BOOST_TEST(test("x*********", left_align(10, char_('*'))[char_('x')]));
         BOOST_TEST(test("x*********", left_align(10, '*')[char_], 'x'));
         BOOST_TEST(test("x*********", left_align(10, '*')['x']));
+        BOOST_TEST(test("xaaaaaaaaa", lower[left_align(10, 'A')['X']]));
+        BOOST_TEST(test("XAAAAAAAAA", upper[left_align(10, 'a')['x']]));
 
         BOOST_TEST(test("x*********", left_align(char_('*'))[char_('x')]));
         BOOST_TEST(test("x*********", left_align(char_('*'))[char_], 'x'));

--- a/test/karma/right_alignment.cpp
+++ b/test/karma/right_alignment.cpp
@@ -11,6 +11,7 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
+#include <boost/spirit/include/karma_upper_lower_case.hpp>
 
 #include "test.hpp"
 
@@ -34,6 +35,8 @@ main()
         BOOST_TEST(test("*********x", right_align(10, char_('*'))[char_('x')]));
         BOOST_TEST(test("*********x", right_align(10, '*')[char_], 'x'));
         BOOST_TEST(test("*********x", right_align(10, '*')['x']));
+        BOOST_TEST(test("aaaaaaaaax", lower[right_align(10, 'A')['X']]));
+        BOOST_TEST(test("AAAAAAAAAX", upper[right_align(10, 'a')['x']]));
 
         BOOST_TEST(test("*********x", right_align(char_('*'))[char_('x')]));
         BOOST_TEST(test("*********x", right_align(char_('*'))[char_], 'x'));


### PR DESCRIPTION
I found a bug in the factory function for `karma::left_align`. `upper[left_align(10, 'a')['x']]` currently fails to compile because the constructor for the `left_align` object is given a different type. I applied the modifiers to the pad character because `right_align` does, and that appears to be the goal. However, should it be a direct change? In other words should `upper[left_align(10, 'a')['x']]` output `Xaaaaaaaaa` or `XAAAAAAAAA`?