### PR TITLE
Qi: `pow10` is already in the `spirit::traits` namespace

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -31,8 +31,6 @@
 
 namespace boost { namespace spirit { namespace traits
 {
-    using spirit::traits::pow10;
-    
     namespace detail
     {
         template <typename T, typename AccT>


### PR DESCRIPTION
Fixes the following warning message from the Intel compiler:
> boost/spirit/home/qi/numeric/detail/real_impl.hpp(34): warning #780:
>  using-declaration ignored -- it refers to the current namespace