### PR TITLE
Tests: Fix warnings from `support/utree.cpp` test

### DIFF
--- a/test/support/utree.cpp
+++ b/test/support/utree.cpp
@@ -348,10 +348,10 @@ int main()
         BOOST_TEST((utree(1) || utree(0)) == utree(true));
         BOOST_TEST((utree(1) || utree(1)) == utree(true));
 
-        BOOST_TEST(!utree(true)   == utree(false));
-        BOOST_TEST(!utree(false)  == utree(true));
-        BOOST_TEST(!utree(1)      == utree(false));
-        BOOST_TEST(!utree(0)      == utree(true));
+        BOOST_TEST((!utree(true))   == utree(false));
+        BOOST_TEST((!utree(false))  == utree(true));
+        BOOST_TEST((!utree(1))      == utree(false));
+        BOOST_TEST((!utree(0))      == utree(true));
 
         BOOST_TEST((utree(456) + utree(123)) == utree(456 + 123));
         BOOST_TEST((utree(456) + utree(123.456)) == utree(456 + 123.456));


### PR DESCRIPTION
Fixes following warnings:
```
gcc.compile.c++ ../../../bin.v2/libs/spirit/test/support_utree-p3.test/gcc-5/debug/coverage-on/support/utree.o
In file included from ../../../boost/detail/lightweight_test.hpp:15:0,
                 from support/utree.cpp:11:
support/utree.cpp: In function ‘int main()’:
support/utree.cpp:351:35: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
         BOOST_TEST(!utree(true)   == utree(false));
                                   ^
../../../boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
support/utree.cpp:352:35: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
         BOOST_TEST(!utree(false)  == utree(true));
                                   ^
../../../boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
support/utree.cpp:353:35: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
         BOOST_TEST(!utree(1)      == utree(false));
                                   ^
../../../boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
support/utree.cpp:354:35: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
         BOOST_TEST(!utree(0)      == utree(true));
                                   ^
../../../boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
```