### PR TITLE
Correct/Clarify documentation list operator

### DIFF
--- a/doc/qi/operator.qbk
+++ b/doc/qi/operator.qbk
@@ -447,8 +447,12 @@ not defined in __binary_parser_concept__.
     [[Expression]       [Semantics]]
     [[`a % b`]          [Match a list of one or more repetitions of `a`
                         separated by occurrences of `b`. This is equivalent
-                        to `a >> *(b >> a)`.]]
+                        to `a >> *(omit[b] >> a)`.]]
 ]
+
+[note The list operator `a % b` omits the attribute of parser `b`. If you need `b` to contribute to the
+      result attribute choose `a >> *(b >> a)` over the list operator `a % b`.]
+
 
 [heading Attributes]
 

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     template <typename Variant, typename Expected>
     struct find_substitute
     {
-        // Get the typr from the variant that can be a substitute for Expected.
+        // Get the type from the variant that can be a substitute for Expected.
         // If none is found, just return Expected
 
         typedef Variant variant_type;
@@ -138,8 +138,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Component>
         bool call(Component const& component, mpl::false_) const
         {
+            // fix for alternative.cpp test case, FHE 2016-07-28
             return call_optional_or_variant(
-                component, spirit::traits::not_is_variant<Attribute, qi::domain>());
+                component, mpl::not_<spirit::traits::not_is_optional<Attribute, qi::domain>>());
         }
 
         template <typename Component>

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     template <typename Variant, typename Expected>
     struct find_substitute
     {
-        // Get the type from the variant that can be a substitute for Expected.
+        // Get the typr from the variant that can be a substitute for Expected.
         // If none is found, just return Expected
 
         typedef Variant variant_type;
@@ -138,9 +138,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Component>
         bool call(Component const& component, mpl::false_) const
         {
-            // fix for alternative.cpp test case, FHE 2016-07-28
             return call_optional_or_variant(
-                component, mpl::not_<spirit::traits::not_is_optional<Attribute, qi::domain>>());
+                component, spirit::traits::not_is_variant<Attribute, qi::domain>());
         }
 
         template <typename Component>


### PR DESCRIPTION
This PR adds a fix to the operator % documentation and adds a note according to that.

I'd still prefer a solution where the list operator does not implicitly omits b, because lit and omit are available. That would appeala more compliant to me.

See discussion below. You recommended to comment that. 

https://sourceforge.net/p/spirit/mailman/spirit-general/thread/OF9AB6BCBF.6A515C09-ONC1257FBE.0060CDB1-C1257FBE.0061E33E%40maxence.de/#msg35114909





