### PR TITLE
Context& -> Context const&

### DIFF
--- a/include/boost/spirit/home/x3/binary/binary.hpp
+++ b/include/boost/spirit/home/x3/binary/binary.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context& context, unused_type, Attribute& attr_param) const
+          , Context const& context, unused_type, Attribute& attr_param) const
         {
             x3::skip_over(first, last, context);
 
@@ -69,7 +69,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context& context, unused_type, Attribute& attr_param) const
+          , Context const& context, unused_type, Attribute& attr_param) const
         {
             x3::skip_over(first, last, context);
 

--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace spirit { namespace x3
           : from(from_), to(to_) {}
 
         template <typename Char, typename Context>
-        bool test(Char ch_, Context& context) const
+        bool test(Char ch_, Context const& context) const
         {
 
             char_type ch = char_type(ch_);  // optimize for token based parsing

--- a/include/boost/spirit/home/x3/directive/confix.hpp
+++ b/include/boost/spirit/home/x3/directive/confix.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace spirit { namespace x3
                  , typename RContext, typename Attribute>
         bool parse(
             Iterator& first, Iterator const& last
-            , Context& context, RContext& rcontext, Attribute& attr) const
+            , Context const& context, RContext& rcontext, Attribute& attr) const
         {
             Iterator save = first;
 

--- a/include/boost/spirit/home/x3/numeric/bool.hpp
+++ b/include/boost/spirit/home/x3/numeric/bool.hpp
@@ -70,7 +70,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context>
         bool parse_main(Iterator& first, Iterator const& last
-          , Context& context, T& attr) const
+          , Context const& context, T& attr) const
         {
             x3::skip_over(first, last, context);
             return (n_ && policies.parse_true(first, last, attr, get_case_compare<encoding>(context)))
@@ -79,7 +79,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context>
         bool parse(Iterator& first, Iterator const& last
-          , Context& context, unused_type, T& attr) const
+          , Context const& context, unused_type, T& attr) const
         {
             return parse_main(first, last, context, attr);
         }

--- a/include/boost/spirit/home/x3/numeric/real.hpp
+++ b/include/boost/spirit/home/x3/numeric/real.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context>
         bool parse(Iterator& first, Iterator const& last
-          , Context& context, unused_type, T& attr_) const
+          , Context const& context, unused_type, T& attr_) const
         {
             x3::skip_over(first, last, context);
             return extract_real<T, RealPolicies>::parse(first, last, attr_, policies);
@@ -36,7 +36,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context& context, unused_type, Attribute& attr_param) const
+          , Context const& context, unused_type, Attribute& attr_param) const
         {
             // this case is called when Attribute is not T
             T attr_;


### PR DESCRIPTION
fix parsers like x3::skip(x3::space)[x3::double_] compile problem

x3 directives like skip, with and no_case create an rvalue context therefore cannot bind with Context&. Besides, we are not really changing the context in these places (all the other places use Context const& already). I think using const& is fine here. 

The example seems rare, but it could be a blocking issue if we want to use these directives on a generic parser. 