### PR TITLE
Don't try to declare std::complex for Android builds

### DIFF
--- a/include/boost/spirit/home/classic/phoenix/special_ops.hpp
+++ b/include/boost/spirit/home/classic/phoenix/special_ops.hpp
@@ -30,6 +30,7 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+#ifndef ANDROID
 //#if !defined(PHOENIX_NO_STD_NAMESPACE)
 namespace PHOENIX_STD
 {
@@ -40,6 +41,7 @@ namespace PHOENIX_STD
 //#if !defined(PHOENIX_NO_STD_NAMESPACE)
 }
 //#endif
+#endif // ANDROID
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phoenix

--- a/include/boost/spirit/home/classic/phoenix/special_ops.hpp
+++ b/include/boost/spirit/home/classic/phoenix/special_ops.hpp
@@ -30,20 +30,6 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ANDROID
-//#if !defined(PHOENIX_NO_STD_NAMESPACE)
-namespace PHOENIX_STD
-{
-//#endif
-
-    template<typename T> class complex;
-
-//#if !defined(PHOENIX_NO_STD_NAMESPACE)
-}
-//#endif
-#endif // ANDROID
-
-///////////////////////////////////////////////////////////////////////////////
 namespace phoenix
 {
 


### PR DESCRIPTION
This breaks for clang as the NDK namespaces are oddly set up.

The old version works for gcc builds on Android, but clang is now the default compiler with gcc deprecated.

Isn't the declaration undefined behaviour anyway?
