### PR TITLE
Fix clang unused paramter warning.

### DIFF
--- a/include/boost/spirit/home/karma/auxiliary/lazy.hpp
+++ b/include/boost/spirit/home/karma/auxiliary/lazy.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace spirit { namespace karma
           , typename Delimiter, typename Attribute>
         bool lazy_generate_impl(Generator const& g, OutputIterator& sink
           , Context& context, Delimiter const& delim
-          , Attribute const& attr, mpl::true_)
+          , Attribute const& /* attr */, mpl::true_)
         {
             // If DeducedAuto is false (semantic actions is present), the
             // component's attribute is unused.

--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -178,7 +178,7 @@ namespace boost { namespace spirit { namespace karma
         }
 
         template <typename Auto, typename Expr>
-        static void define(rule& lhs, Expr const& expr, mpl::false_)
+        static void define(rule& /* lhs */, Expr const& /* expr */, mpl::false_)
         {
             // Report invalid expression error as early as possible.
             // If you got an error_invalid_expression error message here,


### PR DESCRIPTION
This should fix some small warnings detected by clang 3.9.0 with -Wall -Wextra -Werror.