### PR TITLE
simplify with directive

### DIFF
--- a/include/boost/spirit/home/x3/directive/with.hpp
+++ b/include/boost/spirit/home/x3/directive/with.hpp
@@ -15,21 +15,40 @@ namespace boost { namespace spirit { namespace x3
     ///////////////////////////////////////////////////////////////////////////
     // with directive injects a value into the context prior to parsing.
     ///////////////////////////////////////////////////////////////////////////
+    template <typename Subject, typename Derived, typename T>
+    struct with_value_holder
+      : unary_parser<Subject, Derived>
+    {
+        typedef unary_parser<Subject, Derived> base_type;
+        mutable T val;
+        with_value_holder(Subject const& subject, T&& val)
+          : base_type(subject)
+          , val(std::forward<T>(val)) {}
+    };
+    
+    template <typename Subject, typename Derived, typename T>
+    struct with_value_holder<Subject, Derived, T&>
+      : unary_parser<Subject, Derived>
+    {
+        typedef unary_parser<Subject, Derived> base_type;
+        T& val;
+        with_value_holder(Subject const& subject, T& val)
+          : base_type(subject)
+          , val(val) {}
+    };
+
     template <typename Subject, typename ID, typename T>
     struct with_directive
-      : unary_parser<Subject, with_directive<Subject, ID, T>>
+      : with_value_holder<Subject, with_directive<Subject, ID, T>, T>
     {
-        typedef unary_parser<Subject, with_directive<Subject, ID, T>> base_type;
+        typedef with_value_holder<Subject, with_directive<Subject, ID, T>, T> base_type;
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
         typedef Subject subject_type;
 
-        T val;
-
         with_directive(Subject const& subject, T&& val)
-          : base_type(subject)
-          , val(std::forward<T>(val)) {}
+          : base_type(subject, std::forward<T>(val)) {}
 
         template <typename Iterator, typename Context
           , typename RContext, typename Attribute>

--- a/test/x3/with.cpp
+++ b/test/x3/with.cpp
@@ -56,5 +56,46 @@ main()
         BOOST_TEST(val == 2);
     }
 
+    { // injecting non-const lvalue into the context
+        int val = 0;
+        auto const r  = int_[([](auto& ctx){
+            x3::get<my_tag>(ctx) += x3::_attr(ctx);
+        })];
+        BOOST_TEST(test("123,456", with<my_tag>(val)[r % ',']));
+        BOOST_TEST(579 == val);
+    }
+
+    { // injecting const/non-const lvalue and rvalue into the context
+        struct functor {
+            int operator()(int& val) {
+                return val * 10; // non-const ref returns 10 * injected val
+            }
+            int operator()(int const& val) {
+                return val; // const ref returns injected val
+            }
+        };
+
+        auto f = [](auto& ctx){
+            x3::_val(ctx) = x3::_attr(ctx) + functor()(x3::get<my_tag>(ctx));
+        };
+        auto const r = rule<struct my_rule_class2, int>() = int_[f];
+
+        int attr = 0;
+        int const cval = 10;
+        BOOST_TEST(test_attr("5", with<my_tag>(cval)[r], attr));
+        BOOST_TEST(15 == attr); // x3::get returns const ref to cval
+
+        attr = 0;
+        int val = 10;
+        BOOST_TEST(test_attr("5", with<my_tag>(val)[r], attr));
+        BOOST_TEST(105 == attr); // x3::get returns ref to val
+
+        attr = 0;
+
+        BOOST_TEST(test_attr("5", with<my_tag>(10)[r], attr));
+        // x3::get returns const ref to member variable of with_directive
+        BOOST_TEST(15 == attr);
+    }
+
     return boost::report_errors();
 }

--- a/test/x3/with.cpp
+++ b/test/x3/with.cpp
@@ -65,6 +65,19 @@ main()
         BOOST_TEST(579 == val);
     }
 
+    { // injecting rvalue into the context
+        auto const r1 = int_[([](auto& ctx){
+            x3::get<my_tag>(ctx) += x3::_attr(ctx);
+        })];
+        auto const r2 = rule<struct my_rvalue_rule_class, int>() =
+            x3::lit('(') >> (r1 % ',') >> x3::lit(')')[([](auto& ctx){
+                x3::_val(ctx) = x3::get<my_tag>(ctx);
+            })];
+        int attr = 0;
+        BOOST_TEST(test_attr("(1,2,3)", with<my_tag>(100)[r2], attr));
+        BOOST_TEST(106 == attr);
+    }
+
     { // injecting const/non-const lvalue and rvalue into the context
         struct functor {
             int operator()(int& val) {
@@ -93,8 +106,8 @@ main()
         attr = 0;
 
         BOOST_TEST(test_attr("5", with<my_tag>(10)[r], attr));
-        // x3::get returns const ref to member variable of with_directive
-        BOOST_TEST(15 == attr);
+        // x3::get returns ref to member variable of with_directive
+        BOOST_TEST(105 == attr);
     }
 
     return boost::report_errors();


### PR DESCRIPTION
1. when used as x3::with<ID>(x), where x is an lvalue, we inject an lvalue reference of x to the context.
2. when used as x3::with<ID>(x), where x is a const lvalue, we inject a const lvalue reference of x to the context.
3. when used as x3::with<ID>(x), where x is an rvalue, we move the rvalue to the member of with_directive and inject an lvalue reference of that member to the context.
4. No copy is applied; std::ref can still be used but not needed.
5. remove unused with_context