### PR TITLE
Update PGI C++ compiler support

### DIFF
--- a/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
@@ -98,11 +98,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         };
 
     public:
-        functor()
-#if defined(__PGI)
-          : eof()
-#endif 
-        {}
+        functor() {}
 
 #if BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
         // somehow VC7.1 needs this (meaningless) assignment operator


### PR DESCRIPTION
Remove a PGI-specific workaround in the functor constructor.  The workaround was necessary several years ago to get class functor to compiler with PGI, but the workaround now causes compilation errors.