### PR TITLE
Remove auto_ptr (deprecated in recent C++ standards).

### DIFF
--- a/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -15,7 +15,7 @@
 #include <boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp>
 #include <algorithm>
 #include <functional>
-#include <memory> // for std::auto_ptr
+#include <boost/move/unique_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #endif
 
@@ -156,7 +156,7 @@ struct grammar_definition
             if (definitions[id]!=0)
                 return *definitions[id];
 
-            std::auto_ptr<definition_t>
+            boost::movelib::unique_ptr<definition_t>
                 result(new definition_t(target_grammar->derived()));
 
 #ifdef BOOST_SPIRIT_THREADSAFE

--- a/include/boost/spirit/home/classic/symbols/impl/tst.ipp
+++ b/include/boost/spirit/home/classic/symbols/impl/tst.ipp
@@ -10,7 +10,7 @@
 #define BOOST_SPIRIT_TST_IPP
 
 ///////////////////////////////////////////////////////////////////////////////
-#include <memory> // for std::auto_ptr
+#include <boost/move/unique_ptr.hpp>
 #include <boost/spirit/home/classic/core/assert.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         tst_node*
         clone() const
         {
-            std::auto_ptr<tst_node> copy(new tst_node(value));
+            boost::movelib::unique_ptr<tst_node> copy(new tst_node(value));
 
             if (left)
                 copy->left = left->clone();
@@ -75,7 +75,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             }
             else
             {
-                std::auto_ptr<T> mid_data(new T(*middle.data));
+                boost::movelib::unique_ptr<T> mid_data(new T(*middle.data));
                 copy->middle.data = mid_data.release();
             }
 

--- a/include/boost/spirit/home/support/detail/lexer/generator.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/generator.hpp
@@ -16,6 +16,7 @@
 #include "parser/tree/node.hpp"
 #include "parser/parser.hpp"
 #include "containers/ptr_list.hpp"
+#include <boost/move/unique_ptr.hpp>
 #include "rules.hpp"
 #include "state_machine.hpp"
 
@@ -116,10 +117,10 @@ public:
 protected:
     typedef detail::basic_charset<CharT> charset;
     typedef detail::ptr_list<charset> charset_list;
-    typedef std::auto_ptr<charset> charset_ptr;
+    typedef boost::movelib::unique_ptr<charset> charset_ptr;
     typedef detail::equivset equivset;
     typedef detail::ptr_list<equivset> equivset_list;
-    typedef std::auto_ptr<equivset> equivset_ptr;
+    typedef boost::movelib::unique_ptr<equivset> equivset_ptr;
     typedef typename charset::index_set index_set;
     typedef std::vector<index_set> index_set_vector;
     typedef detail::basic_parser<CharT> parser;
@@ -377,8 +378,8 @@ protected:
         if (followpos_->empty ()) return npos;
 
         std::size_t index_ = 0;
-        std::auto_ptr<node_set> set_ptr_ (new node_set);
-        std::auto_ptr<node_vector> vector_ptr_ (new node_vector);
+        boost::movelib::unique_ptr<node_set> set_ptr_ (new node_set);
+        boost::movelib::unique_ptr<node_vector> vector_ptr_ (new node_vector);
 
         for (typename detail::node::node_vector::const_iterator iter_ =
             followpos_->begin (), end_ = followpos_->end ();


### PR DESCRIPTION
Hi,

I am having issues when using json_spirit and boost 1.61 with GCC 6 and -std=gnu++14 -Wall -Werror -Wextra.

This removes all the last auto_ptr references in boost spirit. Inspired by https://svn.boost.org/trac/boost/ticket/11672.

I have tested with json_spirit and boost 1.61, then ported to the branch "develop" as is.

Cheers,
Romain