### PR TITLE
X3: Fix expect directive's handling of container attributes

### DIFF
--- a/include/boost/spirit/home/x3/directive/expect.hpp
+++ b/include/boost/spirit/home/x3/directive/expect.hpp
@@ -39,6 +39,7 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef unary_parser<Subject, expect_directive<Subject> > base_type;
         static bool const is_pass_through_unary = true;
+        static bool const handles_container = Subject::handles_container;
 
         expect_directive(Subject const& subject)
           : base_type(subject) {}

--- a/test/x3/expect.cpp
+++ b/test/x3/expect.cpp
@@ -101,6 +101,13 @@ main()
             BOOST_TEST((at_c<1>(attr) == 'b'));
             BOOST_TEST((at_c<2>(attr) == 'c'));
         }
+
+        {
+            std::string attr;
+            BOOST_TEST((test_attr("'azaaz'",
+                "'" > *(char_("a") | char_("z")) > "'", attr, space)));
+            BOOST_TEST(attr == "azaaz");
+        }
     }
 
     {


### PR DESCRIPTION
So far, a kleene star within a expect directive did not correctly populate the attribute. For example the program

``` cpp
#include <iostream>
#include <boost/spirit/home/x3.hpp>
#include <boost/spirit/home/support/multi_pass.hpp>

namespace x3 = boost::spirit::x3;
namespace ascii = boost::spirit::x3::ascii;

using x3::lit;
using x3::char_;

int main() {
  auto const rule
    = lit(':')
      > *(char_('A', 'Z') | char_('a', 'z'))
    ;

  std::string input(":AaBbCcDd");
  std::vector<char> result;
  std::cout << "Success: " << parse(input.begin(), input.end(), rule, result) << std::endl;
  for (auto& r : result) {
    std::cout << r;
  }
  std::cout << std::endl;
}
```

gives the following results:
- the parser accepts the string, i.e. `parse` returns true
- but the `result` vector only contains the last character of the string (`'d'`) instead of all the characters.

This pull request fixes this misbehaviour, by adding the `handles_container` flag to the expect directive. It also contains a regression test.
