### PR TITLE
Update exposed attribute for alternative parser

### DIFF
--- a/include/boost/spirit/home/x3/directive/expect.hpp
+++ b/include/boost/spirit/home/x3/directive/expect.hpp
@@ -75,30 +75,4 @@ namespace boost { namespace spirit { namespace x3
     auto const expect = expect_gen{};
 }}}
 
-namespace boost { namespace spirit { namespace x3 { namespace detail
-{
-    // Special case handling for expect expressions.
-    template <typename Subject, typename Context, typename RContext>
-    struct parse_into_container_impl<expect_directive<Subject>, Context, RContext>
-    {
-        template <typename Iterator, typename Attribute>
-        static bool call(
-            expect_directive<Subject> const& parser
-          , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr)
-        {
-            bool r = parse_into_container(
-                parser.subject, first, last, context, rcontext, attr);
-
-            if (!r)
-            {
-                boost::throw_exception(
-                    expectation_failure<Iterator>(
-                        first, what(parser.subject)));
-            }
-            return r;
-        }
-    };
-}}}}
-
 #endif


### PR DESCRIPTION
Removed `parse_into_container_impl` specializations for `alternative` and `expect`. `alternative` now exposes the inner attribute directly when both branches are the same. All tests pass, including test case from [bug 12094](https://svn.boost.org/trac/boost/ticket/12094).

If the alternative parser has matching two element sequences, the sequence is not correctly flattened with the neighboring sequence, i.e.:
```c++
int_ >> ((int_ >> int_) | (int_ >> int_))
```
 This will be done next.