### PR TITLE
Fix: remove extraneous 'typename'

### DIFF
--- a/include/boost/spirit/home/qi/detail/assign_to.hpp
+++ b/include/boost/spirit/home/qi/detail/assign_to.hpp
@@ -208,7 +208,7 @@ namespace boost { namespace spirit { namespace traits
     struct assign_to_attribute_from_value<fusion::extension::adt_attribute_proxy<Attribute, N, Const>, T>
     {
         static void
-        call(typename T const& val, typename fusion::extension::adt_attribute_proxy<Attribute, N, Const>& attr)
+        call(T const& val, typename fusion::extension::adt_attribute_proxy<Attribute, N, Const>& attr)
         {
             attr = val;
         }


### PR DESCRIPTION
Defect introduced by new code in a4f9ea9d58303b0d6a4347bcea4f30a9fdddebd2