### PR TITLE
fixed 1.59.0 rc3: compiler warnings in real_impl.hpp

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -284,7 +284,7 @@ namespace boost { namespace spirit { namespace qi  { namespace detail
                     // If there is no number, disregard the exponent altogether.
                     // by resetting 'first' prior to the exponent prefix (e|E)
                     first = e_pos;
-                    n = acc_n;
+                    n = T(acc_n);
                 }
             }
             else if (frac_digits)
@@ -306,11 +306,11 @@ namespace boost { namespace spirit { namespace qi  { namespace detail
                     return true;    // got a NaN or Inf, return immediately
                 }
 
-                n = acc_n;
+                n = T(acc_n);
             }
             else
             {
-                n = acc_n;
+                n = T(acc_n);
             }
 
             // If we got a negative sign, negate the number


### PR DESCRIPTION
explicit type conversions & static_cast to avoid compiler
warning
warning C4244: '=' : conversion from 'unsigned __int64' to
'double',
possible loss of data
in real_impl.hpp