### PR TITLE
Silence MSVC warnings

### DIFF
--- a/include/boost/spirit/home/support/terminal.hpp
+++ b/include/boost/spirit/home/support/terminal.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #endif
 
+#include <boost/config.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_function.hpp>
 #include <boost/proto/proto.hpp>
@@ -261,6 +262,12 @@ namespace boost { namespace spirit
           : base_type(proto::terminal<Terminal>::type::make(t)) 
         {}
 
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+// warning C4348: 'boost::spirit::terminal<...>::result_helper': redefinition of default parameter: parameter 3, 4
+#pragma warning(disable: 4348)
+#endif
+
         template <
             bool Lazy
           , typename A0
@@ -268,6 +275,10 @@ namespace boost { namespace spirit
           , typename A2 = unused_type
         >
         struct result_helper;
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
 
         template <
             typename A0


### PR DESCRIPTION
Silence mass MSVC-14 warnings:

boost/spirit/home/support/terminal.hpp(264): warning C4348: 'boost::spirit::terminal<boost::spirit::tag::lit>::result_helper': redefinition of default parameter: parameter 3
boost/spirit/home/support/terminal.hpp(270): note: see declaration of 'boost::spirit::terminal<boost::spirit::tag::lit>::result_helper'
boost/spirit/home/support/common_terminals.hpp(142): note: see reference to class template instantiation 'boost::spirit::terminal<boost::spirit::tag::lit>' being compiled
boost/spirit/home/support/terminal.hpp(264): warning C4348: 'boost::spirit::terminal<boost::spirit::tag::lit>::result_helper': redefinition of default parameter: parameter 4
boost/spirit/home/support/terminal.hpp(270): note: see declaration of 'boost::spirit::terminal<boost::spirit::tag::lit>::result_helper'

and so on for all terminals.