### PR TITLE
Support variadic fusion.

### DIFF
--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -1060,12 +1060,13 @@ namespace boost { namespace spirit { namespace traits
         typedef T type;
     };
 
+#if !defined(BOOST_FUSION_HAS_VARIADIC_VECTOR)
     template <typename T>
     struct strip_single_element_vector<fusion::vector1<T> >
     {
         typedef T type;
     };
-
+#endif
     template <typename T>
     struct strip_single_element_vector<fusion::vector<T> >
     {

--- a/include/boost/spirit/home/support/terminal.hpp
+++ b/include/boost/spirit/home/support/terminal.hpp
@@ -16,7 +16,6 @@
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_function.hpp>
 #include <boost/proto/proto.hpp>
-#include <boost/fusion/include/void.hpp>
 #include <boost/spirit/home/support/meta_compiler.hpp>
 #include <boost/spirit/home/support/detail/make_vector.hpp>
 #include <boost/spirit/home/support/unused.hpp>
@@ -236,12 +235,9 @@ namespace boost { namespace spirit
           : to_nonlazy_arg<A>
         {};
 
+        // incomplete type: should not be appeared unused_type in nonlazy arg.
         template <>
-        struct to_nonlazy_arg<unused_type>
-        {
-            // unused arg: make_vector wants fusion::void_
-            typedef fusion::void_ type;
-        };
+        struct to_nonlazy_arg<unused_type>;
     }
 
     template <typename Terminal>
@@ -268,10 +264,42 @@ namespace boost { namespace spirit
         template <
             bool Lazy
           , typename A0
-          , typename A1
-          , typename A2
+          , typename A1 = unused_type
+          , typename A2 = unused_type
         >
         struct result_helper;
+
+        template <
+            typename A0
+        >
+        struct result_helper<false, A0>
+        {
+            typedef typename
+                proto::terminal<
+                    terminal_ex<
+                        Terminal
+                      , typename detail::result_of::make_vector<
+                            typename detail::to_nonlazy_arg<A0>::type>::type>
+                >::type
+            type;
+        };
+
+        template <
+            typename A0
+          , typename A1
+        >
+        struct result_helper<false, A0, A1>
+        {
+            typedef typename
+                proto::terminal<
+                    terminal_ex<
+                        Terminal
+                      , typename detail::result_of::make_vector<
+                            typename detail::to_nonlazy_arg<A0>::type
+                          , typename detail::to_nonlazy_arg<A1>::type>::type>
+                >::type
+            type;
+        };
 
         template <
             typename A0


### PR DESCRIPTION
First commit avoids compile error on partial specialization in c++11 due to deprecation.
Second commit removes use of undocumented fusion::void_.