### PR TITLE
Karma.Tests: Added `regression_real_policy_sign.cpp` to test suite

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -243,6 +243,7 @@ path-constant LEX_DIR : $(BOOST_ROOT)/libs/spirit/test/lex ;
      [ run karma/regression_center_alignment.cpp           : : : :  karma_regression_center_alignment ]
      [ run karma/regression_container_variant_sequence.cpp : : : :  karma_regression_container_variant_sequence ]
      [ run karma/regression_real_0.cpp                     : : : :  karma_regression_real_0 ]
+     [ run karma/regression_real_policy_sign.cpp           : : : :  karma_regression_real_policy_sign ]
      [ run karma/regression_unicode_char.cpp               : : : :  karma_regression_unicode_char ]
      [ run karma/regression_iterator.cpp                   : : : :  karma_regression_iterator ]
 


### PR DESCRIPTION
The test was added in 90d65d4be785050f65eeee03769cfb995c4adf5b,
but still is not used in the test suite.
