### PR TITLE
Spirit QI grammar doesn't work

### DIFF
--- a/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -15,7 +15,7 @@
 #include <boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp>
 #include <algorithm>
 #include <functional>
-#include <memory> // for std::auto_ptr
+#include <boost/move/unique_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #endif
 
@@ -156,7 +156,7 @@ struct grammar_definition
             if (definitions[id]!=0)
                 return *definitions[id];
 
-            std::auto_ptr<definition_t>
+            boost::movelib::unique_ptr<definition_t>
                 result(new definition_t(target_grammar->derived()));
 
 #ifdef BOOST_SPIRIT_THREADSAFE

--- a/include/boost/spirit/home/classic/symbols/impl/tst.ipp
+++ b/include/boost/spirit/home/classic/symbols/impl/tst.ipp
@@ -10,7 +10,7 @@
 #define BOOST_SPIRIT_TST_IPP
 
 ///////////////////////////////////////////////////////////////////////////////
-#include <memory> // for std::auto_ptr
+#include <boost/move/unique_ptr.hpp>
 #include <boost/spirit/home/classic/core/assert.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         tst_node*
         clone() const
         {
-            std::auto_ptr<tst_node> copy(new tst_node(value));
+            boost::movelib::unique_ptr<tst_node> copy(new tst_node(value));
 
             if (left)
                 copy->left = left->clone();
@@ -75,7 +75,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             }
             else
             {
-                std::auto_ptr<T> mid_data(new T(*middle.data));
+                boost::movelib::unique_ptr<T> mid_data(new T(*middle.data));
                 copy->middle.data = mid_data.release();
             }
 

--- a/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace spirit { namespace traits
             typedef unsignedtype type;                                        \
             static type call(signedtype n)                                    \
             {                                                                 \
-                return (n >= 0) ? n : (unsignedtype)(-n);                     \
+                return static_cast<unsignedtype>((n >= 0) ? n : -n);          \
             }                                                                 \
         }                                                                     \
     /**/
