### PR TITLE
prevent unused warnings in x3

### DIFF
--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -40,8 +40,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator&, Iterator const&
+          , Context const&, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_, attr_);
@@ -76,8 +76,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator&, Iterator const&
+          , Context const&, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_ + 0, value_ + N, attr_);

--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace spirit { namespace x3
             !is_same<unused_type, attribute_type>::value;
         static bool const handles_container =
             traits::is_container<attribute_type>::value;
-        
+
         attr_parser(Value const& value)
           : value_(value) {}
         attr_parser(Value&& value)
@@ -40,8 +40,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator&, Iterator const&
-          , Context const&, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator& /*first*/, Iterator const& /*last*/
+          , Context const& /*context*/, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_, attr_);
@@ -54,7 +54,7 @@ namespace boost { namespace spirit { namespace x3
         // silence MSVC warning C4512: assignment operator could not be generated
         attr_parser& operator= (attr_parser const&);
     };
-    
+
     template <typename Value, std::size_t N>
     struct attr_parser<Value[N]> : parser<attr_parser<Value[N]>>
     {
@@ -63,7 +63,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_attribute =
             !is_same<unused_type, attribute_type>::value;
         static bool const handles_container = true;
-        
+
         attr_parser(Value const (&value)[N])
         {
             std::copy(value + 0, value + N, value_ + 0);
@@ -76,8 +76,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator&, Iterator const&
-          , Context const&, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator& /*first*/, Iterator const& /*last*/
+          , Context const& /*context*/, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_ + 0, value_ + N, attr_);
@@ -90,7 +90,7 @@ namespace boost { namespace spirit { namespace x3
         // silence MSVC warning C4512: assignment operator could not be generated
         attr_parser& operator= (attr_parser const&);
     };
-    
+
     template <typename Value>
     struct get_info<attr_parser<Value>>
     {

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -45,7 +45,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context const& context, unused_type, Attribute&) const
+          , Context const& context, unused_type, Attribute& /*attr*/) const
         {
             x3::skip_over(first, last, context);
             return f(x3::get<rule_context_tag>(context));

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -45,7 +45,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context const& context, unused_type, Attribute& attr) const
+          , Context const& context, unused_type, Attribute&) const
         {
             x3::skip_over(first, last, context);
             return f(x3::get<rule_context_tag>(context));

--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -115,7 +115,7 @@ namespace boost { namespace spirit { namespace x3
     struct get_info<char_set<Encoding, Attribute>>
     {
         typedef std::string result_type;
-        std::string operator()(char_set<Encoding, Attribute> const& p) const
+        std::string operator()(char_set<Encoding, Attribute> const&) const
         {
             return "char-set";
         }

--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -115,7 +115,7 @@ namespace boost { namespace spirit { namespace x3
     struct get_info<char_set<Encoding, Attribute>>
     {
         typedef std::string result_type;
-        std::string operator()(char_set<Encoding, Attribute> const&) const
+        std::string operator()(char_set<Encoding, Attribute> const& /*p*/) const
         {
             return "char-set";
         }

--- a/include/boost/spirit/home/x3/core/call.hpp
+++ b/include/boost/spirit/home/x3/core/call.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename F, typename Context>
-        auto call(F f, Context const& context, mpl::false_)
+        auto call(F f, Context const&, mpl::false_)
         {
             return f();
         }

--- a/include/boost/spirit/home/x3/core/call.hpp
+++ b/include/boost/spirit/home/x3/core/call.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename F, typename Context>
-        auto call(F f, Context const&, mpl::false_)
+        auto call(F f, Context const& /*context*/, mpl::false_)
         {
             return f();
         }

--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -202,7 +202,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool call(
             Parser const& parser
           , Iterator& first, Iterator const& last, Context const& context
-          , RContext& rcontext, Attribute&, mpl::false_)
+          , RContext& rcontext, Attribute& /*attr*/, mpl::false_)
         {
             return parser.parse(first, last, context, rcontext, unused);
         }

--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -202,7 +202,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool call(
             Parser const& parser
           , Iterator& first, Iterator const& last, Context const& context
-          , RContext& rcontext, Attribute& attr, mpl::false_)
+          , RContext& rcontext, Attribute&, mpl::false_)
         {
             return parser.parse(first, last, context, rcontext, unused);
         }

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -138,7 +138,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
     template <typename ID, typename RHS, typename Context>
     Context const&
-    make_rule_context(RHS const& rhs, Context const& context
+    make_rule_context(RHS const&, Context const& context
       , mpl::false_ /* is_default_parse_rule */)
     {
         return context;
@@ -156,8 +156,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& first, Iterator const& last
-          , Context const& context, ActualAttribute& attr
+            Iterator& , Iterator const&
+          , Context const&, ActualAttribute&
           , mpl::false_ /* No on_success handler */ )
         {
             return true;
@@ -285,7 +285,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool parse_rhs(
             RHS const& rhs
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, ActualAttribute& attr
+          , Context const& context, RContext& rcontext, ActualAttribute&
           , mpl::true_)
         {
             return parse_rhs_main(rhs, first, last, context, rcontext, unused);
@@ -327,6 +327,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 #if defined(BOOST_SPIRIT_X3_DEBUG)
                   context_debug<Iterator, typename make_attribute::value_type>
                 dbg(rule_name, first, last, attr_, ok_parse);
+#else
+                (void)rule_name; // prevent unused warning
 #endif
                 ok_parse=parse_rhs(rhs, first, last, context, attr_, attr_
                    , mpl::bool_

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -138,7 +138,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
     template <typename ID, typename RHS, typename Context>
     Context const&
-    make_rule_context(RHS const&, Context const& context
+    make_rule_context(RHS const& /*rhs*/, Context const& context
       , mpl::false_ /* is_default_parse_rule */)
     {
         return context;
@@ -156,8 +156,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& , Iterator const&
-          , Context const&, ActualAttribute&
+            Iterator& /*first*/, Iterator const& /*last*/
+          , Context const& /*context*/, ActualAttribute& /*attr*/
           , mpl::false_ /* No on_success handler */ )
         {
             return true;
@@ -285,7 +285,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool parse_rhs(
             RHS const& rhs
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, ActualAttribute&
+          , Context const& context, RContext& rcontext, ActualAttribute& /*attr*/
           , mpl::true_)
         {
             return parse_rhs_main(rhs, first, last, context, rcontext, unused);

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace spirit { namespace x3
       , typename Context, typename ActualAttribute>
     inline detail::default_parse_rule_result
     parse_rule(
-        rule<ID, Attribute>
+        rule<ID, Attribute> /*rule_*/
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr)
     {
@@ -156,7 +156,7 @@ namespace boost { namespace spirit { namespace x3
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
-        decltype(rule_name)                                                     \
+        decltype(rule_name) /*rule_*/                                           \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, Attribute& attr)                                \
     {                                                                           \

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace spirit { namespace x3
       , typename Context, typename ActualAttribute>
     inline detail::default_parse_rule_result
     parse_rule(
-        rule<ID, Attribute> rule_
+        rule<ID, Attribute>
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr)
     {
@@ -156,7 +156,7 @@ namespace boost { namespace spirit { namespace x3
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
-        decltype(rule_name) rule_                                               \
+        decltype(rule_name)                                                     \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, Attribute& attr)                                \
     {                                                                           \

--- a/include/boost/spirit/home/x3/operator/detail/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/alternative.hpp
@@ -226,7 +226,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     struct move_if_not_alternative
     {
         template<typename T1, typename T2>
-        static void call(T1&, T2&) {}
+        static void call(T1& /*attr_*/, T2& /*attr*/) {}
     };
 
     template <>

--- a/include/boost/spirit/home/x3/operator/detail/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/alternative.hpp
@@ -226,7 +226,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     struct move_if_not_alternative
     {
         template<typename T1, typename T2>
-        static void call(T1& attr_, T2& attr) {}
+        static void call(T1&, T2&) {}
     };
 
     template <>

--- a/include/boost/spirit/home/x3/support/context.hpp
+++ b/include/boost/spirit/home/x3/support/context.hpp
@@ -79,7 +79,7 @@ namespace boost { namespace spirit { namespace x3
     {
         template <typename ID, typename T, typename Next, typename FoundVal>
         inline Next const&
-        make_unique_context(T& val, Next const& next, FoundVal&)
+        make_unique_context(T&, Next const& next, FoundVal&)
         {
             return next;
         }

--- a/include/boost/spirit/home/x3/support/context.hpp
+++ b/include/boost/spirit/home/x3/support/context.hpp
@@ -74,16 +74,16 @@ namespace boost { namespace spirit { namespace x3
     {
         return { val };
     }
-    
+
     namespace detail
     {
         template <typename ID, typename T, typename Next, typename FoundVal>
         inline Next const&
-        make_unique_context(T&, Next const& next, FoundVal&)
+        make_unique_context(T& /*val*/, Next const& next, FoundVal&)
         {
             return next;
         }
-        
+
         template <typename ID, typename T, typename Next>
         inline context<ID, T, Next>
         make_unique_context(T& val, Next const& next, unused_type)
@@ -91,7 +91,7 @@ namespace boost { namespace spirit { namespace x3
             return { val, next };
         }
     }
-    
+
     template <typename ID, typename T, typename Next>
     inline auto
     make_unique_context(T& val, Next const& next)

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -164,7 +164,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         // Not all containers have "reserve"
         template <typename Container_>
-        static void reserve(Container_& c, std::size_t size) {}
+        static void reserve(Container_&, std::size_t) {}
 
         template <typename T, typename Allocator>
         static void reserve(std::vector<T, Allocator>& c, std::size_t size)
@@ -194,7 +194,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     }
 
     template <typename Iterator>
-    inline bool append(unused_type, Iterator first, Iterator last)
+    inline bool append(unused_type, Iterator, Iterator)
     {
         return true;
     }

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -79,10 +79,10 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     // so that check can be done in traits::is_substitute specialisation
     template <typename T>
     struct container_value<T
-			   , typename enable_if<typename mpl::eval_if <
-						    fusion::traits::is_sequence<T>
-						    , fusion::traits::is_associative<T>
-						    , mpl::false_ >::type >::type>
+      , typename enable_if<typename mpl::eval_if <
+                fusion::traits::is_sequence<T>
+              , fusion::traits::is_associative<T>
+              , mpl::false_ >::type >::type>
     : mpl::identity<T> {};
 
     template <>
@@ -95,7 +95,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
     template <typename Container>
     struct container_iterator<Container const>
-         : mpl::identity<typename Container::const_iterator> {};
+        : mpl::identity<typename Container::const_iterator> {};
 
     template <>
     struct container_iterator<unused_type>
@@ -117,13 +117,13 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         {
             c.insert(std::move(val));
         }
-       
+
         template <typename Container_, typename T>
         static void push_back(Container_& c, T&& val)
         {
             c.push_back(std::move(val));
         }
-       
+
         template <typename T>
         static bool call(Container& c, T&& val)
         {
@@ -164,14 +164,14 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         // Not all containers have "reserve"
         template <typename Container_>
-        static void reserve(Container_&, std::size_t) {}
+        static void reserve(Container_& /*c*/, std::size_t /*size*/) {}
 
         template <typename T, typename Allocator>
         static void reserve(std::vector<T, Allocator>& c, std::size_t size)
         {
             c.reserve(size);
         }
-       
+
         template <typename Container_, typename Iterator>
         static void insert(Container_& c, Iterator first, Iterator last)
         {
@@ -194,7 +194,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     }
 
     template <typename Iterator>
-    inline bool append(unused_type, Iterator, Iterator)
+    inline bool append(unused_type, Iterator /*first*/, Iterator /*last*/)
     {
         return true;
     }


### PR DESCRIPTION
I'm not quite sure about the macro magic in "include/boost/spirit/home/x3/nonterminal/rule.hpp" :/