### PR TITLE
Fixes #12599: real_generator failure

### DIFF
--- a/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
@@ -237,6 +237,48 @@ namespace boost { namespace spirit { namespace traits
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable/* = void*/>
+    struct is_subnormal
+    {
+        static bool call(T)
+        {
+            return false;
+        }
+    };
+
+    template <>
+    struct is_subnormal<float>
+    {
+        static bool call(float n)
+        {
+            return (math::fpclassify)(n) == FP_SUBNORMAL;
+        }
+    };
+
+    template <>
+    struct is_subnormal<double>
+    {
+        static bool call(double n)
+        {
+            return (math::fpclassify)(n) == FP_SUBNORMAL;
+        }
+    };
+
+    template <>
+    struct is_subnormal<long double>
+    {
+        static bool call(long double n)
+        {
+            return (math::fpclassify)(n) == FP_SUBNORMAL;
+        }
+    };
+
+    template <typename T>
+    inline bool test_subnormal(T n)
+    {
+        return is_subnormal<T>::call(n);
+    }
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename Enable/* = void*/>
     struct is_nan
     {
         static bool call(T n)

--- a/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
@@ -95,7 +95,7 @@ namespace boost { namespace spirit { namespace karma
             using namespace std;
 
             U dim = 0;
-            if (0 == (Policies::fmtflags::fixed & flags) && !traits::test_zero(n))
+            if (0 == (Policies::fmtflags::fixed & flags) && !traits::test_zero(n) && !traits::test_subnormal(n))
             {
                 dim = log10(n);
                 if (dim > 0) 

--- a/include/boost/spirit/home/support/numeric_traits.hpp
+++ b/include/boost/spirit/home/support/numeric_traits.hpp
@@ -108,6 +108,9 @@ namespace boost { namespace spirit { namespace traits
     struct is_zero;
 
     template <typename T, typename Enable = void>
+    struct is_subnormal;
+
+    template <typename T, typename Enable = void>
     struct pow10_helper;
 
     template <typename T, typename Enable = void>


### PR DESCRIPTION
```
#define DBL_MAX_10_EXP 308 // comment this line to get a stack overflow instead of an assertion
#include <boost/spirit/include/karma.hpp>
#include <iostream>
#include <iterator>
#include <string>

int main() {
  std::string s;
  boost::spirit::karma::generate(std::back_insert_iterator<std::string>(s), 1e-309); // any subnormal float would do
  std::cout << s << std::endl;
  return 0;
}
```