### PR TITLE
Fix local typedef definition warning

### DIFF
--- a/include/boost/spirit/home/karma/string/lit.hpp
+++ b/include/boost/spirit/home/karma/string/lit.hpp
@@ -175,9 +175,6 @@ namespace boost { namespace spirit { namespace karma
             // fail if attribute isn't matched by immediate literal
             typedef typename attribute<Context>::type attribute_type;
 
-            typedef typename spirit::result_of::extract_from<attribute_type, Attribute>::type
-                extracted_string_type;
-
             using spirit::traits::get_c_string;
             if (!detail::string_compare(
                     get_c_string(


### PR DESCRIPTION
Hello,
I submit this tiny cleanup PR since this causes the following warning (treated as error)
```
...
include/boost/spirit/home/karma/string/lit.hpp: In member function 'bool boost::spirit::karma::literal_string<String, CharEncoding, Tag, no_attribute>::gen
erate(OutputIterator&, Context&, const Delimiter&, const Attribute&) const':
include/boost/spirit/home/karma/string/lit.hpp:179:17: error: typedef 'extracted_string_type' locally defined but not used [-Werror=unused-local-typedefs]
                 extracted_string_type;
                 ^
cc1plus: all warnings being treated as errors
```
The definition of _extracted_string_type_  was introduced by commit 555ce82 and its use removed some days later through 2d4f293. So I guess this local definition can be safely removed.
To you for validation.

Regards,
-----------------------
Platform: linux
Compiler: gcc 4.9.3