### PR TITLE
Facilitate the requirements to custom floating-point type (comparison)

### DIFF
--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -416,7 +416,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
                 {
                     if (count == 0) // must have at least one digit
                         return false;
-                    attr = 0;
+                    attr = Attribute(0);
                     first = it;
                     return true;
                 }

--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -142,7 +142,7 @@ namespace boost { namespace spirit { namespace x3
             bool neg = p.parse_sign(first, last);
 
             // Now attempt to parse an integer
-            T n = 0;
+            T n(0);
             bool got_a_number = p.parse_n(first, last, n);
 
             // If we did not get a number it might be a NaN, Inf or a leading

--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -112,7 +112,7 @@ namespace boost { namespace spirit { namespace x3 { namespace extension
     inline bool
     is_equal_to_one(T const& value)
     {
-        return value == 1.0;
+        return value == T(1);
     }
 
     inline bool


### PR DESCRIPTION
The change allows the user to make custom floating-point type equality comparable only. operator == (double) is not required now.
