### PR TITLE
Fixes for PR #196 expect directive

### DIFF
--- a/example/qi/expect.cpp
+++ b/example/qi/expect.cpp
@@ -9,7 +9,6 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <map>
 
 #include <boost/spirit/home/qi.hpp>
-#include <boost/spirit/home/qi/directive/expect.hpp>
 #include <boost/spirit/home/qi/nonterminal/grammar.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 

--- a/include/boost/spirit/home/qi/detail/expectation_failure.hpp
+++ b/include/boost/spirit/home/qi/detail/expectation_failure.hpp
@@ -11,6 +11,8 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 #endif
 
+#include <stdexcept>
+
 namespace boost { namespace spirit { namespace qi {
     template <typename Iterator>
     struct expectation_failure : std::runtime_error

--- a/include/boost/spirit/home/qi/detail/expectation_failure.hpp
+++ b/include/boost/spirit/home/qi/detail/expectation_failure.hpp
@@ -11,6 +11,8 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 #endif
 
+#include <boost/spirit/home/support/info.hpp>
+
 #include <stdexcept>
 
 namespace boost { namespace spirit { namespace qi {

--- a/include/boost/spirit/home/qi/detail/expectation_failure.hpp
+++ b/include/boost/spirit/home/qi/detail/expectation_failure.hpp
@@ -1,0 +1,31 @@
+/*=============================================================================
+Copyright (c) 2001-2011 Joel de Guzman
+Copyright (c) 2016      Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#if !defined(SPIRIT_EXPECTATION_FAILURE_JULY_19_2016)
+#define SPIRIT_EXPECTATION_FAILURE_JULY_19_2016
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+namespace boost { namespace spirit { namespace qi {
+    template <typename Iterator>
+    struct expectation_failure : std::runtime_error
+    {
+        expectation_failure(Iterator first_, Iterator last_, info const& what)
+            : std::runtime_error("boost::spirit::qi::expectation_failure")
+            , first(first_), last(last_), what_(what)
+        {}
+        ~expectation_failure() throw() {}
+
+        Iterator first;
+        Iterator last;
+        info what_;
+    };
+}}}
+
+#endif

--- a/include/boost/spirit/home/qi/detail/expectation_failure.hpp
+++ b/include/boost/spirit/home/qi/detail/expectation_failure.hpp
@@ -1,6 +1,5 @@
 /*=============================================================================
 Copyright (c) 2001-2011 Joel de Guzman
-Copyright (c) 2016      Frank Hein, maxence business consulting gmbh
 
 Distributed under the Boost Software License, Version 1.0. (See accompanying
 file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/spirit/home/qi/directive/expect.hpp
+++ b/include/boost/spirit/home/qi/directive/expect.hpp
@@ -20,8 +20,6 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/support/info.hpp>
 
-#include <stdexcept>
-
 namespace boost { namespace spirit {
     ///////////////////////////////////////////////////////////////////////////
     // Enablers

--- a/include/boost/spirit/home/qi/directive/expect.hpp
+++ b/include/boost/spirit/home/qi/directive/expect.hpp
@@ -14,6 +14,7 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/spirit/home/qi/meta_compiler.hpp>
 #include <boost/spirit/home/support/has_semantic_action.hpp>
 #include <boost/spirit/home/qi/detail/attributes.hpp>
+#include <boost/spirit/home/qi/detail/expectation_failure.hpp>
 #include <boost/spirit/home/support/common_terminals.hpp>
 #include <boost/spirit/home/support/handles_container.hpp>
 #include <boost/spirit/home/support/unused.hpp>

--- a/include/boost/spirit/home/qi/nonterminal/debug_handler.hpp
+++ b/include/boost/spirit/home/qi/nonterminal/debug_handler.hpp
@@ -14,7 +14,7 @@
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/qi/nonterminal/rule.hpp>
 #include <boost/spirit/home/qi/nonterminal/debug_handler_state.hpp>
-#include <boost/spirit/home/qi/operator/expect.hpp>
+#include <boost/spirit/home/qi/detail/expectation_failure.hpp>
 #include <boost/function.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/vector.hpp>

--- a/include/boost/spirit/home/qi/operator/expect.hpp
+++ b/include/boost/spirit/home/qi/operator/expect.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/spirit/home/qi/operator/sequence_base.hpp>
 #include <boost/spirit/home/qi/detail/expect_function.hpp>
+#include <boost/spirit/home/qi/detail/expectation_failure.hpp>
 #include <boost/spirit/home/qi/meta_compiler.hpp>
 #include <boost/spirit/home/support/has_semantic_action.hpp>
 #include <boost/spirit/home/support/handles_container.hpp>
@@ -36,20 +37,6 @@ namespace boost { namespace spirit
 
 namespace boost { namespace spirit { namespace qi
 {
-    template <typename Iterator>
-    struct expectation_failure : std::runtime_error
-    {
-        expectation_failure(Iterator first_, Iterator last_, info const& what)
-          : std::runtime_error("boost::spirit::qi::expectation_failure")
-          , first(first_), last(last_), what_(what)
-        {}
-        ~expectation_failure() throw() {}
-
-        Iterator first;
-        Iterator last;
-        info what_;
-    };
-
     template <typename Elements>
     struct expect_operator : sequence_base<expect_operator<Elements>, Elements>
     {

--- a/include/boost/spirit/home/qi/operator/expect.hpp
+++ b/include/boost/spirit/home/qi/operator/expect.hpp
@@ -19,7 +19,6 @@
 #include <boost/spirit/home/support/has_semantic_action.hpp>
 #include <boost/spirit/home/support/handles_container.hpp>
 #include <boost/spirit/home/support/info.hpp>
-#include <stdexcept>
 
 namespace boost { namespace spirit
 {

--- a/include/boost/spirit/include/version.hpp
+++ b/include/boost/spirit/include/version.hpp
@@ -14,7 +14,7 @@
 //  This is the version of the current Spirit distribution
 //
 ///////////////////////////////////////////////////////////////////////////////
-#define SPIRIT_VERSION 0x2053
+#define SPIRIT_VERSION 0x2054
 #define SPIRIT_PIZZA_VERSION SUPER_HOT_SPANISH_SARDINES  // :-O
 
 #endif

--- a/test/qi/expectd.cpp
+++ b/test/qi/expectd.cpp
@@ -20,7 +20,6 @@
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_statement.hpp>
-#include <mxc/qitoo/qitoo.hpp>
 
 #include <string>
 #include <iostream>


### PR DESCRIPTION
his PR contains fixes for both issues reported by Lastique and
MarcelRaad. It makes PR #197 obsolete.

Removed obsolete dependency  of test/qi/expectd.cpp on
mxc/qitoo/qitoo.hpp. Was reintroduced by mistake.

Created qi/detail/expectation_failure.hpp. It defines the
expectation_failure template as a common dependency of expect directive
and expect operator. Removed expectation_failure from
operator/expect.hpp.

Changed dependency of debug_handler.hpp to from operator/expect.hpp to expectation_failure.hpp.

Changed version.hpp to 2.54. I did not notice that addl file in the
first place.