### PR TITLE
Fix for spirit_v2 qi/alternative test case

### DIFF
--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -147,7 +147,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         bool call_unused(Component const& component, mpl::true_) const
         {
             // return true if the parser succeeds
-            //BOOST_STATIC_ASSERT_MSG(spirit::traits::not_is_variant<Attribute, qi::domain>::value, "Optional");
             return call(component,
                 mpl::and_<
                     spirit::traits::not_is_variant<Attribute, qi::domain>,

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     template <typename Variant, typename Expected>
     struct find_substitute
     {
-        // Get the typr from the variant that can be a substitute for Expected.
+        // Get the type from the variant that can be a substitute for Expected.
         // If none is found, just return Expected
 
         typedef Variant variant_type;
@@ -138,14 +138,16 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Component>
         bool call(Component const& component, mpl::false_) const
         {
+            // fix for alternative.cpp test case, FHE 2016-07-28
             return call_optional_or_variant(
-                component, spirit::traits::not_is_variant<Attribute, qi::domain>());
+                component, mpl::not_<spirit::traits::not_is_optional<Attribute, qi::domain>>());
         }
 
         template <typename Component>
         bool call_unused(Component const& component, mpl::true_) const
         {
             // return true if the parser succeeds
+            //BOOST_STATIC_ASSERT_MSG(spirit::traits::not_is_variant<Attribute, qi::domain>::value, "Optional");
             return call(component,
                 mpl::and_<
                     spirit::traits::not_is_variant<Attribute, qi::domain>,


### PR DESCRIPTION
For me it looks like an issue involving the type traits `not_is_variant` and `not_is_optional`. `boost::optionals` which contain a `boost::variant`  (`boost::optional<boost::variant>`) are treated as variants, i.e. `not_is_variant` gives `mpl::false_`. 

This leads to `call_optional_or_variant` gets called with `mpl::false_` which seems to be incorrect for this type. 

Because `not_is_variant` and `not_is_optional` are not mutually exclusive in that context, I changed that to continue with `mpl::true` if the Attribute is an optional.

With that change the test case compiles. 

But I am actually not sure about the intention behind treating optionals as variants by the traits. If this design produces side effects qi relies on, my change might be not sufficient. 

The spirit_v2/qi test suite compiles successfully and all tests succeed now. So I assume, there are no side effects which stopped working.

I corrected a typo in a comment, too.

I did not look after the errors karma and lex produce. I am not into those right now.