### PR TITLE
Fix warning "typedef 'iterator_t' locally defined but not used" in classic/error_handling/exceptions.hpp

### DIFF
--- a/include/boost/spirit/home/classic/error_handling/exceptions.hpp
+++ b/include/boost/spirit/home/classic/error_handling/exceptions.hpp
@@ -140,7 +140,6 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         parse(ScannerT const& scan) const
         {
             typedef typename parser_result<ParserT, ScannerT>::type result_t;
-            typedef typename ScannerT::iterator_t iterator_t;
 
             result_t hit = this->subject().parse(scan);
             if (!hit)


### PR DESCRIPTION
Hi,

Here is a small warning fix in classic/error_handling/exceptions.hpp when using gcc 4.9 and -Wall -Wextra:

boost/spirit/home/classic/error_handling/exceptions.hpp:143:51: warning: typedef 'iterator_t' locally defined but not used [-Wunused-local-typedefs]
             typedef typename ScannerT::iterator_t iterator_t;

Ok for the trunk ?

Cheers,
Romain
