### PR TITLE
Fix link error on classic's regression test.

### DIFF
--- a/classic/test/Jamfile
+++ b/classic/test/Jamfile
@@ -175,7 +175,7 @@ local multi-threading = <library>/boost/thread//boost_thread
         ;
 
     test-suite "spirit.classic.utility.actors"
-        : [ spirit-run actor/$(actor_test_sources).cpp ]
+        : [ spirit-run actor/$(actor_test_sources).cpp : : : <library>/boost/system//boost_system ]
         ;
 
     test-suite "spirit.classic.typeof-support"


### PR DESCRIPTION
see [spirit/classic - action_tests](http://www.boost.org/development/tests/develop/developer/output/teeks99-01a-Ubuntu14-04-64-boost-bin-v2-libs-spirit-classic-test-action_tests-test-gcc-5-1-debug.html) and [spirit/classic - action_tests_debug](http://www.boost.org/development/tests/develop/developer/output/teeks99-01a-Ubuntu14-04-64-boost-bin-v2-libs-spirit-classic-test-action_tests_debug-test-gcc-5-1-debug.html).