### PR TITLE
Qi.Examples: Fixed missing `using` statement for `expect` directive

### DIFF
--- a/example/qi/reference.cpp
+++ b/example/qi/reference.cpp
@@ -1032,6 +1032,7 @@ main()
     {
         //[reference_using_declarations_expectd
         using boost::spirit::ascii::char_;
+        using boost::spirit::qi::expect;
         using boost::spirit::qi::expectation_failure;
         //]
 


### PR DESCRIPTION
Error message:
> qi/reference.cpp:1047:31: error: ‘expect’ was not declared in this scope
>              test_parser("xi", expect[char_('o')]); // should throw an exception

Introduced with PR #196 (commit d494fe189b447b359d88f188d95d4e40ef3997ff)