### PR TITLE
fix name hiding bug #12497

### DIFF
--- a/include/boost/spirit/home/qi/detail/construct.hpp
+++ b/include/boost/spirit/home/qi/detail/construct.hpp
@@ -143,20 +143,20 @@ namespace boost { namespace spirit { namespace traits
 
 #ifdef BOOST_HAS_LONG_LONG
     template <typename Iterator>
-    struct assign_to_attribute_from_iterators<boost::long_long_type, Iterator>
+    struct assign_to_attribute_from_iterators<::boost::long_long_type, Iterator>
     {
         static void
-        call(Iterator const& first, Iterator const& last, boost::long_long_type& attr)
+        call(Iterator const& first, Iterator const& last, ::boost::long_long_type& attr)
         {
             Iterator first_ = first;
             qi::parse(first_, last, long_long_type(), attr);
         }
     };
     template <typename Iterator>
-    struct assign_to_attribute_from_iterators<boost::ulong_long_type, Iterator>
+    struct assign_to_attribute_from_iterators<::boost::ulong_long_type, Iterator>
     {
         static void
-        call(Iterator const& first, Iterator const& last, boost::ulong_long_type& attr)
+        call(Iterator const& first, Iterator const& last, ::boost::ulong_long_type& attr)
         {
             Iterator first_ = first;
             qi::parse(first_, last, ulong_long_type(), attr);


### PR DESCRIPTION
::boost::long_long_type was hidden by ::boost::spirit::long_long_type silently making the specialization inactive

See also https://svn.boost.org/trac/boost/ticket/12497, thanks @K-ballo for the leg-work there, that made it much easier to spot.