### PR TITLE
Fix dangling refs in debug of call_rule_defintion`

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -328,9 +328,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
              // traits::post_transform when, for example,
              // ActualAttribute is a recursive variant).
 #if defined(BOOST_SPIRIT_X3_DEBUG)
-                typedef typename make_attribute::type dbg_attribute_type;
-                context_debug<Iterator, dbg_attribute_type>
-                dbg(rule_name, first, last, dbg_attribute_type(attr_), ok_parse);
+                context_debug<Iterator, transform_attr>
+                dbg(rule_name, first, last, attr_, ok_parse);
 #endif
                 ok_parse = parse_rhs(rhs, first, last, context, attr_, attr_
                    , mpl::bool_


### PR DESCRIPTION
There is an issue in `call_rule_definition` where it tries to print the
attribute before transformation (via `context_debug` -> `simple_trace`).

However, it breaks if the made attribute type doesn't match the actual
attribute type. In this case, it makes `context_debug` store a dangling
reference to a temporary converted attribute, leading to Undefined
Behaviour.

See also https://stackoverflow.com/a/43688320/85371
