### PR TITLE
Fix gcc's warning/error when building with -Wmisleading-indentation

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -278,14 +278,20 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 #define SPIRIT_NUMERIC_INNER_LOOP(z, x, data)                                 \
         if (!check_max_digits<MaxDigits>::call(count + leading_zeros)         \
             || it == last)                                                    \
+        {                                                                     \
             break;                                                            \
+        }                                                                     \
         ch = *it;                                                             \
         if (!radix_check::is_valid(ch))                                       \
+        {                                                                     \
             break;                                                            \
+        }                                                                     \
         if (!extractor::call(ch, count, val))                                 \
         {                                                                     \
             if (IgnoreOverflowDigits)                                         \
+            {                                                                 \
                 first = it;                                                   \
+            }                                                                 \
             traits::assign_to(val, attr);                                     \
             return IgnoreOverflowDigits;                                      \
         }                                                                     \
@@ -386,10 +392,14 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     ///////////////////////////////////////////////////////////////////////////
 #define SPIRIT_NUMERIC_INNER_LOOP(z, x, data)                                 \
         if (it == last)                                                       \
+        {                                                                     \
             break;                                                            \
+        }                                                                     \
         ch = *it;                                                             \
         if (!radix_check::is_valid(ch))                                       \
+        {                                                                     \
             break;                                                            \
+        }                                                                     \
         if (!extractor::call(ch, count, val))                                 \
         {                                                                     \
             traits::assign_to(val, attr);                                     \


### PR DESCRIPTION
Hi,

I am having troubles when including "boost/spirit/include/qi.hpp" with gcc 6 and -Wall -Werror turned on. gcc (wrongly) complains about misleading indentation in the macro SPIRIT_NUMERIC_INNER_LOOP. This is likely caused by the fact that we have extra indentation after each line so that the backlslashes are properly aligned, and the macro is eventually putting this on a single line. Anyway, an easy fix is to use braces around all block of code.

Ok for the merge ?

Cheers,
Romain