### PR TITLE
Fix float parser missing optimization

### DIFF
--- a/include/boost/spirit/home/support/detail/pow10.hpp
+++ b/include/boost/spirit/home/support/detail/pow10.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #endif
 
+#include <cfloat>
 #include <boost/config/no_tr1/cmath.hpp>
 #include <boost/limits.hpp>
 #include <boost/spirit/home/support/unused.hpp>


### PR DESCRIPTION
Fixes [Ticket #12642](https://svn.boost.org/trac/boost/ticket/12642). The optimized pow10 function would not be used unless cfloat had already been externally included.