### PR TITLE
X3: Support recursive rules that modify the context

### DIFF
--- a/include/boost/spirit/home/x3/support/subcontext.hpp
+++ b/include/boost/spirit/home/x3/support/subcontext.hpp
@@ -24,13 +24,6 @@ namespace boost { namespace spirit { namespace x3
         template <typename Context>
         subcontext(Context const& /*context*/)
         {}
-        
-        template <typename ID_>
-        unused_type
-        get(ID_) const
-        {
-            return unused;
-        }
     };
 
     template <typename T>
@@ -43,10 +36,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Context>
         subcontext(Context const& context)
-          : context_type(x3::get<typename T::first_type>(context))
+          : context_type{x3::get<typename T::first_type>(context), unused}
         {}
-
-        using context_type::get;
     };
 
     template <typename T, typename... Tail>
@@ -54,24 +45,22 @@ namespace boost { namespace spirit { namespace x3
       : subcontext<Tail...>
       , context<
             typename T::first_type, typename T::second_type
-          , subcontext<Tail...>
+          , subcontext<Tail...> const&
         >
     {
         typedef subcontext<Tail...> base_type;
         typedef context<
             typename T::first_type, typename T::second_type
-          , base_type
+          , base_type const&
         > context_type;
 
         template <typename Context>
         subcontext(Context const& context)
           : base_type(context)
-          , context_type(
+          , context_type{
                 x3::get<typename T::first_type>(context)
-              , *static_cast<base_type*>(this))
+              , *static_cast<base_type*>(this)}
         {}
-
-        using context_type::get;
     };
 
 }}}

--- a/include/boost/spirit/home/x3/support/unused.hpp
+++ b/include/boost/spirit/home/x3/support/unused.hpp
@@ -56,14 +56,6 @@ namespace boost { namespace spirit { namespace x3
         {
             return *this;
         }
-
-        // unused_type can also masquerade as an empty context (see context.hpp)
-
-        template <typename ID>
-        unused_type get(ID) const
-        {
-            return {};
-        }
     };
 
     auto const unused = unused_type{};


### PR DESCRIPTION
make_context() always pushed a new node to the context list when the context is modified (e.g., for "with", "skip", or "no_skip" directives). If such directives are used in recursive rules, this leads to an infinite loop of template instantiations, effectively limiting the use of recursive rules in x3.

To fix this, we first check if the tag for the new node is already contained in the context. If we find the tag, we remove the corresponding existing node from the context before pushing the new node with the requested tag.

In order to remove a context entry, we have to rebuild all context nodes up to this entry. We can reuse (i.e. link to) the tail of the old context after this entry.

In order to resolve life-time issues of newly created context nodes we added an aggregating implementation of struct context.