@@ -285,7 +285,7 @@ namespace boost { namespace spirit { namespace traits
     {
         static bool call(T n)
         {
-            if (!std::numeric_limits<T>::has_infinity) 
+            if (!std::numeric_limits<T>::has_infinity)
                 return false;
             return (n == std::numeric_limits<T>::infinity()) ? true : false;
         }
@@ -771,4 +771,3 @@ namespace boost { namespace spirit { namespace karma
 }}}
 
 #endif
-

--- a/include/boost/spirit/home/support/detail/lexer/generator.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/generator.hpp
@@ -16,6 +16,7 @@
 #include "parser/tree/node.hpp"
 #include "parser/parser.hpp"
 #include "containers/ptr_list.hpp"
+#include <boost/move/unique_ptr.hpp>
 #include "rules.hpp"
 #include "state_machine.hpp"
 
@@ -116,10 +117,10 @@ public:
 protected:
     typedef detail::basic_charset<CharT> charset;
     typedef detail::ptr_list<charset> charset_list;
-    typedef std::auto_ptr<charset> charset_ptr;
+    typedef boost::movelib::unique_ptr<charset> charset_ptr;
     typedef detail::equivset equivset;
     typedef detail::ptr_list<equivset> equivset_list;
-    typedef std::auto_ptr<equivset> equivset_ptr;
+    typedef boost::movelib::unique_ptr<equivset> equivset_ptr;
     typedef typename charset::index_set index_set;
     typedef std::vector<index_set> index_set_vector;
     typedef detail::basic_parser<CharT> parser;
@@ -377,8 +378,8 @@ protected:
         if (followpos_->empty ()) return npos;
 
         std::size_t index_ = 0;
-        std::auto_ptr<node_set> set_ptr_ (new node_set);
-        std::auto_ptr<node_vector> vector_ptr_ (new node_vector);
+        boost::movelib::unique_ptr<node_set> set_ptr_ (new node_set);
+        boost::movelib::unique_ptr<node_vector> vector_ptr_ (new node_vector);
 
         for (typename detail::node::node_vector::const_iterator iter_ =
             followpos_->begin (), end_ = followpos_->end ();

--- a/include/boost/spirit/home/support/iterators/multi_pass.hpp
+++ b/include/boost/spirit/home/support/iterators/multi_pass.hpp
@@ -152,15 +152,15 @@ namespace boost { namespace spirit
         {
             return !(*this == y);
         }
-        bool operator>(multi_pass const& y)
+        bool operator>(multi_pass const& y) const
         {
             return y < *this;
         }
-        bool operator>=(multi_pass const& y)
+        bool operator>=(multi_pass const& y) const
         {
             return !(*this < y);
         }
-        bool operator<=(multi_pass const& y)
+        bool operator<=(multi_pass const& y) const
         {
             return !(y < *this);
         }

--- a/include/boost/spirit/home/support/iterators/multi_pass.hpp
+++ b/include/boost/spirit/home/support/iterators/multi_pass.hpp
@@ -148,7 +148,7 @@ namespace boost { namespace spirit
             return policies_base_type::less_than(*this, y);
         }
 
-        bool operator!=(multi_pass const& y)
+        bool operator!=(multi_pass const& y) const
         {
             return !(*this == y);
         }

--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -40,8 +40,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator& /* first */, Iterator const& /* last */
+          , Context const& /* context */, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_, attr_);
@@ -76,8 +76,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator& /* first */, Iterator const& /* last */
+          , Context const& /* context */, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_ + 0, value_ + N, attr_);

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -45,7 +45,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context const& context, unused_type, Attribute& attr) const
+          , Context const& context, unused_type, Attribute& /* attr */) const
         {
             x3::skip_over(first, last, context);
             return f(x3::get<rule_context_tag>(context));

--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -115,7 +115,7 @@ namespace boost { namespace spirit { namespace x3
     struct get_info<char_set<Encoding, Attribute>>
     {
         typedef std::string result_type;
-        std::string operator()(char_set<Encoding, Attribute> const& p) const
+        std::string operator()(char_set<Encoding, Attribute> const& /* p */) const
         {
             return "char-set";
         }

--- a/include/boost/spirit/home/x3/core/call.hpp
+++ b/include/boost/spirit/home/x3/core/call.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename F, typename Context>
-        auto call(F f, Context const& context, mpl::false_)
+        auto call(F f, Context const& /* context */, mpl::false_)
         {
             return f();
         }

--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -202,7 +202,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool call(
             Parser const& parser
           , Iterator& first, Iterator const& last, Context const& context
-          , RContext& rcontext, Attribute& attr, mpl::false_)
+          , RContext& rcontext, Attribute& /* attr */, mpl::false_)
         {
             return parser.parse(first, last, context, rcontext, unused);
         }

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -139,7 +139,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
     template <typename ID, typename RHS, typename Context>
     Context const&
-    make_rule_context(RHS const& /* rhs */, Context const& /* context */
+    make_rule_context(RHS const& /* rhs */, Context const& context
       , mpl::false_ /* is_default_parse_rule */)
     {
         return context;

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -7,6 +7,7 @@
 #if !defined(BOOST_SPIRIT_X3_DETAIL_RULE_JAN_08_2012_0326PM)
 #define BOOST_SPIRIT_X3_DETAIL_RULE_JAN_08_2012_0326PM
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/spirit/home/x3/auxiliary/guard.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/core/skip_over.hpp>
@@ -138,7 +139,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
     template <typename ID, typename RHS, typename Context>
     Context const&
-    make_rule_context(RHS const& rhs, Context const& context
+    make_rule_context(RHS const& /* rhs */, Context const& /* context */
       , mpl::false_ /* is_default_parse_rule */)
     {
         return context;
@@ -156,8 +157,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& first, Iterator const& last
-          , Context const& context, ActualAttribute& attr
+            Iterator& /* first */, Iterator const& /* last */
+          , Context const& /* context */, ActualAttribute& /* attr */
           , mpl::false_ /* No on_success handler */ )
         {
             return true;
@@ -285,7 +286,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool parse_rhs(
             RHS const& rhs
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, ActualAttribute& attr
+          , Context const& context, RContext& rcontext, ActualAttribute& /* attr */
           , mpl::true_)
         {
             return parse_rhs_main(rhs, first, last, context, rcontext, unused);
@@ -300,6 +301,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
           , Context const& context, ActualAttribute& attr
           , ExplicitAttrPropagation)
         {
+            boost::ignore_unused(rule_name);
+
             typedef traits::make_attribute<Attribute, ActualAttribute> make_attribute;
 
             // do down-stream transformation, provides attribute for

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -156,7 +156,7 @@ namespace boost { namespace spirit { namespace x3
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
-        decltype(rule_name) rule_                                               \
+        decltype(rule_name) /* rule_ */                                         \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, Attribute& attr)                                \
     {                                                                           \

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace spirit { namespace x3
       , typename Context, typename ActualAttribute>
     inline detail::default_parse_rule_result
     parse_rule(
-        rule<ID, Attribute> rule_
+        rule<ID, Attribute> /* rule_ */
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr)
     {

--- a/include/boost/spirit/home/x3/operator/detail/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/alternative.hpp
@@ -226,7 +226,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     struct move_if_not_alternative
     {
         template<typename T1, typename T2>
-        static void call(T1& attr_, T2& attr) {}
+        static void call(T1& /* attr_ */, T2& /* attr */) {}
     };
 
     template <>

--- a/include/boost/spirit/home/x3/support/context.hpp
+++ b/include/boost/spirit/home/x3/support/context.hpp
@@ -74,12 +74,12 @@ namespace boost { namespace spirit { namespace x3
     {
         return { val };
     }
-    
+
     namespace detail
     {
         template <typename ID, typename T, typename Next, typename FoundVal>
         inline Next const&
-        make_unique_context(T& val, Next const& next, FoundVal&)
+        make_unique_context(T& /* val */, Next const& next, FoundVal&)
         {
             return next;
         }
@@ -91,7 +91,7 @@ namespace boost { namespace spirit { namespace x3
             return { val, next };
         }
     }
-    
+
     template <typename ID, typename T, typename Next>
     inline auto
     make_unique_context(T& val, Next const& next)

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -159,7 +159,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
     private:
         template <typename Iterator>
-        static void reserve(Container& c, Iterator first, Iterator last, mpl::false_)
+        static void reserve(Container& /* c */, Iterator /* first */, Iterator /* last */, mpl::false_)
         {
             // Not all containers have "reserve"
         }
@@ -199,7 +199,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     }
 
     template <typename Iterator>
-    inline bool append(unused_type, Iterator first, Iterator last)
+    inline bool append(unused_type, Iterator /* first */, Iterator /* last */)
     {
         return true;
     }

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -303,6 +303,7 @@ path-constant LEX_DIR : $(BOOST_ROOT)/libs/spirit/test/lex ;
 
      [ run support/utree.cpp                  : : : : support_utree ]
      [ run support/utree_debug.cpp            : : : : support_utree_debug ]
+     [ run support/istream_iterator_basic.cpp : : : : istream_iterator_basic ]
 
     ;
 

--- a/test/support/istream_iterator_basic.cpp
+++ b/test/support/istream_iterator_basic.cpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2016 Jeffrey E. Trull
+// 
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying 
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// A series of simple tests for the istream_iterator
+
+#include <boost/detail/lightweight_test.hpp>
+
+#include <sstream>
+
+#include <boost/spirit/include/support_istream_iterator.hpp>
+
+int main()
+{
+  std::stringstream ss("HELO\n");
+  boost::spirit::istream_iterator it(ss);
+
+  // Check iterator concepts
+  boost::spirit::istream_iterator it2(it);  // CopyConstructible
+  BOOST_TEST( it2 == it );                  // EqualityComparable
+  BOOST_TEST( *it2 == 'H' );
+
+  boost::spirit::istream_iterator end;      // DefaultConstructible
+  BOOST_TEST( it != end );
+  it = end;                                 // CopyAssignable
+  BOOST_TEST( it == end );
+
+  std::swap(it, it2);                       // Swappable
+  BOOST_TEST( it2 == end );
+  BOOST_TEST( *it == 'H' );
+  
+  ++it;
+  BOOST_TEST( *it == 'E' );
+  BOOST_TEST( *it++ == 'E' );
+
+  // "Incrementing a copy of a does not change the value read from a"
+  boost::spirit::istream_iterator it3 = it;
+  BOOST_TEST( *it == 'L' );
+  BOOST_TEST( *it3 == 'L' );
+  ++it;
+  BOOST_TEST( *it == 'O' );
+  BOOST_TEST( *it3 == 'L' );
+
+  it3 = it;
+  // "a == b implies ++a == ++b"
+  BOOST_TEST( ++it3 == ++it );
+
+  // Usage of const iterators
+  boost::spirit::istream_iterator const itc = it;
+  BOOST_TEST( itc == it );
+  BOOST_TEST( *itc == *it );
+  ++it;
+  BOOST_TEST( itc != it );
+
+  // Skipping le/gt comparisons as unclear what they are for in forward iterators...
+
+  return boost::report_errors();
+}
+// Destructible


### PR DESCRIPTION
I've followed the Spirit QI tutorial based on the bellow grammar (http://www.boost.org/doc/libs/1_60_0/libs/spirit/doc/html/spirit/introduction.html):

group       = '(' >> expression >> ')';
factor      = integer | group;
term        = factor >> *(('*' >> factor) | ('/' >> factor));
expression  = term >> *(('+' >> term) | ('-' >> term));

The parser returns true to the input: "1 blabla 2".