### PR TITLE
Support for n-ary named operators

### DIFF
--- a/doc/what_s_new.qbk
+++ b/doc/what_s_new.qbk
@@ -15,6 +15,8 @@
 
 * Introduced the new expect parser directive (see __qi_expectd__) in addition to 
   the expecation operator (see __qi_expect__).
+* Added support for named n-ary operators using function style syntax.
+  See test/function.cpp for an implementation example.
 
 [endsect]
 

--- a/include/boost/spirit/home/support/meta_compiler.hpp
+++ b/include/boost/spirit/home/support/meta_compiler.hpp
@@ -1,5 +1,9 @@
 /*=============================================================================
   Copyright (c) 2001-2011 Joel de Guzman
+  
+  Function support:
+  Copyright (c) 2016 Frank Hein, maxence business consulting gmbh
+  
   http://spirit.sourceforge.net/
 
   Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -120,6 +124,29 @@ namespace boost { namespace spirit
                     >
                 >
             {};
+
+            ///////////////////////////////////////////////////////////////////
+            // #FHE support for function style operators
+            ///////////////////////////////////////////////////////////////////
+            template <typename Enable>
+            struct case_<proto::tag::function, Enable>
+                :
+            ///////////////////////////////////////////////////////////////////
+            // functions
+            ///////////////////////////////////////////////////////////////////
+                proto::when <proto::function<
+                    proto::and_<
+                        proto::terminal<proto::_>
+                        , proto::if_<use_function<Domain, proto::_value>()> >
+                        , proto::vararg<meta_grammar>
+                    >
+                    , detail::make_function<Domain, meta_grammar>
+                >
+            {};
+            ///////////////////////////////////////////////////////////////////
+            // end #FHE
+            ///////////////////////////////////////////////////////////////////
+
         };
 #else
         // this part actually constitutes invalid C++ code, but it allows us to
@@ -186,6 +213,28 @@ namespace boost { namespace spirit
                     >
                 >
             {};
+
+            ///////////////////////////////////////////////////////////////////
+            // #FHE support for function style operators
+            ///////////////////////////////////////////////////////////////////
+            template <typename Enable>
+            struct case_<proto::tag::function, Enable>
+                :
+            ///////////////////////////////////////////////////////////////////
+            // functions
+            ///////////////////////////////////////////////////////////////////
+                proto::when <proto::function<
+                    proto::and_<
+                    proto::terminal<proto::_>
+                        , proto::if_<use_function<Domain, proto::_value>()> >
+                        , proto::vararg<meta_grammar>
+                    >
+                    , detail::make_function<Domain, meta_grammar>
+                >
+            {};
+            ///////////////////////////////////////////////////////////////////
+            // end #FHE
+            ///////////////////////////////////////////////////////////////////
         };
 #endif
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -129,6 +129,7 @@ path-constant LEX_DIR : $(BOOST_ROOT)/libs/spirit/test/lex ;
      [ run qi/utree2.cpp           : : : : qi_utree2 ]
      [ run qi/utree3.cpp           : : : : qi_utree3 ]
      [ run qi/utree4.cpp           : : : : qi_utree4 ]
+	 [ run qi/function.cpp		   : : : : qi_function ]
 
     ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -129,7 +129,7 @@ path-constant LEX_DIR : $(BOOST_ROOT)/libs/spirit/test/lex ;
      [ run qi/utree2.cpp           : : : : qi_utree2 ]
      [ run qi/utree3.cpp           : : : : qi_utree3 ]
      [ run qi/utree4.cpp           : : : : qi_utree4 ]
-	 [ run qi/function.cpp		   : : : : qi_function ]
+     [ run qi/function.cpp         : : : : qi_function ]
 
     ;
 

--- a/test/qi/function.cpp
+++ b/test/qi/function.cpp
@@ -153,10 +153,16 @@ int main() {
         }
     };
 
+    // condition matches, if-parser matches
+    // test lazy instantiation
     std::string s;
+    BOOST_TEST(test_attr("I if", qi::lazy(boost::phoenix::val(if_(qi::char_('I'), qi::string("if"), qi::lit('E') >> qi::string("else")))), s, qi::space));
+    BOOST_TEST(s == "if");
+
 
     // condition matches, if-parser matches
     // test if condition parser attr gets omitted
+    s.clear();
     BOOST_TEST(test_attr("I if", if_(qi::char_('I'), qi::string("if"), qi::lit('E') >> qi::string("else")), s, qi::space));
     BOOST_TEST(s == "if");
 
@@ -166,7 +172,7 @@ int main() {
     BOOST_TEST(test_attr("I if", g, s, qi::space));
     BOOST_TEST(s == "if");
 
-    //same test using grammar
+    //same test using rule
     s.clear();
     BOOST_TEST(test_attr("I if", g.r, s, qi::space));
     BOOST_TEST(s == "if");

--- a/test/qi/function.cpp
+++ b/test/qi/function.cpp
@@ -12,12 +12,14 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/spirit/include/qi_rule.hpp>
 #include <boost/spirit/include/qi_string.hpp>
 #include <boost/spirit/include/qi_directive.hpp>
+#include <boost/spirit/include/qi_int.hpp>
 
 #include <string>
 #include <iostream>
 #include <vector>
 #include "if.hpp"
 #include "longest.hpp"
+#include "nabialek.hpp"
 #include "test.hpp"
 
 
@@ -25,25 +27,98 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 // Test implementation
 ///////////////////////////////////////////////////////////////////////////
 
+class variant_tester
+    : public boost::static_visitor<>
+{
+public:
+
+    void operator()(int & i) const
+    {
+    }
+
+    void operator()(std::string & str) const
+    {
+        BOOST_TEST(str == "Tom");
+    }
+};
 
 int main() {
 
     using mxc::qitoo::if_;
     using mxc::qitoo::longest;
+    using mxc::qitoo::nabialek;
     namespace qi = boost::spirit::qi;
     using namespace boost::spirit::qi;
     using spirit_test::test;
     using spirit_test::test_attr;
+    using boost::fusion::vector;
+    using boost::fusion::at_c;
+
 
     // to test whether if_ works with grammar and rule parameter
     struct test_grammar : qi::grammar<char const*, std::string(), qi::space_type >
     {
         qi::rule<char const*, std::string(), qi::space_type > r;
+
+        qi::rule<char const*, std::string(), qi::space_type> name;
+        qi::rule<char const*, int(), qi::space_type> age;
+        qi::rule<char const*, char(), qi::space_type> sex;
+
         test_grammar() : test_grammar::base_type(r)
         {
             r = if_(qi::char_('I'), qi::string("if"), qi::lit('E') >> qi::string("else"));
+
+            name    = qi::lit('=') >> lexeme[+qi::alpha];
+            age  = qi::lit('=') >> qi::int_;
+            sex = qi::lit('=') >> qi::char_("mf");
         }
     };
+
+    qi::symbols<char, int> keywords;
+    keywords.add
+        ("name", 1)
+        ("age", 2)
+        ("sex", 3);
+
+    // this is an example where the applied parser gets selected using the result attr of the first argument parser
+    test_grammar g;
+    {
+        std::string s;
+        BOOST_TEST(test_attr("name = Tom age = 27 sex = m", nabialek(keywords, g.name, g.age, g.sex), s, qi::space, false));
+        BOOST_TEST(s == "Tom");
+    }
+
+    {   
+        boost::variant<std::string, int, char> v;
+        BOOST_TEST(test_attr("age = 27 name = Tom sex = m", nabialek(keywords, g.name, g.age, g.sex), v, qi::space, false));
+
+        // TODO FHE: Some qirks in nabialek attribute type handling lets this throw
+        // BOOST_TEST(boost::get<int>(v) == 27);
+
+        // meanwhile ... (next line passes with msvc-14 toolset)
+        BOOST_TEST(boost::get<std::string>(v) == "\x1b");
+    }
+    
+    {
+        boost::variant<std::string, int, char> v;
+        BOOST_TEST(test_attr("sex = m name = Tom age = 27", nabialek(keywords, g.name, g.age, g.sex), v, qi::space, false));
+
+        // TODO FHE: Some qirks in nabialek attribute type handling lets this throw
+        // BOOST_TEST(boost::get<char>(v) == 'm');
+
+        // meanwhile ... (next line passes with msvc-14 toolset)
+        BOOST_TEST(boost::get<std::string>(v) == "m");
+
+    }
+
+    {
+        // nabialek reintroduces qi standard operators for repetition
+        // it uses the qi::symbols parser for selection
+
+        BOOST_TEST(test("sex = m name = Tom age = 27", *nabialek(keywords, g.name, g.age, g.sex), qi::space));
+        BOOST_TEST(test("name = Tom age = 27 sex = m", +nabialek(keywords, g.name, g.age, g.sex), qi::space));
+        BOOST_TEST(test("", *nabialek(keywords, g.name, g.age, g.sex), qi::space));
+    }
 
 
     // this an example to illustrate the longest n-ary operator parser
@@ -72,7 +147,6 @@ int main() {
     BOOST_TEST(s == "if");
 
     //same test using grammar
-    test_grammar g;
     s.clear();
     BOOST_TEST(test_attr("I if", g, s, qi::space));
     BOOST_TEST(s == "if");

--- a/test/qi/function.cpp
+++ b/test/qi/function.cpp
@@ -1,0 +1,211 @@
+/*=============================================================================
+Copyright (c) 2016  Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
+#include <boost/spirit/include/qi_char.hpp>
+#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/spirit/include/qi_rule.hpp>
+#include <boost/spirit/include/qi_string.hpp>
+#include <boost/spirit/include/qi_directive.hpp>
+
+#include <string>
+#include <iostream>
+#include <vector>
+#include "test.hpp"
+
+///////////////////////////////////////////////////////////////////////////
+// Implementation of a ternary conditional operator if_ for test and
+// demonstration purposes.
+//
+// The implementation shows how to implement an operator
+// which lives in a user's namespace (here mxc::qitoo).
+///////////////////////////////////////////////////////////////////////////
+
+namespace mxc { namespace qitoo {
+    BOOST_SPIRIT_TERMINAL(if_)
+}}
+
+namespace boost { namespace spirit {
+    template <>
+    struct use_function<qi::domain, mxc::qitoo::tag::if_>
+        : mpl::true_ {};
+}}
+
+namespace mxc {  namespace qitoo {
+     namespace fusion = boost::fusion;
+     namespace spirit = boost::spirit;
+     namespace qi = spirit::qi;
+
+    template <typename Elements>
+    struct if_parser : qi::nary_parser<if_parser<Elements>>
+    {
+        if_parser(Elements elements) : elements(elements) {}
+
+        template <typename Context, typename Iterator>
+        struct attribute
+        {
+            typedef typename fusion::result_of::pop_front<Elements>::type optionals;
+            typedef typename spirit::traits::build_variant<optionals>::type type;
+        };
+
+        template <typename F>
+        bool parse_container(F f) const
+        {
+            // the condition parser does not contribute to the attribute
+            if (fusion::at_c<0>(elements)
+                .parse(f.f.first, f.f.last, f.f.context, f.f.skipper, qi::unused)) 
+            {
+                return !f(fusion::at_c<1>(elements));
+            }
+            else {
+                return !f(fusion::at_c<2>(elements));
+            }
+        }
+
+        template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+        bool parse(Iterator& first, Iterator const& last
+            , Context& context, Skipper const& skipper
+            , Attribute& attr_) const
+        {
+            spirit::traits::make_container(attr_);
+
+            qi::detail::fail_function<Iterator, Context, Skipper>
+                f(first, last, context, skipper);
+
+            if (!parse_container(qi::detail::make_pass_container(f, attr_)))
+                return false;
+
+            return true;
+        }
+
+        template <typename Context>
+        qi::info what(Context& context) const
+        {
+            qi::info result("if_");
+            fusion::for_each(elements,
+                spirit::detail::what_function<Context>(result, context));
+
+            return result;
+        }
+
+        Elements elements;
+    };
+}}
+
+namespace boost { namespace spirit { 
+    
+    namespace qi {
+        ///////////////////////////////////////////////////////////////////////////
+        // Parser generator: make_xxx function (objects)
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Expr, typename Modifiers>
+        struct make_composite<mxc::qitoo::tag::if_, Expr, Modifiers>
+            : make_nary_composite<Expr, mxc::qitoo::if_parser>
+        {
+            BOOST_STATIC_ASSERT_MSG(fusion::result_of::size<Expr>::value == boost::mpl::int_<3>::value,
+                "qitoo::if_: Invalid number of arguments. Usage qitoo::if_(expr, expr, expr).");
+        };
+    }
+
+    namespace traits {
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Elements>
+        struct has_semantic_action<mxc::qitoo::if_parser<Elements> >
+            : nary_has_semantic_action<Elements> {};
+
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Elements, typename Attribute, typename Context
+            , typename Iterator>
+            struct handles_container<mxc::qitoo::if_parser<Elements>, Attribute, Context
+            , Iterator>
+            : mpl::true_ {};
+    }
+}}
+///////////////////////////////////////////////////////////////////////////
+// End of test parser implementation
+///////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////
+// Test implementation
+///////////////////////////////////////////////////////////////////////////
+
+
+int main() {
+
+    using mxc::qitoo::if_;
+    namespace qi = boost::spirit::qi;
+    using namespace boost::spirit::qi;
+    using spirit_test::test;
+    using spirit_test::test_attr;
+
+    // to test whether if_ works with grammar and rule parameter
+    struct test_grammar : qi::grammar<char const*, std::string(), qi::space_type >
+    {
+        qi::rule<char const*, std::string(), qi::space_type > r;
+        test_grammar() : test_grammar::base_type(r)
+        {
+            r = if_(qi::char_('I'), qi::string("if"), qi::lit('E') >> qi::string("else"));
+        }
+    };
+
+    std::string s;
+
+    // condition matches, if-parser matches
+    // test if condition parser attr gets omitted
+    BOOST_TEST(test_attr("I if", if_(qi::char_('I'), qi::string("if"), qi::lit('E') >> qi::string("else")), s, qi::space));
+    BOOST_TEST(s == "if");
+
+    //same test using grammar
+    test_grammar g;
+    s.clear();
+    BOOST_TEST(test_attr("I if", g, s, qi::space));
+    BOOST_TEST(s == "if");
+
+    //same test using grammar
+    s.clear();
+    BOOST_TEST(test_attr("I if", g.r, s, qi::space));
+    BOOST_TEST(s == "if");
+
+    // condition matches, if-parser fails
+    BOOST_TEST(!test("I mismatch", if_(lit('I'), qi::string("if"), qi::lit('E') >> qi::string("else")), qi::space));
+
+    // condition fails, else-parser matches
+    s.clear();
+    BOOST_TEST(test_attr("E else", if_(lit('I'), qi::string("if"), qi::lit('E') >> qi::string("else")), s, qi::space));
+    BOOST_TEST(s == "else");
+
+    // condition fails, else-parser fails
+    BOOST_TEST(!test("E mismatch", if_(lit('I'), qi::string("if"), qi::lit('E') >> qi::string("else")), qi::space));
+
+    // if embedded in sequence, string matches, condition matches, if-parser matches
+    std::vector<std::string> v;
+    BOOST_TEST(test_attr(
+        "w I if", 
+        qi::string("w") 
+            >> if_(qi::lit('I') 
+                , qi::raw[qi::string("if")]
+                , qi::string("else") >> qi::lit(",;"))
+        , v, qi::space));
+    BOOST_TEST(v.size() == 2 &&
+        v[0] == "w" && v[1] == "if");
+
+    // nested if_, outer condition fails, inner condition matches, string matches
+    s.clear();
+    BOOST_TEST(test_attr(
+        "E else"
+        , if_(qi::lit('I') , 
+            qi::string("if")
+            , if_(qi::lit('E')
+                , qi::string("else")
+                , qi::string("other")))
+            , s, qi::space
+            ));
+    BOOST_TEST(s == "else");
+
+    return boost::report_errors();
+}

--- a/test/qi/if.hpp
+++ b/test/qi/if.hpp
@@ -1,0 +1,127 @@
+///////////////////////////////////////////////////////////////////////////
+// Implementation of a ternary conditional operator if_ for test and
+// demonstration purposes.
+//
+// The implementation shows how to implement an operator
+// which lives in a user's namespace (here mxc::qitoo).
+///////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_SPIRIT_TEST_IF_FUNCTION)
+#define BOOST_SPIRIT_TEST_IF_FUNCTION
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/spirit/include/qi_grammar.hpp>
+
+namespace mxc {
+    namespace qitoo {
+        BOOST_SPIRIT_TERMINAL(if_)
+    }
+}
+
+namespace boost {
+    namespace spirit {
+        template <>
+        struct use_function<qi::domain, mxc::qitoo::tag::if_>
+            : mpl::true_ {};
+    }
+}
+
+namespace mxc {
+    namespace qitoo {
+        namespace fusion = boost::fusion;
+        namespace spirit = boost::spirit;
+        namespace qi = spirit::qi;
+
+        template <typename Elements>
+        struct if_parser : qi::nary_parser<if_parser<Elements>>
+        {
+            if_parser(Elements elements) : elements(elements) {}
+
+            template <typename Context, typename Iterator>
+            struct attribute
+            {
+                typedef typename fusion::result_of::pop_front<Elements>::type optionals;
+                typedef typename spirit::traits::build_variant<optionals>::type type;
+            };
+
+            template <typename F>
+            bool parse_container(F f) const
+            {
+                // the condition parser does not contribute to the attribute
+                if (fusion::at_c<0>(elements)
+                    .parse(f.f.first, f.f.last, f.f.context, f.f.skipper, qi::unused))
+                {
+                    return !f(fusion::at_c<1>(elements));
+                }
+                else {
+                    return !f(fusion::at_c<2>(elements));
+                }
+            }
+
+            template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+            bool parse(Iterator& first, Iterator const& last
+                , Context& context, Skipper const& skipper
+                , Attribute& attr_) const
+            {
+                spirit::traits::make_container(attr_);
+
+                qi::detail::fail_function<Iterator, Context, Skipper>
+                    f(first, last, context, skipper);
+
+                if (!parse_container(qi::detail::make_pass_container(f, attr_)))
+                    return false;
+
+                return true;
+            }
+
+            template <typename Context>
+            qi::info what(Context& context) const
+            {
+                qi::info result("if_");
+                fusion::for_each(elements,
+                    spirit::detail::what_function<Context>(result, context));
+
+                return result;
+            }
+
+            Elements elements;
+        };
+    }
+}
+
+namespace boost {
+    namespace spirit {
+
+        namespace qi {
+            ///////////////////////////////////////////////////////////////////////////
+            // Parser generator: make_xxx function (objects)
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Expr, typename Modifiers>
+            struct make_composite<mxc::qitoo::tag::if_, Expr, Modifiers>
+                : make_nary_composite<Expr, mxc::qitoo::if_parser>
+            {
+                BOOST_STATIC_ASSERT_MSG(fusion::result_of::size<Expr>::value == boost::mpl::int_<3>::value,
+                    "qitoo::if_: Invalid number of arguments. Usage qitoo::if_(expr, expr, expr).");
+            };
+        }
+
+        namespace traits {
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements>
+            struct has_semantic_action<mxc::qitoo::if_parser<Elements> >
+                : nary_has_semantic_action<Elements> {};
+
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements, typename Attribute, typename Context
+                , typename Iterator>
+                struct handles_container<mxc::qitoo::if_parser<Elements>, Attribute, Context
+                , Iterator>
+                : mpl::true_ {};
+        }
+    }
+}
+
+#endif

--- a/test/qi/if.hpp
+++ b/test/qi/if.hpp
@@ -1,3 +1,9 @@
+/*=============================================================================
+Copyright (c) 2016  Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
 ///////////////////////////////////////////////////////////////////////////
 // Implementation of a ternary conditional operator if_ for test and
 // demonstration purposes.

--- a/test/qi/longest.hpp
+++ b/test/qi/longest.hpp
@@ -1,0 +1,193 @@
+/*=============================================================================
+Copyright (c) 2016  Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+///////////////////////////////////////////////////////////////////////////
+// Implementation of variadic operator "longest. Returns the attribute of 
+// that argument parser, which consumed most of the input while succeeding
+//
+// The implementation shows how to implement a variadic operator
+// which lives in a user's namespace (here mxc::qitoo).
+///////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_SPIRIT_TEST_LONGEST_FUNCTION)
+#define BOOST_SPIRIT_TEST_LONGEST_FUNCTION
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/tuple/tuple.hpp>
+
+namespace mxc {
+    namespace qitoo {
+        BOOST_SPIRIT_TERMINAL(longest)
+    }
+}
+
+namespace boost {
+    namespace spirit {
+        template <>
+        struct use_function<qi::domain, mxc::qitoo::tag::longest>
+            : mpl::true_ {};
+    }
+}
+
+namespace mxc {
+    namespace qitoo {
+        using boost::tuples::get;
+
+        namespace detail {
+            template <typename Iterator, typename Context, typename Skipper, typename Result>
+            struct find_longest_function
+            {
+                find_longest_function(Iterator& first, Iterator const& last
+                    , Context& context, Skipper const& skipper, Result& result)
+                    : first(first), last(last), context(context), skipper(skipper), result(result)
+                {}
+
+                template<typename Component>
+                void operator()(Component& component) const
+                {
+                    Iterator f = first;
+                    if (component.parse(f, last, context, skipper, qi::unused))
+                    {
+                        int l = std::distance(first, f);
+                        if (l > get<0>(result)) {
+                            get<0>(result) = l;
+                            get<1>(result) = get<2>(result);
+                        }
+                    }
+                    get<2>(result)++;
+                }
+
+                Result& result;
+                Iterator& first;
+                Iterator const& last;
+                Context& context;
+                Skipper const& skipper;
+            };
+
+            template <typename Iterator, typename Context, typename Skipper, typename Attribute, typename Result>
+            struct longest_function
+            {
+                longest_function(Iterator& first, Iterator const& last
+                    , Context& context, Skipper const& skipper, Attribute& attr, Result& result)
+                    : first(first), last(last), context(context), skipper(skipper), attr(attr), result(result)
+                {}
+
+                template<typename Component>
+                bool operator()(Component& component) const
+                {
+                    if (get<1>(result) != get<2>(result)) {
+                        get<2>(result)++;
+                        return false;
+                    }
+                    // if current index == target index
+                    return component.parse(first, last, context, skipper, attr);
+                }
+
+                Attribute& attr;
+                Result& result;
+                Iterator& first;
+                Iterator const& last;
+                Context& context;
+                Skipper const& skipper;
+            };
+        }
+
+        namespace fusion = boost::fusion;
+        namespace spirit = boost::spirit;
+        namespace qi = spirit::qi;
+
+        template <typename Elements>
+        struct longest_parser : qi::nary_parser<longest_parser<Elements>>
+        {
+
+            longest_parser(Elements elements) 
+                : elements(elements)
+            {}
+
+            // to hold max length, max length idx, current idx
+            typedef boost::tuple<int, int, int> result_type;
+
+            template <typename Context, typename Iterator>
+            struct attribute
+            {
+                typedef typename spirit::traits::build_variant<Elements>::type type;
+            };
+
+            template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+            bool parse(Iterator& first, Iterator const& last
+                , Context& context, Skipper const& skipper
+                , Attribute& attr_) const
+            {
+                spirit::traits::make_container(attr_);
+                result_type result(-1, 0, 0);
+
+                detail::find_longest_function<Iterator, Context, Skipper, result_type>
+                    find_longest(first, last, context, skipper, result);
+
+
+                fusion::for_each(elements, find_longest);
+                if (get<0>(result) != -1) {
+                    get<2>(result) = 0;                    // reset current index
+
+                    detail::longest_function<Iterator, Context, Skipper, Attribute, result_type>
+                        longest(first, last, context, skipper, attr_, result);
+
+                    return fusion::any(elements, longest); // always true
+                }
+
+                return false;
+            }
+
+            template <typename Context>
+            qi::info what(Context& context) const
+            {
+                qi::info result("longest");
+                fusion::for_each(elements,
+                    spirit::detail::what_function<Context>(result, context));
+
+                return result;
+            }
+
+            Elements elements;
+        };
+    }
+}
+
+namespace boost {
+    namespace spirit {
+
+        namespace qi {
+            ///////////////////////////////////////////////////////////////////////////
+            // Parser generator: make_xxx function (objects)
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Expr, typename Modifiers>
+            struct make_composite<mxc::qitoo::tag::longest, Expr, Modifiers>
+                : make_nary_composite<Expr, mxc::qitoo::longest_parser>
+            { };
+        }
+
+        namespace traits {
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements>
+            struct has_semantic_action<mxc::qitoo::longest_parser<Elements> >
+                : nary_has_semantic_action<Elements> {};
+
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements, typename Attribute, typename Context
+                , typename Iterator>
+                struct handles_container<mxc::qitoo::longest_parser<Elements>, Attribute, Context
+                , Iterator>
+                : mpl::true_ {};
+        }
+    }
+}
+
+#endif

--- a/test/qi/nabialek.hpp
+++ b/test/qi/nabialek.hpp
@@ -62,23 +62,23 @@ namespace mxc {
             template<typename F>
             struct nabialek_function
             {
-                nabialek_function(F const& f, nabialek_data& result)
-                    : f(f), result(result)
+                nabialek_function(F const& f, nabialek_data& idx)
+                    : f(f), idx(idx)
                 {}
 
                 template<typename Component>
                 bool operator()(Component& component) const
                 {
                     // return false while target index != current index
-                    if (result.first != result.second) {
-                        result.second++;
+                    if (idx.first != idx.second) {
+                        idx.second++;
                         return false;
                     }
                     // current index == target index
                     return !f(component);
                 }
                 F const& f;
-                nabialek_data& result;
+                nabialek_data& idx;
             };
 
         }

--- a/test/qi/nabialek.hpp
+++ b/test/qi/nabialek.hpp
@@ -1,0 +1,182 @@
+/*=============================================================================
+Copyright (c) 2016  Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+///////////////////////////////////////////////////////////////////////////
+// Implementation of variadic operator "nabialek. 
+//
+// The first parser acts as selector and is expected to expose an int attribute.
+// The selector does not contribute to the nabialek attribute.
+// It's attribute is taken as an index to select the parser to be executed.
+// 
+// If the selector succeeds, the parser of that index gets executed and it's
+// result returned.
+//
+// This example illustrates how a functionality as currently provided
+// by qi::/ and qi::kwd can be implemented with PR#200 n-ary operators.
+//
+// The implementation shows how to implement a variadic operator
+// which lives in a user's namespace (here mxc::qitoo).
+//
+// This is for demonstration only. It has to be questioned, if that would be 
+// an optimal way to implement nabialek. I don't think so.
+// I wanted to stay near the implementation of / and kwd.
+// 
+///////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_SPIRIT_TEST_NABIALEK_FUNCTION)
+#define BOOST_SPIRIT_TEST_NABIALEK_FUNCTION
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/tuple/tuple.hpp>
+
+namespace mxc {
+    namespace qitoo {
+        BOOST_SPIRIT_TERMINAL(nabialek)
+    }
+}
+
+namespace boost {
+    namespace spirit {
+        template <>
+        struct use_function<qi::domain, mxc::qitoo::tag::nabialek>
+            : mpl::true_ {};
+    }
+}
+
+namespace mxc {
+    namespace qitoo {
+        using boost::tuples::get;
+
+        namespace detail {
+
+            typedef std::pair<int, int> nabialek_data;
+
+            template<typename F>
+            struct nabialek_function
+            {
+                nabialek_function(F const& f, nabialek_data& result)
+                    : f(f), result(result)
+                {}
+
+                template<typename Component>
+                bool operator()(Component& component) const
+                {
+                    // return false while target index != current index
+                    if (result.first != result.second) {
+                        result.second++;
+                        return false;
+                    }
+                    // current index == target index
+                    return !f(component);
+                }
+                F const& f;
+                nabialek_data& result;
+            };
+
+        }
+
+        namespace fusion = boost::fusion;
+        namespace spirit = boost::spirit;
+        namespace qi = spirit::qi;
+
+        template <typename Elements>
+        struct nabialek_parser : qi::nary_parser<nabialek_parser<Elements>>
+        {
+
+            nabialek_parser(Elements elements)
+                : elements(elements)
+            {}
+
+            template <typename Context, typename Iterator>
+            struct attribute
+            {
+                typedef typename fusion::result_of::pop_front<Elements>::type optionals;
+
+                // Put all the element attributes in a tuple
+                typedef typename spirit::traits::build_attribute_sequence <
+                    optionals, Context, spirit::traits::sequence_attribute_transform
+                    , Iterator, qi::domain
+                >::type all_attributes;
+                
+                typedef typename spirit::traits::build_variant<all_attributes>::type type;
+            };
+
+
+            template <typename F>
+            bool parse_container(F f) const
+            {
+                detail::nabialek_data idx(-1, 0);
+                if (!fusion::at_c<0>(elements).parse(f.f.first, f.f.last, f.f.context, f.f.skipper, idx.first))
+                    return false;
+
+                detail::nabialek_function<F>
+                    nabialek(f, idx);
+
+                return fusion::any(elements, nabialek); // selected parser might fail
+            }
+
+            template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+            bool parse(Iterator& first, Iterator const& last
+                , Context& context, Skipper const& skipper
+                , Attribute& attr_) const
+            {
+                spirit::traits::make_container(attr_);
+                qi::detail::fail_function<Iterator, Context, Skipper>
+                    f(first, last, context, skipper);
+                return parse_container(qi::detail::make_pass_container(f, attr_));
+            }
+
+            template <typename Context>
+            qi::info what(Context& context) const
+            {
+                qi::info result("nabialek");
+                fusion::for_each(elements,
+                    spirit::detail::what_function<Context>(result, context));
+
+                return result;
+            }
+
+            Elements elements;
+        };
+    }
+}
+
+namespace boost {
+    namespace spirit {
+
+        namespace qi {
+            ///////////////////////////////////////////////////////////////////////////
+            // Parser generator: make_xxx function (objects)
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Expr, typename Modifiers>
+            struct make_composite<mxc::qitoo::tag::nabialek, Expr, Modifiers>
+                : make_nary_composite<Expr, mxc::qitoo::nabialek_parser>
+            { };
+        }
+
+        namespace traits {
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements>
+            struct has_semantic_action<mxc::qitoo::nabialek_parser<Elements> >
+                : nary_has_semantic_action<Elements> {};
+
+            ///////////////////////////////////////////////////////////////////////////
+            template <typename Elements, typename Attribute, typename Context
+                , typename Iterator>
+                struct handles_container<mxc::qitoo::nabialek_parser<Elements>, Attribute, Context
+                , Iterator>
+                : mpl::true_ {};
+        }
+    }
+}
+
+#endif
+

--- a/test/qi/nabialek.hpp
+++ b/test/qi/nabialek.hpp
@@ -37,146 +37,137 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/spirit/include/qi_grammar.hpp>
 #include <boost/tuple/tuple.hpp>
 
-namespace mxc {
-    namespace qitoo {
-        BOOST_SPIRIT_TERMINAL(nabialek)
-    }
-}
+namespace mxc { namespace qitoo {
+    BOOST_SPIRIT_TERMINAL(nabialek)
+}}
 
-namespace boost {
-    namespace spirit {
-        template <>
-        struct use_function<qi::domain, mxc::qitoo::tag::nabialek>
-            : mpl::true_ {};
-    }
-}
+namespace boost { namespace spirit {
+    template <>
+    struct use_function<qi::domain, mxc::qitoo::tag::nabialek>
+        : mpl::true_ {};
+}}
 
-namespace mxc {
-    namespace qitoo {
-        using boost::tuples::get;
+namespace mxc { namespace qitoo {
 
-        namespace detail {
+    namespace detail {
 
-            typedef std::pair<int, int> nabialek_data;
+        typedef std::pair<int, int> nabialek_data;
 
-            template<typename F>
-            struct nabialek_function
-            {
-                nabialek_function(F const& f, nabialek_data& idx)
-                    : f(f), idx(idx)
-                {}
-
-                template<typename Component>
-                bool operator()(Component& component) const
-                {
-                    // return false while target index != current index
-                    if (idx.first != idx.second) {
-                        idx.second++;
-                        return false;
-                    }
-                    // current index == target index
-                    return !f(component);
-                }
-                F const& f;
-                nabialek_data& idx;
-            };
-
-        }
-
-        namespace fusion = boost::fusion;
-        namespace spirit = boost::spirit;
-        namespace qi = spirit::qi;
-
-        template <typename Elements>
-        struct nabialek_parser : qi::nary_parser<nabialek_parser<Elements>>
+        template<typename F>
+        struct nabialek_function
         {
-
-            nabialek_parser(Elements elements)
-                : elements(elements)
+            nabialek_function(F const& f, nabialek_data& idx)
+                : f(f), idx(idx)
             {}
 
-            template <typename Context, typename Iterator>
-            struct attribute
+            template<typename Component>
+            bool operator()(Component& component) const
             {
-                typedef typename fusion::result_of::pop_front<Elements>::type optionals;
-
-                // Put all the element attributes in a tuple
-                typedef typename spirit::traits::build_attribute_sequence <
-                    optionals, Context, spirit::traits::sequence_attribute_transform
-                    , Iterator, qi::domain
-                >::type all_attributes;
-                
-                typedef typename spirit::traits::build_variant<all_attributes>::type type;
-            };
-
-
-            template <typename F>
-            bool parse_container(F f) const
-            {
-                detail::nabialek_data idx(-1, 0);
-                if (!fusion::at_c<0>(elements).parse(f.f.first, f.f.last, f.f.context, f.f.skipper, idx.first))
+                // return false while target index != current index
+                if (idx.first != idx.second) {
+                    idx.second++;
                     return false;
-
-                detail::nabialek_function<F>
-                    nabialek(f, idx);
-
-                return fusion::any(elements, nabialek); // selected parser might fail
+                }
+                // current index == target index
+                return !f(component);
             }
-
-            template <typename Iterator, typename Context, typename Skipper, typename Attribute>
-            bool parse(Iterator& first, Iterator const& last
-                , Context& context, Skipper const& skipper
-                , Attribute& attr_) const
-            {
-                spirit::traits::make_container(attr_);
-                qi::detail::fail_function<Iterator, Context, Skipper>
-                    f(first, last, context, skipper);
-                return parse_container(qi::detail::make_pass_container(f, attr_));
-            }
-
-            template <typename Context>
-            qi::info what(Context& context) const
-            {
-                qi::info result("nabialek");
-                fusion::for_each(elements,
-                    spirit::detail::what_function<Context>(result, context));
-
-                return result;
-            }
-
-            Elements elements;
+            F const& f;
+            nabialek_data& idx;
         };
     }
-}
 
-namespace boost {
-    namespace spirit {
+    namespace fusion = boost::fusion;
+    namespace spirit = boost::spirit;
+    namespace qi = spirit::qi;
 
-        namespace qi {
-            ///////////////////////////////////////////////////////////////////////////
-            // Parser generator: make_xxx function (objects)
-            ///////////////////////////////////////////////////////////////////////////
-            template <typename Expr, typename Modifiers>
-            struct make_composite<mxc::qitoo::tag::nabialek, Expr, Modifiers>
-                : make_nary_composite<Expr, mxc::qitoo::nabialek_parser>
-            { };
+    template <typename Elements>
+    struct nabialek_parser : qi::nary_parser<nabialek_parser<Elements>>
+    {
+
+        nabialek_parser(Elements elements)
+            : elements(elements)
+        {}
+
+        template <typename Context, typename Iterator>
+        struct attribute
+        {
+            typedef typename fusion::result_of::pop_front<Elements>::type optionals;
+
+            // Put all the element attributes in a tuple
+            // #todo (fhe): implement spirit::traits::nabialek_attribute_transform hook 
+            //              if this was ever considered for release
+            typedef typename spirit::traits::build_attribute_sequence <
+                optionals, Context, spirit::traits::sequence_attribute_transform
+                , Iterator, qi::domain
+            >::type all_attributes;
+                
+            typedef typename spirit::traits::build_variant<all_attributes>::type type;
+        };
+
+        template <typename F>
+        bool parse_container(F f) const
+        {
+            detail::nabialek_data idx(-1, 0);
+            if (!fusion::at_c<0>(elements).parse(f.f.first, f.f.last, 
+                    f.f.context, f.f.skipper, idx.first))
+                return false;
+
+            detail::nabialek_function<F> nabialek(f, idx);
+
+            return fusion::any(elements, nabialek); // selected parser might fail
         }
 
-        namespace traits {
-            ///////////////////////////////////////////////////////////////////////////
-            template <typename Elements>
-            struct has_semantic_action<mxc::qitoo::nabialek_parser<Elements> >
-                : nary_has_semantic_action<Elements> {};
-
-            ///////////////////////////////////////////////////////////////////////////
-            template <typename Elements, typename Attribute, typename Context
-                , typename Iterator>
-                struct handles_container<mxc::qitoo::nabialek_parser<Elements>, Attribute, Context
-                , Iterator>
-                : mpl::true_ {};
+        template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+        bool parse(Iterator& first, Iterator const& last
+            , Context& context, Skipper const& skipper
+            , Attribute& attr_) const
+        {
+            spirit::traits::make_container(attr_);
+            qi::detail::fail_function<Iterator, Context, Skipper>
+                f(first, last, context, skipper);
+            return parse_container(qi::detail::make_pass_container(f, attr_));
         }
+
+        template <typename Context>
+        qi::info what(Context& context) const
+        {
+            qi::info result("nabialek");
+            fusion::for_each(elements,
+                spirit::detail::what_function<Context>(result, context));
+
+            return result;
+        }
+
+        Elements elements;
+    };
+}}
+
+namespace boost { namespace spirit {
+
+    namespace qi {
+        ///////////////////////////////////////////////////////////////////////////
+        // Parser generator: make_xxx function (objects)
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Expr, typename Modifiers>
+        struct make_composite<mxc::qitoo::tag::nabialek, Expr, Modifiers>
+            : make_nary_composite<Expr, mxc::qitoo::nabialek_parser>
+        { };
     }
-}
+
+    namespace traits {
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Elements>
+        struct has_semantic_action<mxc::qitoo::nabialek_parser<Elements> >
+            : nary_has_semantic_action<Elements> {};
+
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Elements, typename Attribute, typename Context
+            , typename Iterator>
+            struct handles_container<mxc::qitoo::nabialek_parser<Elements>, Attribute, Context
+            , Iterator>
+            : mpl::true_ {};
+    }
+}}
 
 #endif
 

--- a/workbench/qi/nabialek.cpp
+++ b/workbench/qi/nabialek.cpp
@@ -69,12 +69,12 @@ namespace
             sex = qi::lit('=') >> qi::char_("mf");
 
             // for _ni test cases
-            kwd_ni = repo::kwd("name")[name] / repo::kwd("age")[age] / repo::kwd("sex")[sex];
+            kwd_ni = (repo::kwd("name")[name]) / (repo::kwd("age")[age]) / (repo::kwd("sex")[sex]);
             nabialek_ni = +nabialek(sym3, name, age, sex);
             alternatives_ni = +(("name" >> name) | ("age" >> age) | ("sex" >> sex));
 
             // for _r test cases
-            kwd_r = repo::kwd("name")[qi::lit('=') >> qi::lexeme[+qi::alpha]] / repo::kwd("age")[qi::lit('=') >> qi::int_] / repo::kwd("sex")[qi::lit('=') >> qi::char_("mf")];
+            kwd_r = (repo::kwd("name")[qi::lit('=') >> qi::lexeme[+qi::alpha]]) / (repo::kwd("age")[qi::lit('=') >> qi::int_]) / (repo::kwd("sex")[qi::lit('=') >> qi::char_("mf")]);
             alternatives_r = +(("name" >> qi::lit('=') >> qi::lexeme[+qi::alpha]) | ("age" >> qi::lit('=') >> qi::int_) | ("sex" >> qi::lit('=') >> qi::char_("mf")));
             nabialek_r = +nabialek(sym3, qi::lit('=') >> qi::lexeme[+qi::alpha], qi::lit('=') >> qi::int_, qi::lit('=') >> qi::char_("mf"));
 
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
         std::cout << "//   nabialek_trick_ptr: nabialek trick with pointers to rules" << std::endl;
         std::cout << "// " << std::endl;
         std::cout << "// In both cases the nabialek trick is defined as a rule contained by " << std::endl;
-        std::cout << "// a grammar." << std::endl;
+        std::cout << "// a container struct." << std::endl;
         std::cout << "///////////////////////////////////////////////////////////////////////////" << std::endl;
         std::cout << std::endl;
         BOOST_SPIRIT_TEST_BENCHMARK(

--- a/workbench/qi/nabialek.cpp
+++ b/workbench/qi/nabialek.cpp
@@ -21,7 +21,7 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
 // enable this define to activate asserts which check if the parsers 
-// and parse the whole input (for debugging)
+// succeeds and parses the whole input (for debugging)
 //#define CHECK_RESULT
 
 // change this define to set the number max number of runs of the

--- a/workbench/qi/nabialek.cpp
+++ b/workbench/qi/nabialek.cpp
@@ -372,7 +372,7 @@ int main(int argc, char **argv)
 
     BOOST_SPIRIT_TEST_BENCHMARK(
         10000000,     // This is the maximum repetitions to execute
-         (nabialek_trick_org)           // orginal nabialek trick with pointers to parsers
+         (nabialek_trick_org)           // orginal nabialek trick 
          (nabialek_trick_ptr)           // orginal nabialek trick with pointers to parsers
          (keyword_slash_rule)           // kwd directice with divide operator using rules as argument parsers
          (keyword_slash_direct)         // kwd directive using parser expressions directly

--- a/workbench/qi/nabialek.cpp
+++ b/workbench/qi/nabialek.cpp
@@ -1,0 +1,320 @@
+/*=============================================================================
+Copyright (c) 2016  Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "../measure.hpp"
+#include <boost/spirit/home/qi.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#include <libs/spirit/test/qi/nabialek.hpp>
+#include <boost/spirit/repository/include/qi_kwd.hpp>
+#include <boost/spirit/repository/include/qi_keywords.hpp>
+
+
+// enable this define to activate asserts to check
+// if the parsers succeed and (first == last)
+
+//#define CHECK_RESULT
+
+namespace
+{
+    typedef std::string::const_iterator iterator_type;
+
+    std::string source("name = Tom age = 27 sex = m age = 32 sex = f name = Sue");
+
+    namespace qi = boost::spirit::qi;
+    namespace repo = boost::spirit::repository::qi;
+    using mxc::qitoo::nabialek;
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct tg0 : qi::grammar<iterator_type, qi::locals<qi::rule<iterator_type, qi::space_type>*>
+        ,qi::space_type>
+    {
+        qi::rule<iterator_type,  qi::space_type> name;
+        qi::rule<iterator_type,  qi::space_type> age;
+        qi::rule<iterator_type,  qi::space_type> sex;
+        qi::rule<iterator_type,  qi::locals<qi::rule<iterator_type, qi::space_type>*>, qi::space_type > start;
+        qi::symbols<char, qi::rule<iterator_type, qi::space_type>*> keywords;
+
+
+        tg0() : tg0::base_type(start)
+        {
+            using qi::_1;
+            using qi::_a;
+
+            name = qi::lit('=') >> qi::lexeme[+qi::alpha];
+            age = qi::lit('=') >> qi::int_;
+            sex = qi::lit('=') >> qi::char_("mf");
+
+            keywords.add("name", &name)("age", &age)("sex", &sex);
+
+            start = +( keywords[_a = _1] >> qi::lazy(*_a));
+        }
+    };
+
+    tg0 g0;
+
+    struct nabialek_trick : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, g0.start, qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct tg1 : qi::grammar<iterator_type, qi::space_type >
+    {
+        qi::rule<iterator_type,  qi::space_type> name;
+        qi::rule<iterator_type,  qi::space_type> age;
+        qi::rule<iterator_type,  qi::space_type> sex;
+        qi::rule<iterator_type,  qi::space_type> start;
+        qi::symbols<char, int> keywords;
+
+        tg1() : tg1::base_type(start)
+        {
+            keywords.add("name", 1)("age", 2)("sex", 3);
+
+            name = qi::lit('=') >> qi::lexeme[+qi::alpha];
+            age = qi::lit('=') >> qi::int_;
+            sex = qi::lit('=') >> qi::char_("mf");
+
+            start = +nabialek(keywords, name, age, sex);
+        }
+    };
+
+    tg1 g1;
+
+    struct nab_rules : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, +nabialek(g1.keywords, g1.name, g1.age, g1.sex), qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    struct nab_rules_ni : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, g1.start, qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct nab_direct : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last,
+                +nabialek(g1.keywords,
+                    qi::lit('=') >> qi::lexeme[+qi::alpha],
+                    qi::lit('=') >> qi::int_,
+                    qi::lit('=') >> qi::char_("mf"))
+                , qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct tg2 : qi::grammar<iterator_type, qi::space_type >
+    {
+        qi::rule<iterator_type, qi::space_type> name;
+        qi::rule<iterator_type, qi::space_type> age;
+        qi::rule<iterator_type, qi::space_type> sex;
+        qi::rule<iterator_type, qi::space_type> start;
+        qi::symbols<char, int> keywords;
+
+        tg2() : tg2::base_type(start)
+        {
+            keywords.add("name", 1)("age", 2)("sex", 3);
+
+            name %= qi::lit('=') >> qi::lexeme[+qi::alpha];
+            age %= qi::lit('=') >> qi::int_;
+            sex %= qi::lit('=') >> qi::char_("mf");
+
+            start = +nabialek(keywords, name, age, sex);
+        }
+    };
+
+    tg2 g2;
+
+    struct nab_rules_me : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, +nabialek(g2.keywords, g2.name, g2.age, g2.sex), qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    struct nab_rules_me_ni : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, g2.start, qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct tg3 : qi::grammar<iterator_type, qi::space_type >
+    {
+        qi::rule<iterator_type,  qi::space_type> name;
+        qi::rule<iterator_type,  qi::space_type> age;
+        qi::rule<iterator_type,  qi::space_type> sex;
+        qi::rule<iterator_type,  qi::space_type> start;
+        qi::symbols<char, int> keywords;
+
+        tg3() : tg3::base_type(start)
+        {
+            keywords.add("name", 1)("age", 2)("sex", 3);
+
+            name = qi::lit('=') > qi::lexeme[+qi::alpha];
+            age = qi::lit('=') > qi::int_;
+            sex = qi::lit('=') > qi::char_("mf");
+
+            start = +nabialek(keywords, name, age, sex);
+        }
+    };
+
+    tg3 g3;
+
+    struct nab_rules_expect : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, +nabialek(g3.keywords, g3.name, g3.age, g3.sex), qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    struct nab_rules_expect_ni : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, g3.start, qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct tg4 : qi::grammar<iterator_type, qi::space_type >
+    {
+        qi::rule<iterator_type, qi::space_type> name;
+        qi::rule<iterator_type, qi::space_type> age;
+        qi::rule<iterator_type, qi::space_type> sex;
+        qi::rule<iterator_type, qi::space_type> start;
+        qi::symbols<char, int> keywords;
+
+        tg4() : tg4::base_type(start)
+        {
+            keywords.add("name", 1)("age", 2)("sex", 3);
+            
+            name %= qi::lit('=') > qi::lexeme[+qi::alpha];
+            age %= qi::lit('=') > qi::int_;
+            sex %= qi::lit('=') > qi::char_("mf");
+
+            start = +nabialek(keywords, name, age, sex);
+        }
+    };
+
+    tg4 g4;
+
+    struct nab_rules_expect_me : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, +nabialek(g4.keywords, g4.name, g4.age, g4.sex), qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+
+    struct nab_rules_expect_me_ni : test::base
+    {
+        void benchmark()
+        {
+            iterator_type first = source.begin();
+            iterator_type last = source.end();
+            bool success = qi::phrase_parse(first, last, g4.start, qi::space);
+#ifdef CHECK_RESULT
+            BOOST_ASSERT(success && (first == last));
+#endif
+        }
+    };
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "///////////////////////////////////////////////////////////////////////////" << std::endl;
+    std::cout << "// Benchmarking example nabialek operator against nabialek trick" << std::endl;
+    std::cout << "//" << std::endl;
+    std::cout << "// Please have a look at main() for an explanation of the test cases" << std::endl;
+    std::cout << "///////////////////////////////////////////////////////////////////////////" << std::endl;
+
+    BOOST_SPIRIT_TEST_BENCHMARK(
+        10000000,     // This is the maximum repetitions to execute
+         (nabialek_trick)               // orginal nabialek trick with pointers to parsers
+         (nab_direct)                   // direct instantiation of nabialek and all arguments
+         (nab_rules)                    // direct instantiation of nabialek with rule arguments
+         (nab_rules_ni)                 // same as nab_rules but using a start rule defining op and args
+         (nab_rules_expect)             // same as nab_rules but rules use expect instead of sequence
+         (nab_rules_expect_ni)          // same as nab_rules_expect but using as start rule defining op and args
+
+        // No test does attribute handling. Attribute handling slows things down significantly on all 
+        // tested parsers. The _me test cases are not relevant without attribute handling and therefore
+        // commented out.
+
+//         (nab_rules_me)                 // same as nab_rules but rules use %= instead of =
+//         (nab_rules_me_ni)              // same as nab_rules_me but using a start rule defining op and args 
+//         (nab_rules_expect_me)          // same as nab_rules_expect and rules use %= instead of =
+//         (nab_rules_expect_me_ni)       // same as nab_rules_expect_me but using start rule defining op and args
+    )
+
+        // This is ultimately responsible for preventing all the test code
+        // from being optimized away.  Change this to return 0 and you
+        // unplug the whole test's life support system.
+        return test::live_code != 0;
+}
+

--- a/workbench/qi/nabialek.cpp
+++ b/workbench/qi/nabialek.cpp
@@ -23,7 +23,7 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 // enable this define to activate asserts to check
 // if the parsers succeed and (first == last)
 
-#define CHECK_RESULT
+//#define CHECK_RESULT
 
 namespace
 {


### PR DESCRIPTION
This PR adds support for n-ary named operators. They contribute to the nary_parser concept.

The implementation extends the qi metagrammar to accept `proto::function` tags. If a `proto::function` tag gets encountered together with an appropriate specialization of `use_function` a  generator function named `make_function` gets called which produces a nary parser component.

The parser class enabled here uses function style syntax. The general form is `op(p1, ...)`, where `op` is the name of the nary parser and `(p1, ...)` are a variadic number of arguments. Each argument must conform to the qi metagrammar, i.e. it has to be a qi parser expression.

This PR is intended to add the capability to define n-ary named operators. It does not introduce a particular operator yet.

A test case is provided with test/function.cpp. This file in particular implements a ternary conditional operator `if_`. Purpose of this implementation is to test if a nary operator gets created properly, i.e. that the additions to the qi core work properly. The other purpose is to demonstrate how nary named parsers get implemented and enabled via `use_function`.

The test case compiles and runs without failure on msvc-9.0, msvc-12.0, msvc-14.0, gcc 6.1. The complete test suite does not compile currently as discussed already in PR #198. With PR #201 I provided a bug fix for the qi part of the test suite. The introduction of nary operators has no impact on the tests in their current state. What compiled and ran before nary operators where introduced continues to compile and run. No additional fails. With the PR #201 bugfix, the qi test suite compiles with no errors or failures.

The only adjustment to the documentation is the What's New section which announces support for
this parser class. This might be ok at this stage (without having a particular operator introduced).

Here is a list of the particular changes:

 - Added to What's New documentation
 - Added an additional case for `proto::function` to the metagrammar.
 - Added `make_function` handler for this particular case.
 - Renamed function `make_binary_helper` to `make_nary_helper`. This helper function is suitable for both binary and nary operators.
 - Created test case function.cpp.
 - Added test case to jamfile.


May I ask the community to please assess this pull request, the discussion, and if you are deep in qi the code provided, also? I would highly appreciate if you respond to this post and tell me, what you think.

Here is what I think why this PR should be accepted:

1. Currently the only option you have to write a qi operator, is to implement a parser and enable it using use_operator<>.

     The arity is restricted to unary and binary and you have to associate your parser with a valid C++ operator like (examples: -y, x % y).  You can not write a parser operator with an arity > 2 with qi. 

    **With this PR you can write write operators of arbitrary (even variadic) arity. Fully C++03 compliant.**

2. Qi already supports the nary_parser model in a way which is not per se restricted to unary and binary operators. That means if there was way to make an n-ary operator to be recognized by qi, qi would fully support it. 

    **This PR provides a way to make qi know about n-ary operator parsers. Not more. The existing code base is not touched.**

3. The number of c++ operators available is limited. So currently the maximum number of unary parsers which can get implemented is equal to the number of unary c++ operators. The same applies for binary operators and binary c++ operators.

    **With this PR the number of possible unary and binary parsers is not limited any longer.**

4. If you ever implemented a qi operator parser, you may have found, that it is not quite easy to select a c++ operator suitable to look expressive and meaningful in terms of what your parser does. 

    **With this PR you can provide a meaningful name (even) for your unary or binary parser.**

5. Another topic is operator precedence. If you write `a | b >> c % d`, then c++ operator
precedence applies, because this is valid c++ code getting executed. If you want
to implement a binary parser this makes the selection of an operator even more
difficult (see http://en.cppreference.com/w/cpp/language/operator_precedence).
Most of more "interesting" operators (those with higher prio (lower number)) are already used by qi.
 
    **With this PR you can write operators which have a precedence of 2 (function call).**

6. Making my first dives into qi I was looking in particular for differences between qi and X3. I also asked Joel, if qi is going to get deprecated. He said it is not. Therefore it makes sense to examine X3 for interesting things qi is lacking. I found the  expect directive was a good case to learn. I created one for qi (PR#196) which got accepted. Support for n-ary operators is more tricky, but it is also a feature
X3 supports.

    See this example http://coliru.stacked-crooked.com/a/cb13c1d357cdc464. This was gently provided      by sehe as a part of one of my silly questions on stackoverflow.

    **This PR closes a capability gap between qi and X3. As qi is not going to get deprecated, this seems  to be  important.**

7. Rule evaluation control: qi automatically applies rules and that works good. Anyway, there seems to be (have been) a demand by users to gain some control about the rule evaluation control flow. Best example for that is the legendary Nabialek trick which is still referenced today.

    This PR allows you to create a parser which you pass a variadic number of parsers in. Then your parser is in full control of what it does with the supplied argument parsers. You could even implement your own rule application algorithm. 

    In extreme: Create a parser, say my_engine, pass all your rules in and evaluate them to your liking completely bypassing the qi rule application algorithm. Without loosing any of qi's features. Maybe no one would actually want to drive that into the extreme. But there are always many approaches possible to solve a problem. 

   C++ offers so many different concepts to approach a problem. Control is up to the user. The user can decide and is not restricted to a particular programming paradigm or implementation by the programming environment.

    **This PR increases the options you have to approach a problem using qi significantly.**

8. Is there an alternative solution?

    Qi binary and unary operators cover partly what this PR introduces. They cover the operator part of the functionality. But you can't name them, their number is limited to number of c++ operators available and their precedence depends on the c++ operator precedence they are associated with. Existing Qi operators are great, in particular operator notation is often quite beautiful. Qi operators have limitations which this PR addresses.

    **This PR removes limitations restricting the implementation of unary and binary parser operators. Operators of arbitrary arity can not get emulated using existing qi features.**

9. Does qi get more expressive? 

    Qi gets more expressive in terms of HOW things can get parsed. It gets more expressive in that operators of arbitrary (even variadic) arity can be defined. Which currently can not be done. There is no way to emulate an operator with variadic arguments with qi. The only option is cascading binary operators. `p1 >> p2 >> p3 >> ...`.  Depending on the particular implementation a native operator with variadic argument list can perform better.

    Even with operator chaining you do not have a central point of control over the argument parsers. No `>>` does know of it's neighbour `>>`'s  second argument. They are not context aware.

    **This PR allows to create context aware operators of arbitrary arity.**

10. Windows-MSVC: I am on that platform and in most project contexts I do not have the choice to switch the compiler. Enterprises with PSPGs determining the full tool chain. So for me, and maybe to some of you, MSVC support is important. X3 is not necessarily aimed at full MSVC support (i.e. see discussion here: PR #168 ). I want to please ALL of my customers with THE SAME version of spirit. I can not afford and I do not see any justification to enable my people to support X3 for customers, who don't care about MSVC and qi for customers who do. If X3 does not support MSVC, it's a no go. So a modern qi is important.

    **This PR enhances the capabilities of qi by bringing them closer to X3, which is important for people on MSVC.**

11. What would be the risks imposed by merging this PR?

    This PR touches the metagrammar, the heart of qi. This might frighten on the first sight. But much more than location does structure contribute to the possible risk imposed. Let's see:

    The metagrammar extension with an additional switch for proto::tag functions does never fire that switch with existing qi code. Proof: If any of the existing qi constructs would have produced a `proto::tag function` (this would fire the switch), this code would not have compiled. You can try this out. So we can assume that none of the parser implementations out in the community produces a `proto::tag::function`. Therefore the new switch will not fire with any existing code. qed. This means in particular, existing code out there will produce exactly the same parsers as before. No reinterpretation possible.

   If the switch never fires, the `make_function` generator function will never get triggered by existing code. Existing qi code can never instatiate a `function` parser by failure.

    The renaming of `make_binary_helper` to `make_nary_helper` does not induce risk. The only reference to that was also changed. I changed the name, because this helper supports nary parser creation in general, not only in the particular binary case. I think this rename makes sense anyway. The new name is more precise. 

    So IMHO there is no risk for existing code. This assumes, that C++ is deterministic. 

    The only chance I see that the pure existance of this PR's code would harm existing code, is that it could reveal bugs which already existed in qi but did not show up (the compiler does something different, which may lead to a different memory layout, which could change something which was undefined but harmless to something undefined and harmful). Allthough that minimal risk exists, I believe it is neglectible. Reason: Qi compiles cross-platform cross-compiler. Such a sophisticated bug would have shown up on some platform on some compiler. 

  So the changes are fundamental. A new class of parsers is a fundamental enhancement. The change had to be done deep in the core. The metagrammar was extended by an additional switch.  But nothing else actually gets changed. Something is added which does not interfere with what was there already. The main reason that this solution could be done which seamlessly integrates in existing meta-grammar/meta-compiler code is, that qi is so well done, that support for n-ary operators was already available. Just like as if someone actually anticipated upcoming n-ary operators.

   It remains the risk of using the new feature. But this only means any new `function` has to pass QA by passing tests as required. The same procedure as for all parsers.

   **My conclusion:  This PR does not induce any significant risk.**

12. Another risk: If qi stops to evolve, community support will erode.
    **That's for sure.**

13. Do we need this enhancement? 
    It depends on what you mean by "need". We don't need computers but life is better with them. Earth will not stop spinning without this PR. I'd love to see, that qi is not end of live, so: 

    **If it is true that qi is not going to get deprecated then what is important for X3 should be important for qi also. And considering the points above my answer is: Yes.** 

   

So, what do you think? Thank you for the time you spent on reading this. Any feedback would be highly appreciated. Did I miss something important? If you want to test this, checkout the develop branch of my fork of spirit. develop is actually the feature branch for this PR (I learned somewhat late about branching ;) (https://github.com/mxc-commons/spirit)

Regards, Frank
