### PR TITLE
Undo header inclusion from PR #197 (obsolete because of PR #198 being merged)

### DIFF
--- a/include/boost/spirit/home/qi/directive/expect.hpp
+++ b/include/boost/spirit/home/qi/directive/expect.hpp
@@ -19,7 +19,6 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/spirit/home/support/handles_container.hpp>
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/support/info.hpp>
-#include <boost/spirit/home/qi/operator/expect.hpp>
 
 namespace boost { namespace spirit {
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
After moving expectation_failure to detail/expectation_failure.hpp as of PR #198 there is no longer a dependency on operator/expect.hpp.