### PR TITLE
Tests: Fixed multiple unused variable warnings

### DIFF
--- a/test/karma/pattern4.cpp
+++ b/test/karma/pattern4.cpp
@@ -79,8 +79,6 @@ int main()
 
     // copy tests
     {
-        typedef variant<char, int, double> var_type;
-
         karma::rule<outiter_type> a, b, c, start;
 
         a = 'a';
@@ -97,8 +95,6 @@ int main()
     }
 
     {
-        typedef variant<char, int, double> var_type;
-
         karma::rule<outiter_type, space_type> a, b, c, start;
 
         a = 'a';

--- a/test/lex/dedent_handling_phoenix.cpp
+++ b/test/lex/dedent_handling_phoenix.cpp
@@ -83,7 +83,6 @@ int main()
     typedef lex::lexertl::token<std::string::iterator> token_type;
     typedef lex::lexertl::actor_lexer<token_type> base_lexer_type;
     typedef multi_tokens<base_lexer_type> lexer_type;
-    typedef lexer_type::iterator_type iterator;
 
     std::string in("AAABBC");
     std::string::iterator first(in.begin());

--- a/test/lex/token_iterpair.cpp
+++ b/test/lex/token_iterpair.cpp
@@ -108,7 +108,6 @@ test_token_ids(int const* ids, std::vector<Token> const& tokens)
         if (*ids == -1)
             return false;           // reached end of expected data
 
-        typename Token::token_value_type const& value (t.value());
         if (t.id() != static_cast<std::size_t>(*ids))        // token id must match
             return false;
         ++ids;
@@ -126,7 +125,6 @@ test_token_states(std::size_t const* states, std::vector<Token> const& tokens)
         if (*states == std::size_t(-1))
             return false;           // reached end of expected data
 
-        typename Token::token_value_type const& value (t.value());
         if (t.state() != *states)            // token state must match
             return false;
         ++states;


### PR DESCRIPTION
```
lex/token_iterpair.cpp:111:49: warning: unused variable 'value' [-Wunused-variable]
        typename Token::token_value_type const& value (t.value());
                                                ^
lex/token_iterpair.cpp:129:49: warning: unused variable 'value' [-Wunused-variable]
        typename Token::token_value_type const& value (t.value());
                                                ^
karma/pattern4.cpp: In function ‘int main()’:
karma/pattern4.cpp:82:44: warning: typedef ‘var_type’ locally defined but not used [-Wunused-local-typedefs]
         typedef variant<char, int, double> var_type;
                                            ^
karma/pattern4.cpp:100:44: warning: typedef ‘var_type’ locally defined but not used [-Wunused-local-typedefs]
         typedef variant<char, int, double> var_type;
                                            ^
lex/dedent_handling_phoenix.cpp: In function ‘int main()’:
lex/dedent_handling_phoenix.cpp:86:39: warning: typedef ‘iterator’ locally defined but not used [-Wunused-local-typedefs]
     typedef lexer_type::iterator_type iterator;
                                       ^
```