### PR TITLE
[MSVC] problem with BOOST_FUSION_DEFINE_STRUCT_INLINE

### DIFF
--- a/include/boost/spirit/home/x3/support/traits/value_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/value_traits.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         static T call()
         {
-            return boost::value_initialized<T>();
+            return boost::value_initialized<T>().data();
         }
     };
 }}}}


### PR DESCRIPTION
There is a bug in MSVC that it will call non-explicit constructor of a destination type instead of calling type conversion operator of source class.

BOOST_FUSION_DEFINE_STRUCT_INLINE generates a class that has non-explicit template constructor calling boost::fusion::copy. MSVC instantianes it and fails in boost::fusion::copy because boost::value_initialized<T> is not a sequence.
