### PR TITLE
Qi.Tests: utree1: Fixed operator precedence warnings [clang]

### DIFF
--- a/test/qi/utree1.cpp
+++ b/test/qi/utree1.cpp
@@ -163,6 +163,11 @@ int main()
         BOOST_TEST(check(ut, "( ( \"a\" ) ( 25.5 ) \"b\" )"));
         ut.clear();
 
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-shift-op-parentheses"
+#endif
+
         BOOST_TEST(test_attr("a25.5b", r1 > r2 >> r3, ut));
         BOOST_TEST(ut.which() == utree_type::list_type);
         BOOST_TEST(check(ut, "( \"a\" ( 25.5 ) ( \"b\" ) )"));
@@ -181,6 +186,10 @@ int main()
         BOOST_TEST(test_attr("a25.5b", r3 >> r2 > char_, ut));
         BOOST_TEST(ut.which() == utree_type::list_type);
         BOOST_TEST(check(ut, "( ( \"a\" ) ( 25.5 ) \"b\" )"));
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Fixes this warnings from Clang:
```
qi/utree1.cpp:171:49: warning: overloaded operator >> has higher precedence than comparison operator [-Woverloaded-shift-op-parentheses]
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > r1, ut));
                                       ~~~~~~~~ ^ ~~
qi/utree1.cpp:171:43: note: place parentheses around the '>>' expression to silence this warning
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > r1, ut));
                                       ~~~^~~~~
qi/utree1.cpp:171:49: note: place parentheses around comparison expression to evaluate it first
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > r1, ut));
                                             ~~~^~~~
qi/utree1.cpp:181:49: warning: overloaded operator >> has higher precedence than comparison operator [-Woverloaded-shift-op-parentheses]
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > char_, ut));
                                       ~~~~~~~~ ^ ~~~~~
qi/utree1.cpp:181:43: note: place parentheses around the '>>' expression to silence this warning
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > char_, ut));
                                       ~~~^~~~~
qi/utree1.cpp:181:49: note: place parentheses around comparison expression to evaluate it first
        BOOST_TEST(test_attr("a25.5b", r3 >> r2 > char_, ut));
                                             ~~~^~~~~~~
```