### PR TITLE
X3: Fix char_range boundaries

### DIFF
--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -42,8 +42,8 @@ namespace boost { namespace spirit { namespace x3
 
             char_type ch = char_type(ch_);  // optimize for token based parsing
             return ((sizeof(Char) <= sizeof(char_type)) || encoding::ischar(ch_))
-                        && (get_case_compare<encoding>(context)(ch, from) > 0 )
-                        && (get_case_compare<encoding>(context)(ch , to) < 0 );
+                        && (get_case_compare<encoding>(context)(ch, from) >= 0 )
+                        && (get_case_compare<encoding>(context)(ch , to) <= 0 );
         }
 
         char_type from, to;

--- a/test/x3/char1.cpp
+++ b/test/x3/char1.cpp
@@ -31,6 +31,11 @@ main()
         BOOST_TEST(test("x", char_('a', 'z')));
         BOOST_TEST(!test("x", char_('0', '9')));
 
+        BOOST_TEST(test("0", char_('0', '9')));
+        BOOST_TEST(test("9", char_('0', '9')));
+        BOOST_TEST(!test("0", ~char_('0', '9')));
+        BOOST_TEST(!test("9", ~char_('0', '9')));
+
         BOOST_TEST(!test("x", ~char_));
         BOOST_TEST(!test("x", ~char_('x')));
         BOOST_TEST(test(" ", ~char_('x')));


### PR DESCRIPTION
These small changes should fix the behaviour described in [ticket 11531](https://svn.boost.org/trac/boost/ticket/11531).