### PR TITLE
reenabled support for BOOST_FUSION_ADAPT_ADT adapted structs

### DIFF
--- a/include/boost/spirit/home/qi/detail/assign_to.hpp
+++ b/include/boost/spirit/home/qi/detail/assign_to.hpp
@@ -18,6 +18,7 @@
 #include <boost/spirit/home/qi/detail/attributes.hpp>
 #include <boost/spirit/home/support/container.hpp>
 #include <boost/fusion/include/copy.hpp>
+#include <boost/fusion/adapted/struct/detail/extension.hpp>
 #include <boost/ref.hpp>
 #include <boost/range/iterator_range.hpp>
 
@@ -200,6 +201,16 @@ namespace boost { namespace spirit { namespace traits
         call(boost::optional<T> const& val, Attribute& attr)
         {
             assign_to(val.get(), attr);
+        }
+    };
+
+    template <typename Attribute, int N, bool Const, typename T>
+    struct assign_to_attribute_from_value<fusion::extension::adt_attribute_proxy<Attribute, N, Const>, T>
+    {
+        static void
+        call(typename T const& val, typename fusion::extension::adt_attribute_proxy<Attribute, N, Const>& attr)
+        {
+            attr = val;
         }
     };
 


### PR DESCRIPTION
since commit 69cc5370381e48352dc01c708599e9b49b7460f0 (hkaiser hkaiser
authored on 7 Nov 2009) spirit support BOOST_FUSION_ADAPT_ADT adapted
structs was broken