### PR TITLE
Fix: use boost::none global instance instead of constructing it ourse…

### DIFF
--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -90,7 +90,7 @@ namespace boost { namespace spirit { namespace qi
         static void post(boost::optional<Exposed>&, Transformed const&) {}
         static void fail(boost::optional<Exposed>& val)
         {
-             val = none_t();    // leave optional uninitialized if rhs failed
+             val = none;    // leave optional uninitialized if rhs failed
         }
     };
 

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -1154,7 +1154,7 @@ namespace boost { namespace spirit { namespace traits
         static void call(boost::optional<T>& val)
         {
             if (val)
-                val = none_t();   // leave optional uninitialized
+                val = none;   // leave optional uninitialized
         }
     };
 


### PR DESCRIPTION
…lves.

Fixes regression introduce by Boost.Optional in
9f8dd573866a48938d53eab8eade1de41e62a6b1