### PR TITLE
Don't forward declare struct tst_pass_through

### DIFF
--- a/include/boost/spirit/home/qi/string/tst_map.hpp
+++ b/include/boost/spirit/home/qi/string/tst_map.hpp
@@ -11,14 +11,13 @@
 #pragma once
 #endif
 
+#include <boost/spirit/home/qi/string/tst.hpp>
 #include <boost/spirit/home/qi/string/detail/tst.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/pool/object_pool.hpp>
 
 namespace boost { namespace spirit { namespace qi
 {
-    struct tst_pass_through; // declared in tst.hpp
-
     template <typename Char, typename T>
     struct tst_map
     {


### PR DESCRIPTION
It is used later in find(), so complete type is needed. Include tst.hpp which defines it.

Test program:
```
#include <boost/spirit/home/qi/string/tst_map.hpp>

int main() {
	boost::spirit::qi::tst_map<char, int> map;
	int* x;
	map.find(x, x);
	return 0;
}
```

Clang output:
```
In file included from test.cc:1:
/usr/local/include/boost/spirit/home/qi/string/tst_map.hpp:74:38: error: invalid use of incomplete type 'boost::spirit::qi::tst_pass_through'
            return find(first, last, tst_pass_through());
                                     ^~~~~~~~~~~~~~~~~~
/usr/local/include/boost/spirit/home/qi/string/tst_map.hpp:20:12: note: forward declaration of 'boost::spirit::qi::tst_pass_through'
    struct tst_pass_through; // declared in tst.hpp
           ^
1 error generated.
```

gcc output:
```
In file included from test.cc:1:0:
/usr/local/include/boost/spirit/home/qi/string/tst_map.hpp: In instantiation of 'T* boost::spirit::qi::tst_map<Char, T>::find(Iterator&, Iterator) const [with Iterator = int*; Char = char; T = int]':
test.cc:6:15:   required from here
/usr/local/include/boost/spirit/home/qi/string/tst_map.hpp:74:56: error: invalid use of incomplete type 'struct boost::spirit::qi::tst_pass_through'
             return find(first, last, tst_pass_through());
                                                        ^
/usr/local/include/boost/spirit/home/qi/string/tst_map.hpp:20:12: error: forward declaration of 'struct boost::spirit::qi::tst_pass_through'
     struct tst_pass_through; // declared in tst.hpp
            ^
```