### PR TITLE
[MSVC] fix error C2995

### DIFF
--- a/example/x3/rexpr/rexpr_full/Jamfile
+++ b/example/x3/rexpr/rexpr_full/Jamfile
@@ -19,7 +19,7 @@ project spirit-x3-example-rexpr
    ;
 
 lib rexpr
-   : [ glob src/*.cpp ] /boost//system
+   : [ glob src/*.cpp ] /boost//system /boost//filesystem
    ;
 
 build-project test ;

--- a/include/boost/spirit/home/x3/core/call.hpp
+++ b/include/boost/spirit/home/x3/core/call.hpp
@@ -10,7 +10,7 @@
 #include <type_traits>
 
 #include <boost/spirit/home/x3/support/context.hpp>
-#include <boost/spirit/home/x3/support/utility/is_callable.hpp>
+#include <boost/spirit/home/x3/support/utility/sfinae.hpp>
 #include <boost/range/iterator_range.hpp>
 
 namespace boost { namespace spirit { namespace x3
@@ -46,13 +46,13 @@ namespace boost { namespace spirit { namespace x3
     namespace detail
     {
         template <typename F, typename Context>
-        auto call(F f, Context const& context, mpl::true_)
+        auto call(int, F f, Context const& context) -> decltype(f(context))
         {
             return f(context);
         }
 
         template <typename F, typename Context>
-        auto call(F f, Context const& context, mpl::false_)
+        auto call(low_priority, F f, Context const& /*context*/) -> decltype(f())
         {
             return f();
         }
