### PR TITLE
Repair plain_token_range and add tests

### DIFF
--- a/include/boost/spirit/home/lex/qi/plain_token.hpp
+++ b/include/boost/spirit/home/lex/qi/plain_token.hpp
@@ -159,7 +159,7 @@ namespace boost { namespace spirit { namespace qi
                 typedef typename token_type::id_type id_type;
 
                 token_type const& t = *first;
-                if (id_type(idmin) >= t.id() && id_type(idmin) <= t.id())
+                if (id_type(idmax) >= t.id() && id_type(idmin) <= t.id())
                 {
                     spirit::traits::assign_to(t, attr);
                     ++first;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -268,6 +268,7 @@ path-constant LEX_DIR : $(BOOST_ROOT)/libs/spirit/test/lex ;
      [ run lex/token_moretypes.cpp           : : : : lex_token_moretypes ]
      [ run lex/token_omit.cpp                : : : : lex_token_omit ]
      [ run lex/token_onetype.cpp             : : : : lex_token_onetype ]
+     [ run lex/plain_token.cpp               : : : : plain_token ]
 
     ;
 

--- a/test/lex/plain_token.cpp
+++ b/test/lex/plain_token.cpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2001-2010 Hartmut Kaiser
+//  Copyright (c) 2016 Jeffrey E. Trull
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// #define BOOST_SPIRIT_LEXERTL_DEBUG
+#define BOOST_VARIANT_MINIMIZE_SIZE
+
+#define BOOST_SPIRIT_DEBUG 1
+#define BOOST_SPIRIT_LEXERTL_DEBUG 1
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/config/warning_disable.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/spirit/include/phoenix_container.hpp>
+
+#include <iostream>
+#include <string>
+
+namespace qi = boost::spirit::qi;
+namespace lex = boost::spirit::lex;
+
+enum tokenids
+{
+    // left tokens
+    IDLPAREN = lex::min_token_id, 
+    IDLANGLE,
+    IDLBRACE,
+    IDLSQUARE,
+    // right tokens
+    IDRPAREN,
+    IDRANGLE,
+    IDRBRACE,
+    IDRSQUARE,
+    IDANY
+};
+
+template <typename Lexer>
+struct delimiter_tokens : lex::lexer<Lexer>
+{
+    delimiter_tokens()
+    {
+        this->self = 
+                lex::char_('(', IDLPAREN)
+            |   lex::char_(')', IDRPAREN)
+            |   lex::char_('<', IDLANGLE)
+            |   lex::char_('>', IDRANGLE)
+            |   lex::char_('{', IDLBRACE)
+            |   lex::char_('}', IDRBRACE)
+            |   lex::char_('[', IDLSQUARE)
+            |   lex::char_(']', IDRSQUARE)
+            |   lex::string(".", IDANY)
+            ;
+    }
+};
+
+int main()
+{
+    typedef lex::lexertl::token<
+        std::string::iterator, boost::mpl::vector<std::string>
+    > token_type;
+
+    typedef lex::lexertl::lexer<token_type> lexer_type;
+    delimiter_tokens<lexer_type> delims;
+
+    // two test cases for the token range
+    std::string angled_delimiter_str("<canvas>");
+
+    using qi::token;
+    // angle brackets
+    std::string::iterator beg = angled_delimiter_str.begin();
+    BOOST_TEST(lex::tokenize_and_parse(
+                   beg, angled_delimiter_str.end(),
+                   delims,
+                   token(IDLPAREN, IDLSQUARE)
+                     >> +token(IDANY)
+                     >> token(IDRPAREN, IDRSQUARE)));
+                                       
+    std::string paren_delimiter_str("(setq foo nil)");
+    beg = paren_delimiter_str.begin();
+    BOOST_TEST(lex::tokenize_and_parse(
+                   beg, paren_delimiter_str.end(),
+                   delims,
+                   token(IDLPAREN, IDLSQUARE)
+                     >> +token(IDANY)
+                     >> token(IDRPAREN, IDRSQUARE)));
+
+    // reset and use a regular plain token
+    beg = paren_delimiter_str.begin();
+    BOOST_TEST(lex::tokenize_and_parse(
+                   beg, paren_delimiter_str.end(),
+                   delims,
+                   token(IDLPAREN) >> +token(IDANY) >> token(IDRPAREN)));
+
+    return boost::report_errors();
+}

--- a/test/lex/plain_token.cpp
+++ b/test/lex/plain_token.cpp
@@ -6,19 +6,12 @@
 // #define BOOST_SPIRIT_LEXERTL_DEBUG
 #define BOOST_VARIANT_MINIMIZE_SIZE
 
-#define BOOST_SPIRIT_DEBUG 1
-#define BOOST_SPIRIT_LEXERTL_DEBUG 1
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/config/warning_disable.hpp>
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
 
-#include <iostream>
 #include <string>
 
 namespace qi = boost::spirit::qi;


### PR DESCRIPTION
plain_token_range has a bug where it really only checks for equality against the bottom of the range supplied.  This patch restores the intended behavior.