### PR TITLE
Qi: List operator not omitting second argument

### DIFF
--- a/example/qi/List.cpp
+++ b/example/qi/List.cpp
@@ -1,0 +1,67 @@
+/*=============================================================================
+Copyright (c) 2016 Frank Hein, maxence business consulting gmbh
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <iostream>
+#include <map>
+
+#include <boost/spirit/home/qi.hpp>
+
+namespace qi = boost::spirit::qi;
+
+using iterator_type = std::string::const_iterator;
+using result_type = std::string;
+
+template<typename Parser>
+void parse(const std::string message, const std::string& input, const std::string& rule, const Parser& parser) {
+    iterator_type iter = input.begin(), end = input.end();
+
+    std::vector<result_type> parsed_result;
+
+    std::cout << "-------------------------\n";
+    std::cout << message << "\n";
+    std::cout << "Rule: " << rule << std::endl;
+    std::cout << "Parsing: \"" << input << "\"\n";
+
+    bool result = qi::phrase_parse(iter, end, parser, qi::space, parsed_result);
+    if (result)
+    {
+        std::cout << "Parser succeeded.\n";
+        std::cout << "Parsed " << parsed_result.size() << " elements:";
+        for (const auto& str : parsed_result)
+            std::cout << "[" << str << "]";
+        std::cout << std::endl;
+    }
+    else
+    {
+        std::cout << "Parser failed" << std::endl;
+    }
+    if (iter == end) {
+        std::cout << "EOI reached." << std::endl;
+    }
+    else {
+        std::cout << "EOI not reached. Unparsed: \"" << std::string(iter, end) << "\"" << std::endl;
+    }
+    std::cout << "-------------------------\n";
+
+}
+
+int main() {
+
+     qi::rule < iterator_type, std::string(), qi::space_type>
+        id = (qi::alpha | qi::char_('_')) >> *(qi::alnum | qi::char_('_'));
+
+    parse("List Operator (%), list with several different 'delimiters' (not omitted) "
+        , "item1, item2, item3; item 4"
+        , "id  % qi::char_(\";,\"))"
+        , id % qi::char_(";,"));
+
+    parse("List Operator (%), list with several different 'delimiters' (omitted)."
+        , "item1, item2, item3; item 4"
+        , "id % (qi::omit[qi::char_(\";,\")]"
+        , id % qi::omit[qi::char_(";,")]);
+
+    return 0;
+}

--- a/include/boost/spirit/home/qi/operator/list.hpp
+++ b/include/boost/spirit/home/qi/operator/list.hpp
@@ -62,13 +62,16 @@ namespace boost { namespace spirit { namespace qi
         bool parse_container(F f) const
         {
             // in order to succeed we need to match at least one element 
-            if (f (left))
+            if (f(left))
                 return false;
 
             typename F::iterator_type save = f.f.first;
-            while (right.parse(f.f.first, f.f.last, f.f.context, f.f.skipper, unused)
-              && !f (left))
+            while (right.parse(f.f.first, f.f.last, f.f.context, f.f.skipper, qi::unused)
+                && left.parse(f.f.first, f.f.last, f.f.context, f.f.skipper, qi::unused))
             {
+                f.f.first = save;
+                f(right);
+                f(left);
                 save = f.f.first;
             }
 


### PR DESCRIPTION
For discussion: This is an example of the list operator not omitting the second argument's attribute.
For this one the original docu page's first part is true: `a % b` is equivalent to `a >> *(b >> a)`. 
The attribute section would need correction, because `b` would not longer get omitted.
See #208.

To retain the behaviour of the current list operator using the new one, you'd have to write `a % omit[b]`. An example file is provided to show the difference.

It feels strange that currently `a % char_('b')` is equivalent to `a % lit('b')`. Just a matter of taste? 