### PR TITLE
dangling reference to attribute when BOOST_SPIRIT_X3_DEBUG is defined

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -325,7 +325,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
              // traits::post_transform when, for example,
              // ActualAttribute is a recursive variant).
 #if defined(BOOST_SPIRIT_X3_DEBUG)
-                typedef typename make_attribute::value_type dbg_attribute_type;
+                typedef typename make_attribute::type dbg_attribute_type;
                 context_debug<Iterator, dbg_attribute_type>
                 dbg(rule_name, first, last, dbg_attribute_type(attr_), ok_parse);
 #endif

--- a/test/x3/debug.cpp
+++ b/test/x3/debug.cpp
@@ -34,6 +34,26 @@ struct my_error_handler
     }
 };
 
+struct my_attribute
+{
+    bool alive = true;
+
+    void access() const
+    {
+        BOOST_TEST(alive);
+    }
+    ~my_attribute()
+    {
+        alive = false;
+    }
+
+    friend std::ostream & operator << (std::ostream & os, my_attribute const & attr)
+    {
+        attr.access();
+        return os << "my_attribute";
+    }
+};
+
 int
 main()
 {
@@ -42,6 +62,7 @@ main()
 
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::rule;
+    using boost::spirit::x3::symbols;
     using boost::spirit::x3::int_;
     using boost::spirit::x3::alpha;
 
@@ -109,6 +130,16 @@ main()
         BOOST_TEST(!test("(123,456]", r));
         BOOST_TEST(!test("(123;456)", r));
         BOOST_TEST(!test("[123,456]", r));
+    }
+
+    {
+        symbols<my_attribute> a{{{ "a", my_attribute{} }}};
+
+        auto b = rule<struct b, my_attribute>("b") = a;
+
+        my_attribute attr;
+
+        BOOST_TEST(test_attr("a", b, attr));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
dbg_attribute_type(attr_) creates a temporary that is bound to const reference inside of context_debug.

This will fail on assert:

    #define BOOST_SPIRIT_X3_DEBUG

    #include <iostream>
    #include <boost/spirit/home/x3.hpp>

    namespace x3 = boost::spirit::x3;

    struct p
    {
        bool alive = true;

        void access() const
        {
            assert(alive);
        }
        ~p()
        {
            alive = false;
        }
    };

    std::ostream & operator << (std::ostream & os, p o)
    {
        o.access();
        return os << "o";
    }

    x3::symbols<p> s
    {
        {
            { "s", p{} }
        },
        "s"
    };

    auto r = x3::rule<struct r, p>{ "r" } = s;

    int main()
    {
        std::string str = "s";
        auto b = str.begin();
        auto e = str.end();

        p v;

        phrase_parse(b, e, r, x3::blank, v) && b == e;
    }
