### PR TITLE
Fix "unused locally defined typedef" in parse_tree.hpp

### DIFF
--- a/include/boost/spirit/home/classic/tree/parse_tree.hpp
+++ b/include/boost/spirit/home/classic/tree/parse_tree.hpp
@@ -76,7 +76,6 @@ struct pt_tree_policy :
     template<typename MatchAT, typename MatchBT>
     static void concat(MatchAT& a, MatchBT const& b)
     {
-        typedef typename match_t::attr_t attr_t;
         BOOST_SPIRIT_ASSERT(a && b);
 
         std::copy(b.trees.begin(), b.trees.end(),


### PR DESCRIPTION
Hi,

When building against Spirit with -Wall -Wextra and gcc 4.9, we get:

79:42: error: typedef 'attr_t' locally defined but not used [-Werror=unused-local-typedefs]
typedef typename match_t::attr_t attr_t;

in file include/boost/spirit/home/classic/tree/parse_tree.hpp.

This patch fixes it.

Cheers,
Romain