### PR TITLE
Suppress an "unused parameter" warning of rule_

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -156,7 +156,7 @@ namespace boost { namespace spirit { namespace x3
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
-        decltype(rule_name) rule_                                               \
+        decltype(rule_name) /* rule_ */                                         \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, Attribute& attr)                                \
     {                                                                           \


### PR DESCRIPTION
The `rule_` parameter is not used in `parse_rule`, which `BOOST_SPIRIT_DEFINE` expands to. GCC with `-Wunused-parameter` (often indirectly activated by `-Wall -Wextra`) issues a warning when a function parameter is not used in its function body.