### PR TITLE
Lex: Fixed unique_ptr usage

### DIFF
--- a/include/boost/spirit/home/support/detail/lexer/generator.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/generator.hpp
@@ -495,21 +495,13 @@ protected:
                         delete *l_iter_;
                         *l_iter_ = overlap_.release ();
 
-                        // VC++ 6 Hack:
-                        charset_ptr temp_overlap_ (new charset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.reset (new charset);
                         ++iter_;
                     }
                     else if (r_->empty ())
                     {
-                        delete r_.release ();
-                        r_ = overlap_;
-
-                        // VC++ 6 Hack:
-                        charset_ptr temp_overlap_ (new charset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.swap (r_);
+                        overlap_.reset (new charset);
                         break;
                     }
                     else
@@ -518,10 +510,7 @@ protected:
                             static_cast<charset *>(0));
                         *iter_ = overlap_.release ();
 
-                        // VC++ 6 Hack:
-                        charset_ptr temp_overlap_ (new charset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.reset(new charset);
                         ++iter_;
                         end_ = lhs_->end ();
                     }
@@ -643,21 +632,13 @@ protected:
                         delete *l_iter_;
                         *l_iter_ = overlap_.release ();
 
-                        // VC++ 6 Hack:
-                        equivset_ptr temp_overlap_ (new equivset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.reset (new equivset);
                         ++iter_;
                     }
                     else if (r_->empty ())
                     {
-                        delete r_.release ();
-                        r_ = overlap_;
-
-                        // VC++ 6 Hack:
-                        equivset_ptr temp_overlap_ (new equivset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.swap (r_);
+                        overlap_.reset (new equivset);
                         break;
                     }
                     else
@@ -666,10 +647,7 @@ protected:
                             static_cast<equivset *>(0));
                         *iter_ = overlap_.release ();
 
-                        // VC++ 6 Hack:
-                        equivset_ptr temp_overlap_ (new equivset);
-
-                        overlap_ = temp_overlap_;
+                        overlap_.reset (new equivset);
                         ++iter_;
                         end_ = lhs_->end ();
                     }


### PR DESCRIPTION
Lex is using `unique_ptr` from `movelib` and relying on a bug in it, described in [a ticket](https://svn.boost.org/trac/boost/ticket/11758).
Since that bug fixed in `movelib` Lex is uncompilable.

I have simplified unique_ptr usage by the following rules:
  - `delete ptr.release()` is equal to `ptr.reset()`
  - `delete a.release(); a = b;` is equal to `b.swap(a); b.reset();`

Now Lex test suite compiles and runs succesfully. VC++ 6 should be happy too despite the fact that Boost no longer supports it.