### PR TITLE
x3::lit should delegate std::basic_string<Char> instead of Char*

### DIFF
--- a/include/boost/spirit/home/x3/string/literal_string.hpp
+++ b/include/boost/spirit/home/x3/string/literal_string.hpp
@@ -70,10 +70,10 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename Char>
-        literal_string<Char const*, char_encoding::standard, unused_type>
+        literal_string<std::basic_string<Char>, char_encoding::standard, unused_type>
         lit(std::basic_string<Char> const& s)
         {
-            return { s.c_str() };
+            return { s };
         }
     }
 
@@ -97,10 +97,10 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
+        inline literal_string<std::basic_string<wchar_t>, char_encoding::standard_wide, unused_type>
         lit(std::basic_string<wchar_t> const& s)
         {
-            return { s.c_str() };
+            return { s };
         }
     }
 
@@ -125,10 +125,10 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename Char>
-        literal_string<Char const*, char_encoding::ascii, unused_type>
+        literal_string<std::basic_string<Char>, char_encoding::ascii, unused_type>
         lit(std::basic_string<Char> const& s)
         {
-            return { s.c_str() };
+            return { s };
         }
     }
 
@@ -153,10 +153,10 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename Char>
-        literal_string<Char const*, char_encoding::iso8859_1, unused_type>
+        literal_string<std::basic_string<Char>, char_encoding::iso8859_1, unused_type>
         lit(std::basic_string<Char> const& s)
         {
-            return { s.c_str() };
+            return { s };
         }
     }
 


### PR DESCRIPTION
The rule x3::lit("H\x02\x00"s) is currently broken, because x3::lit delegates the c_str() to literal_string.
So the string is truncated at '\x00'.

Instead we should delegate the string. Then x3::lit("H\x02\x00"s) works fine.