### PR TITLE
std::logic_error - Initialization Order Fiasco

### DIFF
--- a/include/boost/spirit/home/x3/core/parser.hpp
+++ b/include/boost/spirit/home/x3/core/parser.hpp
@@ -18,6 +18,7 @@
 #include <boost/spirit/home/x3/support/context.hpp>
 #include <boost/spirit/home/x3/support/traits/has_attribute.hpp>
 #include <boost/spirit/home/x3/support/utility/sfinae.hpp>
+#include <boost/assert.hpp>
 #include <string>
 
 #if !defined(BOOST_SPIRIT_X3_NO_RTTI)
@@ -63,6 +64,21 @@ namespace boost { namespace spirit { namespace x3
         }
     };
 
+    namespace detail {
+        template <typename Parser>
+        static void assert_initialized_rule(Parser const& p) {
+            // Assert that we are not copying an unitialized static rule. If
+            // the static is in another TU, it may be initialized after we copy
+            // it. If so, its name member will be nullptr.
+            //
+            // Rather than hardcoding behaviour for rule-type subject parsers,
+            // we simply allow get_info<> to do the check in debug builds.
+#ifndef NDEBUG
+            what(p); // note: allows get_info<> to diagnose the issue
+#endif
+        }
+    }
+
     struct unary_category;
     struct binary_category;
 
@@ -74,7 +90,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_action = Subject::has_action;
 
         unary_parser(Subject const& subject)
-            : subject(subject) {}
+            : subject(subject) { detail::assert_initialized_rule(subject); }
 
         unary_parser const& get_unary() const { return *this; }
 
@@ -91,7 +107,11 @@ namespace boost { namespace spirit { namespace x3
             left_type::has_action || right_type::has_action;
 
         binary_parser(Left const& left, Right const& right)
-            : left(left), right(right) {}
+            : left(left), right(right)
+        {
+            detail::assert_initialized_rule(left);
+            detail::assert_initialized_rule(right);
+        }
 
         binary_parser const& get_binary() const { return *this; }
 

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -134,7 +134,8 @@ namespace boost { namespace spirit { namespace x3
         typedef std::string result_type;
         std::string operator()(T const& r) const
         {
-            return r.name;
+            BOOST_ASSERT_MSG(r.name, "uninitialized rule"); // static initialization order fiasco
+            return r.name? r.name : "uninitialized";
         }
     };
 


### PR DESCRIPTION
(reported by Exagon http://stackoverflow.com/a/41785268/85371)

Due to [Static Initialization Order Fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order) sometimes X3 parsing aborts with a `std::logic_error`. The cause is unitialized `rule::name` fields.

It is clear that the design of Spirit X3 has accounted for static initialization order in that the `parse_rule` specializations contain function-local instances that defeat the issue.

However, the rule name initialization lives inside the namespace-scope static variable and its initialization is not guarded. This is probably an oversight.

Unfortunately I don't think there is a clean/elegant solution that will not introduce more function-local statics (with their syntax and runtime overhead).

This PR adds diagnostics to detect when a rule was copied before its initialization. The commit comments and code detail the approach.