@@ -69,7 +69,7 @@ namespace boost { namespace spirit { namespace x3
         auto val_context = make_context<rule_val_context_tag>(rcontext, context);
         auto where_context = make_context<where_context_tag>(rng, val_context);
         auto attr_context = make_context<attr_context_tag>(attr, where_context);
-        return detail::call(f, attr_context, is_callable<F(decltype(attr_context) const&)>());
+        return detail::call(0, f, attr_context);
     }
 }}}
 

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -154,9 +154,10 @@ namespace boost { namespace spirit { namespace x3
     /***/
 
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
+    using BOOST_PP_CAT(rule_name, _synonym) = decltype(rule_name);              \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
-        decltype(rule_name) rule_                                               \
+        BOOST_PP_CAT(rule_name, _synonym) rule_                                 \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, Attribute& attr)                                \
     {                                                                           \

--- a/include/boost/spirit/home/x3/support/utility/sfinae.hpp
+++ b/include/boost/spirit/home/x3/support/utility/sfinae.hpp
@@ -10,6 +10,11 @@
 
 namespace boost { namespace spirit { namespace x3
 {
+    struct low_priority
+    {
+        low_priority(int) { }
+    };
+
     template <typename Expr, typename T = void>
     struct disable_if_substitution_failure
     {

--- a/test/x3/actions.cpp
+++ b/test/x3/actions.cpp
@@ -4,6 +4,7 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
+#include <boost/bind.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <cstring>
@@ -22,6 +23,7 @@ auto fun1 =
 
 struct fun_action
 {
+    using result_type = void;
     template <typename Context>
     void operator()(Context const& ctx) const
     {
@@ -65,9 +67,9 @@ int main()
     }
 
     {
-        using namespace std::placeholders;
+        using namespace boost::placeholders;
         char const *s1 = "{42}", *e1 = s1 + std::strlen(s1);
-        x3::parse(s1, e1, '{' >> int_[std::bind(fun_action(), _1)] >> '}');
+        x3::parse(s1, e1, '{' >> int_[boost::bind(fun_action(), _1)] >> '}');
     }
 
     BOOST_TEST(x == (42*3));

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -239,9 +239,8 @@ main()
 
     {   // test action
         using namespace boost::spirit::x3::ascii;
-        using boost::spirit::x3::_attr;
         char ch;
-        auto f = [&](auto& ctx){ ch = _attr(ctx); };
+        auto f = [&](auto& ctx){ ch = boost::spirit::x3::_attr(ctx); };
 
         BOOST_TEST(test("x", alnum[f]));
         BOOST_TEST(ch == 'x');

--- a/test/x3/difference.cpp
+++ b/test/x3/difference.cpp
@@ -43,20 +43,18 @@ main()
     }
 
     {
-        using boost::spirit::x3::_attr;
-
         std::string s;
 
         BOOST_TEST(test(
             "/*abcdefghijk*/"
-          , "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += _attr(ctx); })] >> "*/"
+          , "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += boost::spirit::x3::_attr(ctx); })] >> "*/"
         ));
         BOOST_TEST(s == "abcdefghijk");
         s.clear();
 
         BOOST_TEST(test(
             "    /*abcdefghijk*/"
-          , "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += _attr(ctx); })] >> "*/"
+          , "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += boost::spirit::x3::_attr(ctx); })] >> "*/"
           , space
         ));
         BOOST_TEST(s == "abcdefghijk");

--- a/test/x3/extensions/confix.cpp
+++ b/test/x3/extensions/confix.cpp
@@ -37,7 +37,7 @@ int main()
             BOOST_TEST(value == 123);
 
             value = 0;
-            const auto lambda = [&value](auto& ctx ){ value = x3::_attr(ctx) + 1; };
+            const auto lambda = [&value](auto& ctx ){ value = boost::spirit::x3::_attr(ctx) + 1; };
             BOOST_TEST(test_attr("/*123*/", comment[x3::uint_][lambda], value));
             BOOST_TEST(value == 124);
         }

--- a/test/x3/int1.cpp
+++ b/test/x3/int1.cpp
@@ -142,12 +142,11 @@ main()
     //  action tests
     ///////////////////////////////////////////////////////////////////////////
     {
-        using boost::spirit::x3::_attr;
         using boost::spirit::x3::ascii::space;
         using boost::spirit::x3::int_;
         int n, m;
 
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto& ctx){ n = boost::spirit::x3::_attr(ctx); };
 
         BOOST_TEST(test("123", int_[f]));
         BOOST_TEST(n == 123);

--- a/test/x3/kleene.cpp
+++ b/test/x3/kleene.cpp
@@ -90,20 +90,16 @@ main()
     }
 
     { // actions
-        using boost::spirit::x3::_attr;
-
         std::string v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto& ctx){ v = boost::spirit::x3::_attr(ctx); };
 
         BOOST_TEST(test("bbbb", (*char_)[f]) && 4 == v.size() &&
             v[0] == 'b' && v[1] == 'b' && v[2] == 'b' &&  v[3] == 'b');
     }
 
     { // more actions
-        using boost::spirit::x3::_attr;
-
         std::vector<int> v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto& ctx){ v = boost::spirit::x3::_attr(ctx); };
 
         BOOST_TEST(test("123 456 789", (*int_)[f], space) && 3 == v.size() &&
             v[0] == 123 && v[1] == 456 && v[2] == 789);

--- a/test/x3/list.cpp
+++ b/test/x3/list.cpp
@@ -89,10 +89,8 @@ main()
     }
 
     { // actions
-        using boost::spirit::x3::_attr;
-
         std::string s;
-        auto f = [&](auto& ctx){ s = std::string(_attr(ctx).begin(), _attr(ctx).end()); };
+        auto f = [&](auto& ctx){ s = std::string(boost::spirit::x3::_attr(ctx).begin(), boost::spirit::x3::_attr(ctx).end()); };
 
         BOOST_TEST(test("a,b,c,d,e,f,g,h", (char_ % ',')[f]));
         BOOST_TEST(s == "abcdefgh");

--- a/test/x3/raw.cpp
+++ b/test/x3/raw.cpp
@@ -18,7 +18,6 @@ int main()
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::raw;
     using boost::spirit::x3::eps;
-    using boost::spirit::x3::_attr;
 
     {
         boost::iterator_range<char const*> range;
@@ -43,7 +42,7 @@ int main()
 
     {
         boost::iterator_range<char const*> range;
-        BOOST_TEST((test("x", raw[alpha][ ([&](auto& ctx){ range = _attr(ctx); }) ])));
+        BOOST_TEST((test("x", raw[alpha][ ([&](auto& ctx){ range = boost::spirit::x3::_attr(ctx); }) ])));
         BOOST_TEST(range.size() == 1 && *range.begin() == 'x');
     }
 

--- a/test/x3/uint1.cpp
+++ b/test/x3/uint1.cpp
@@ -131,12 +131,11 @@ main()
     //  action tests
     ///////////////////////////////////////////////////////////////////////////
     {
-        using boost::spirit::x3::_attr;
         using boost::spirit::x3::uint_;
         using boost::spirit::x3::ascii::space;
         int n;
 
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto& ctx){ n = boost::spirit::x3::_attr(ctx); };
 
         BOOST_TEST(test("123", uint_[f]));
         BOOST_TEST(n == 123);


### PR DESCRIPTION
MSVC-2015 can't handle decltype in function template argument list.
C2995: function template has already been defined. Moving decltype out
of the function fixes the problem.
