### PR TITLE
Tests: Removed unused `argc` and `argv` parameters

### DIFF
--- a/test/karma/regression_real_0.cpp
+++ b/test/karma/regression_real_0.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <string>
 
-int main( int argc, char** argv )
+int main()
 {
     namespace karma = boost::spirit::karma;
     std::string output;

--- a/test/lex/regression_less_8563.cpp
+++ b/test/lex/regression_less_8563.cpp
@@ -27,7 +27,7 @@ struct test_lexer : boost::spirit::lex::lexer<BaseLexer>
     }
 };
 
-int main(int argc, char* argv[])
+int main()
 {
     typedef lex::lexertl::token<char const*> token_type;
     typedef lex::lexertl::actor_lexer<token_type> lexer_type;

--- a/test/lex/regression_static_wide_6253.cpp
+++ b/test/lex/regression_static_wide_6253.cpp
@@ -28,7 +28,7 @@ struct my_lexer : boost::spirit::lex::lexer<BaseLexer>
     lex::token_def<lex::unused_type, wchar_t> token;
 };
 
-int main(int argc, char* argv[])
+int main()
 {
     typedef lex::lexertl::token<wchar_t const*> token_type;
     typedef lex::lexertl::lexer<token_type> lexer_type;


### PR DESCRIPTION
Fixes following warnings:
```
karma_regression_real_0-p3
..\libs\spirit\test\karma\regression_real_0.cpp:15:15: warning: unused parameter 'argc' [-Wunused-parameter]
..\libs\spirit\test\karma\regression_real_0.cpp:15:28: warning: unused parameter 'argv' [-Wunused-parameter]

regression_less_8563-p3
..\libs\spirit\test\lex\regression_less_8563.cpp:30:14: warning: unused parameter 'argc' [-Wunused-parameter]
..\libs\spirit\test\lex\regression_less_8563.cpp:30:31: warning: unused parameter 'argv' [-Wunused-parameter]

regression_static_wide_6253-p3
..\libs\spirit\test\lex\regression_static_wide_6253.cpp:31:14: warning: unused parameter 'argc' [-Wunused-parameter]
..\libs\spirit\test\lex\regression_static_wide_6253.cpp:31:31: warning: unused parameter 'argv' [-Wunused-parameter]

```