### PR TITLE
Karma.Tests: Fixed bool increment warning

### DIFF
--- a/test/karma/bool.cpp
+++ b/test/karma/bool.cpp
@@ -117,7 +117,7 @@ int main()
 
         bool b = false;
         BOOST_TEST(test("false", bool_, phoenix::ref(b)));
-        BOOST_TEST(test("true", bool_, ++phoenix::ref(b)));
+        BOOST_TEST(test("true", bool_, !phoenix::ref(b)));
     }
 #endif
 


### PR DESCRIPTION
```
warning: incrementing expression of type bool is deprecated and incompatible with C++1z [-Wdeprecated-increment-bool]
karma/bool.cpp:120:40: note: in instantiation of template class 'boost::phoenix::actor<boost::proto::exprns_::basic_expr<boost::proto::tagns_::tag::pre_inc, boost::proto::argsns_::list1<boost::phoenix::actor<boost::proto::exprns_::basic_expr<boost::proto::tagns_::tag::terminal, boost::proto::argsns_::term<boost::reference_wrapper<bool> >, 0> > >, 1> >' requested here
        BOOST_TEST(test("true", bool_, ++phoenix::ref(b)));
                                       ^
```