### PR TITLE
Fixed bug in karma::duplicate attribute reporting

### DIFF
--- a/include/boost/spirit/home/karma/directive/duplicate.hpp
+++ b/include/boost/spirit/home/karma/directive/duplicate.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace spirit { namespace karma
         template <typename T
           , bool IsSequence = fusion::traits::is_sequence<T>::value>
         struct first_attribute_of_subject
-          : fusion::result_of::at_c<T, 0>
+          : remove_reference<typename fusion::result_of::at_c<T, 0>::type>
         {};
 
         template <typename T>

--- a/test/karma/duplicate.cpp
+++ b/test/karma/duplicate.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2001-2011 Hartmut Kaiser
-// 
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying 
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/config/warning_disable.hpp>
@@ -22,26 +22,34 @@ int main()
     // test for sequences
     {
         BOOST_TEST(test("2.02.0", duplicate[double_ << double_], 2.0));
-        BOOST_TEST(test_delimited("2.0 2.0 ", 
+        BOOST_TEST(test_delimited("2.0 2.0 ",
             duplicate[double_ << double_], 2.0, space));
-        BOOST_TEST(test("2.02.02.0", 
+        BOOST_TEST(test("2.02.02.0",
             duplicate[double_ << double_ << double_], 2.0));
-        BOOST_TEST(test_delimited("2.0 2.0 2.0 ", 
+        BOOST_TEST(test_delimited("2.0 2.0 2.0 ",
             duplicate[double_ << double_ << double_], 2.0, space));
     }
-    
+
     // test for non-sequences
     {
         BOOST_TEST(test("2.02.0", duplicate["2.0" << double_], 2.0));
-        BOOST_TEST(test_delimited("2.0 2.0 ", 
+        BOOST_TEST(test_delimited("2.0 2.0 ",
             duplicate["2.0" << double_], 2.0, space));
     }
 
     // test for subjects exposing no attribute
     {
         BOOST_TEST(test("2.02.0", duplicate["2.0"] << double_, 2.0));
-        BOOST_TEST(test_delimited("2.0 2.0 ", 
+        BOOST_TEST(test_delimited("2.0 2.0 ",
             duplicate["2.0"] << double_, 2.0, space));
+    }
+
+    // test for attribute reporting
+    {
+        BOOST_TEST(test("bar", (duplicate["bar"] | "foo")));
+        BOOST_TEST(test("2.0", (duplicate[double_] | "foo"), 2.0));
+        BOOST_TEST(test("2.02.0",
+            (duplicate[double_ << double_] | "foo"), 2.0));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
An expression such as `generate(..., (duplicate[double_ << double_] | "foo"), 2.0)` will output "foo" even though `duplicate[double_ << double_]` should never fail. The problem is that `duplicate` adds a reference to the reported attribute type. The `is_convertible` check will fail, causing the first branch of the alternative to be ignored at compile-time.

All of the tests were run on OSX with this patch - no issues. I leave it to the spirit braintrust to determine whether this could cause any issues with code in the wild.