### PR TITLE
support nothrow expect

### DIFF
--- a/doc/x3/quick_reference.qbk
+++ b/doc/x3/quick_reference.qbk
@@ -224,7 +224,8 @@ pages and pages of reference documentation.
     [[__x3_sequence__]      [`tuple<A, B>`]             [Sequence. Parse `a` followed by `b`]]
     [[__x3_expect__]        [`tuple<A, B>`]             [Expect. Parse `a` followed by `b`. `b` is
                                                         expected to match when `a` matches, otherwise,
-                                                        an `expectation_failure` is thrown.]]
+                                                        the whole parser fails. The failure can be
+                                                        handled by error handler, such as on_error().]]
     [[__x3_difference__]    [`A`]                       [Difference. Parse `a` but not `b`]]
     [[__x3_list__]          [`vector<A>`]               [List. Parse `a` delimited `b` one or more times]]
 ]

--- a/include/boost/spirit/home/x3/auxiliary/guard.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/guard.hpp
@@ -36,28 +36,30 @@ namespace boost { namespace spirit { namespace x3
         {
             for (;;)
             {
-                try
+                Iterator i = first;
+                if (this->subject.parse(i, last, context, rcontext, attr))
                 {
-                    Iterator i = first;
-                    bool r = this->subject.parse(i, last, context, rcontext, attr);
-                    if (r)
-                        first = i;
-                    return r;
+                    first = i;
+                    return true;
                 }
-                catch (expectation_failure<Iterator> const& x)
+                else if (has_expectation_failure(context))
                 {
-                    switch (handler(first, last, x, context))
+                    auto const& failure = 
+                        get_expectation_failure(first, context);
+                    switch (handler(first, last, failure, context))
                     {
                         case error_handler_result::fail:
+                            reset_expectation_failure(context);
                             return false;
                         case error_handler_result::retry:
                             continue;
                         case error_handler_result::accept:
                             return true;
                         case error_handler_result::rethrow:
-                            throw;
+                            return false;
                     }
                 }
+                return false;
             }
             return false;
         }

--- a/include/boost/spirit/home/x3/core/proxy.hpp
+++ b/include/boost/spirit/home/x3/core/proxy.hpp
@@ -10,6 +10,7 @@
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/core/detail/parse_into_container.hpp>
 #include <boost/spirit/home/x3/support/traits/attribute_category.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -29,7 +30,7 @@ namespace boost { namespace spirit { namespace x3
           , Context const& context, RuleContext& rcontext, Attribute& attr, Category) const
         {
             this->subject.parse(first, last, context, rcontext, attr);
-            return true;
+            return !has_expectation_failure(context);
         }
 
         // Main entry point.

--- a/include/boost/spirit/home/x3/directive/matches.hpp
+++ b/include/boost/spirit/home/x3/directive/matches.hpp
@@ -11,6 +11,7 @@
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/support/traits/move_to.hpp>
 #include <boost/spirit/home/x3/support/unused.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -30,6 +31,8 @@ namespace boost { namespace spirit { namespace x3
         {
             bool const result = this->subject.parse(
                     first, last, context, rcontext, unused);
+            if (has_expectation_failure(context))
+                return false;
             traits::move_to(result, attr);
             return true;
         }

--- a/include/boost/spirit/home/x3/directive/repeat.hpp
+++ b/include/boost/spirit/home/x3/directive/repeat.hpp
@@ -13,6 +13,7 @@
 #include <boost/function_types/parameter_types.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/operator/kleene.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3 { namespace detail
 {
@@ -85,7 +86,7 @@ namespace boost { namespace spirit { namespace x3
                       this->subject, first, last, context, rcontext, attr))
                     break;
             }
-            return true;
+            return !has_expectation_failure(context);
         }
 
         RepeatCountLimit repeat_limit;

--- a/include/boost/spirit/home/x3/directive/seek.hpp
+++ b/include/boost/spirit/home/x3/directive/seek.hpp
@@ -9,6 +9,7 @@
 #define BOOST_SPIRIT_X3_SEEK_APRIL_13_2014_1920PM
 
 #include <boost/spirit/home/x3/core/parser.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -35,6 +36,10 @@ namespace boost { namespace spirit { namespace x3
                 {
                     first = current;
                     return true;
+                }
+                else if (has_expectation_failure(context))
+                {
+                    return false;
                 }
             }
 

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -235,25 +235,29 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         {
             for (;;)
             {
-                try
+                if (parse_rhs_main(
+                    rhs, first, last, context, rcontext, attr, mpl::false_()))
                 {
-                    return parse_rhs_main(
-                        rhs, first, last, context, rcontext, attr, mpl::false_());
+                    return true;
                 }
-                catch (expectation_failure<Iterator> const& x)
+                else if(has_expectation_failure(context))
                 {
-                    switch (ID().on_error(first, last, x, context))
+                    auto const& failure =
+                        get_expectation_failure(first, context);
+                    switch (ID().on_error(first, last, failure, context))
                     {
                         case error_handler_result::fail:
+                            reset_expectation_failure(context);
                             return false;
                         case error_handler_result::retry:
                             continue;
                         case error_handler_result::accept:
                             return true;
                         case error_handler_result::rethrow:
-                            throw;
+                            return false;
                     }
                 }
+                return false;
             }
         }
 

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -29,9 +29,9 @@ namespace boost { namespace spirit { namespace x3
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr)
     {
-        static_assert(!is_same<decltype(get<ID>(context)), unused_type>::value,
+        static_assert(!is_same<decltype(x3::get<ID>(context)), unused_type>::value,
             "BOOST_SPIRIT_DEFINE undefined for this rule.");
-        return get<ID>(context).parse(first, last, context, unused, attr);
+        return x3::get<ID>(context).parse(first, last, context, unused, attr);
     }
 
     template <typename ID, typename RHS, typename Attribute, bool force_attribute_>

--- a/include/boost/spirit/home/x3/operator/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/alternative.hpp
@@ -10,6 +10,7 @@
 #include <boost/spirit/home/x3/support/traits/attribute_of.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/operator/detail/alternative.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -27,7 +28,8 @@ namespace boost { namespace spirit { namespace x3
           , Context const& context, RContext& rcontext, unused_type) const
         {
             return this->left.parse(first, last, context, rcontext, unused)
-               || this->right.parse(first, last, context, rcontext, unused);
+               || (!has_expectation_failure(context)
+                   && this->right.parse(first, last, context, rcontext, unused));
         }
 
         template <typename Iterator, typename Context
@@ -37,7 +39,8 @@ namespace boost { namespace spirit { namespace x3
           , Context const& context, RContext& rcontext, Attribute& attr) const
         {
             return detail::parse_alternative(this->left, first, last, context, rcontext, attr)
-               || detail::parse_alternative(this->right, first, last, context, rcontext, attr);
+               || (!has_expectation_failure(context)
+                    && detail::parse_alternative(this->right, first, last, context, rcontext, attr));
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/difference.hpp
+++ b/include/boost/spirit/home/x3/operator/difference.hpp
@@ -10,6 +10,7 @@
 #include <boost/spirit/home/x3/support/traits/attribute_of.hpp>
 #include <boost/spirit/home/x3/support/traits/has_attribute.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -29,7 +30,8 @@ namespace boost { namespace spirit { namespace x3
         {
             // Try Right first
             Iterator start = first;
-            if (this->right.parse(first, last, context, rcontext, unused))
+            if (this->right.parse(first, last, context, rcontext, unused)
+              || has_expectation_failure(context))
             {
                 // Right succeeds, we fail.
                 first = start;

--- a/include/boost/spirit/home/x3/operator/kleene.hpp
+++ b/include/boost/spirit/home/x3/operator/kleene.hpp
@@ -12,6 +12,7 @@
 #include <boost/spirit/home/x3/support/traits/container_traits.hpp>
 #include <boost/spirit/home/x3/support/traits/attribute_of.hpp>
 #include <boost/spirit/home/x3/core/detail/parse_into_container.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -32,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
             while (detail::parse_into_container(
                 this->subject, first, last, context, rcontext, attr))
                 ;
-            return true;
+            return !has_expectation_failure(context);
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/list.hpp
+++ b/include/boost/spirit/home/x3/operator/list.hpp
@@ -12,6 +12,7 @@
 #include <boost/spirit/home/x3/support/traits/container_traits.hpp>
 #include <boost/spirit/home/x3/support/traits/attribute_of.hpp>
 #include <boost/spirit/home/x3/core/detail/parse_into_container.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -44,7 +45,7 @@ namespace boost { namespace spirit { namespace x3
             }
 
             first = save;
-            return true;
+            return !has_expectation_failure(context);
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/not_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/not_predicate.hpp
@@ -8,6 +8,7 @@
 #define SPIRIT_NOT_PREDICATE_MARCH_23_2007_0618PM
 
 #include <boost/spirit/home/x3/core/parser.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -28,7 +29,8 @@ namespace boost { namespace spirit { namespace x3
           , Context const& context, RContext& rcontext, Attribute& /*attr*/) const
         {
             Iterator i = first;
-            return !this->subject.parse(i, last, context, rcontext, unused);
+            return !this->subject.parse(i, last, context, rcontext, unused)
+              && !has_expectation_failure(context);
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/optional.hpp
+++ b/include/boost/spirit/home/x3/operator/optional.hpp
@@ -14,6 +14,7 @@
 #include <boost/spirit/home/x3/support/traits/move_to.hpp>
 #include <boost/spirit/home/x3/support/traits/optional_traits.hpp>
 #include <boost/spirit/home/x3/support/traits/attribute_category.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -37,7 +38,7 @@ namespace boost { namespace spirit { namespace x3
         {
             detail::parse_into_container(
                 this->subject, first, last, context, rcontext, attr);
-            return true;
+            return !has_expectation_failure(context);
         }
 
         // Attribute is an optional
@@ -59,7 +60,7 @@ namespace boost { namespace spirit { namespace x3
                 // assign the parsed value into our attribute
                 x3::traits::move_to(val, attr);
             }
-            return true;
+            return !has_expectation_failure(context);
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/plus.hpp
+++ b/include/boost/spirit/home/x3/operator/plus.hpp
@@ -12,6 +12,7 @@
 #include <boost/spirit/home/x3/support/traits/container_traits.hpp>
 #include <boost/spirit/home/x3/support/traits/attribute_of.hpp>
 #include <boost/spirit/home/x3/core/detail/parse_into_container.hpp>
+#include <boost/spirit/home/x3/directive/expect.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
@@ -36,7 +37,7 @@ namespace boost { namespace spirit { namespace x3
             while (detail::parse_into_container(
                 this->subject, first, last, context, rcontext, attr))
                 ;
-            return true;
+            return !has_expectation_failure(context);
         }
     };
 

--- a/test/x3/expect.cpp
+++ b/test/x3/expect.cpp
@@ -8,6 +8,8 @@
 #include <boost/spirit/home/x3.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
+#include <boost/spirit/home/x3/binary.hpp>
+#include <boost/spirit/home/x3/directive/with.hpp>
 
 #include <string>
 #include <iostream>
@@ -22,52 +24,45 @@ main()
     using boost::spirit::x3::expect;
     using spirit_test::test;
     using spirit_test::test_attr;
-    using boost::spirit::x3::expectation_failure;
+    using boost::spirit::x3::lexeme;
+    using boost::spirit::x3::no_case;
+    using boost::spirit::x3::no_skip;
+    using boost::spirit::x3::omit;
+    using boost::spirit::x3::raw;
+    using boost::spirit::x3::skip;
+    using boost::spirit::x3::seek;
+    using boost::spirit::x3::repeat;
+    using boost::spirit::x3::matches;
+    using boost::spirit::x3::eps;
+    using boost::spirit::x3::eoi;
+    using boost::spirit::x3::eol;
+    using boost::spirit::x3::attr;
+    using boost::spirit::x3::dword;
+    using boost::spirit::x3::int_;
+    using boost::spirit::x3::symbols;
+    using boost::spirit::x3::confix;
+    using boost::spirit::x3::with;
 
     {
-        try
-        {
-            BOOST_TEST((test("aa", char_ >> expect[char_])));
-            BOOST_TEST((test("aaa", char_ >> expect[char_ >> char_('a')])));
-            BOOST_TEST((test("xi", char_('x') >> expect[char_('i')])));
-            BOOST_TEST((!test("xi", char_('y') >> expect[char_('o')]))); // should not throw!
-            BOOST_TEST((test("xin", char_('x') >> expect[char_('i') >> char_('n')])));
-            BOOST_TEST((!test("xi", char_('x') >> expect[char_('o')])));
-        }
-        catch (expectation_failure<char const*> const& x)
-        {
-            std::cout << "expected: " << x.which();
-            std::cout << " got: \"" << x.where() << '"' << std::endl;
-        }
+        BOOST_TEST((test("aa", char_ >> expect[char_])));
+        BOOST_TEST((test("aaa", char_ >> expect[char_ >> char_('a')])));
+        BOOST_TEST((test("xi", char_('x') >> expect[char_('i')])));
+        BOOST_TEST((!test("xi", char_('y') >> expect[char_('o')]))); // should not throw!
+        BOOST_TEST((test("xin", char_('x') >> expect[char_('i') >> char_('n')])));
+        BOOST_TEST((!test("xi", char_('x') >> expect[char_('o')])));
     }
 
     {
-        try
-        {
-            BOOST_TEST((test("aa", char_ > char_)));
-            BOOST_TEST((test("aaa", char_ > char_ > char_('a'))));
-            BOOST_TEST((test("xi", char_('x') > char_('i'))));
-            BOOST_TEST((!test("xi", char_('y') > char_('o')))); // should not throw!
-            BOOST_TEST((test("xin", char_('x') > char_('i') > char_('n'))));
-            BOOST_TEST((!test("xi", char_('x') > char_('o'))));
-        }
-        catch (expectation_failure<char const*> const& x)
-        {
-            std::cout << "expected: " << x.which();
-            std::cout << " got: \"" << x.where() << '"' << std::endl;
-        }
+        BOOST_TEST((test("aa", char_ > char_)));
+        BOOST_TEST((test("aaa", char_ > char_ > char_('a'))));
+        BOOST_TEST((test("xi", char_('x') > char_('i'))));
+        BOOST_TEST((!test("xi", char_('y') > char_('o')))); // should not throw!
+        BOOST_TEST((test("xin", char_('x') > char_('i') > char_('n'))));
+        BOOST_TEST((!test("xi", char_('x') > char_('o'))));
     }
 
     {
-        try
-        {
-            BOOST_TEST((!test("ay:a", char_ > char_('x') >> ':' > 'a')));
-        }
-        catch (expectation_failure<char const*> const& x)
-        {
-            std::cout << "expected: " << x.which();
-            std::cout << " got: \"" << x.where() << '"' << std::endl;
-        }
+        BOOST_TEST((!test("ay:a", char_ > char_('x') >> ':' > 'a')));
     }
 
     { // Test that attributes with > (sequences) work just like >> (sequences)
@@ -104,29 +99,168 @@ main()
     }
 
     {
-        try
-        {
-            BOOST_TEST((test(" a a", char_ > char_, space)));
-            BOOST_TEST((test(" x i", char_('x') > char_('i'), space)));
-            BOOST_TEST((!test(" x i", char_('x') > char_('o'), space)));
-        }
-        catch (expectation_failure<char const*> const& x)
-        {
-            std::cout << "expected: " << x.which();
-            std::cout << " got: \"" << x.where() << '"' << std::endl;
-        }
+        BOOST_TEST((test(" a a", char_ > char_, space)));
+        BOOST_TEST((test(" x i", char_('x') > char_('i'), space)));
+        BOOST_TEST((!test(" x i", char_('x') > char_('o'), space)));
     }
 
     {
-        try
-        {
-            BOOST_TEST((test("bar", expect[lit("foo")])));
-        }
-        catch (expectation_failure<char const*> const& x)
-        {
-            std::cout << "expected: " << x.which();
-            std::cout << " got: \"" << x.where() << '"' << std::endl;
-        }
+        BOOST_TEST((!test("bar", expect[lit("foo")])));
+    }
+
+    { // Test expect in skipper
+        BOOST_TEST((test("accbeabfcdg", repeat(7)[alpha], lit('a') > 'b' | lit('c') > 'd')));
+        std::string attr;
+        BOOST_TEST((test_attr("accbeabfcdg", repeat(7)[alpha], attr, lit('a') > 'b' | lit('c') > 'd')));
+        BOOST_TEST((attr == "accbefg"));
+    }
+
+    { // Test expect in auxilary parsers
+        BOOST_TEST((test("a12", lit('a') > eps > +digit)));
+        BOOST_TEST((!test("a12", lit('a') > eps(false) > +digit)));
+        BOOST_TEST((test("a12", lit('a') > +digit > eoi)));
+        BOOST_TEST((!test("a12", lit('a') > eoi > +digit)));
+        BOOST_TEST((test("a12\n", lit('a') > +digit > eol)));
+        BOOST_TEST((!test("a12\n", lit('a') > eol > +digit)));
+        int n = 0;
+        BOOST_TEST((test_attr("abc", lit("abc") > attr(12) > eoi, n)));
+        BOOST_TEST((12 == n));
+    }
+
+    { // Test expect in binary, numeric, char, string parsers
+        BOOST_TEST((test("12abcd", +digit > dword)));
+        BOOST_TEST((!test("12abc", +digit > dword)));
+        BOOST_TEST((test("abc12", +alpha > int_)));
+        BOOST_TEST((!test("abc", +alpha > int_)));
+        BOOST_TEST((test("12a", +digit > lit('a'))));
+        BOOST_TEST((!test("12a", +digit > lit('b'))));
+        symbols<> s;
+        s.add("cat");
+        BOOST_TEST((test("12cat", +digit > s)));
+        BOOST_TEST((!test("12dog", +digit > s)));
+    }
+
+    { // Test expect in confix
+        BOOST_TEST((test("[12cat]", confix('[', ']')[+digit > lit("cat")])));
+        BOOST_TEST((!test("[12dog]", confix('[', ']')[+digit > lit("cat")])));
+    }
+
+    { // Test expect in expect
+        BOOST_TEST((test("abc", lit('a') >> expect[lit('b') >> 'c'])));
+        BOOST_TEST((!test("abc", lit('a') >> expect[lit('b') >> 'd'])));
+        BOOST_TEST((!test("abc", lit('a') >> expect[lit('b') > 'd'])));
+    }
+
+    { // Test expect in lexeme
+        BOOST_TEST((test("12 ab", int_ >> lexeme[lit('a') > 'b'], space)));
+        BOOST_TEST((!test("12 a b", int_ >> lexeme[lit('a') > 'b'], space)));
+    }
+
+    { // Test expect in matches
+        BOOST_TEST((test("ab", matches[lit('a') >> 'b'])));
+        BOOST_TEST((test("ac", matches[lit('a') >> 'b'] >> "ac")));
+        BOOST_TEST((test("ab", matches[lit('a') > 'b'])));
+        BOOST_TEST((!test("ac", matches[lit('a') > 'b'] >> "ac")));
+        bool attr = false;
+        BOOST_TEST((test_attr("ab", matches[lit('a') > 'b'], attr)));
+        BOOST_TEST((true == attr));
+    }
+
+    { // Test expect in no_case
+        BOOST_TEST((test("12 aB", int_ >> no_case[lit('a') > 'b'], space)));
+        BOOST_TEST((!test("12 aB", int_ >> no_case[lit('a') > 'c'], space)));
+    }
+
+    { // Test expect in no_skip
+        BOOST_TEST((test("12 3ab", int_ >> int_ >> no_skip[lit('a') > 'b'], space)));
+        BOOST_TEST((!test("12 3ab", int_ >> int_ >> no_skip[lit('a') > 'c'], space)));
+    }
+
+    { // Test expect in omit
+        BOOST_TEST((test("ab", omit[lit('a') > 'b'])));
+        BOOST_TEST((!test("ab", omit[lit('a') > 'c'])));
+    }
+
+    { // Test expect in raw
+        BOOST_TEST((test("ab", raw[lit('a') > 'b'])));
+        BOOST_TEST((!test("ab", raw[lit('a') > 'c'])));
+    }
+
+    { // Test expect in repeat
+        BOOST_TEST((test("ababac", repeat(1, 3)[lit('a') >> 'b'] >> "ac" | +alpha)));
+        BOOST_TEST((!test("ababac", repeat(1, 3)[lit('a') > 'b'] | +alpha)));
+        BOOST_TEST((!test("acab", repeat(2, 3)[lit('a') > 'b'] | +alpha)));
+        BOOST_TEST((test("bcab", repeat(2, 3)[lit('a') > 'b'] | +alpha)));
+    }
+
+    { // Test expect in seek
+        BOOST_TEST((test("a1b1c1", seek[lit('c') > '1'])));
+        BOOST_TEST((!test("a1b1c2c1", seek[lit('c') > '1'])));
+    }
+
+    { // Test expect in skip
+        BOOST_TEST((test("ab[]c[]d", skip(lit('[') > ']')[+alpha])));
+        BOOST_TEST((!test("ab[]c[5]d", skip(lit('[') > ']')[+alpha])));
+        BOOST_TEST((test("a1[]b2c3[]d4", skip(lit('[') > ']')[+(alpha > digit)])));
+        BOOST_TEST((!test("a1[]b2c3[]d", skip(lit('[') > ']')[+(alpha > digit)])));
+    }
+
+    { // Test expect in alternative
+        BOOST_TEST((test("ac", lit('a') >> 'b' | "ac")));
+        BOOST_TEST((!test("ac", lit('a') > 'b' | "ac")));
+        BOOST_TEST((test("ac", lit('a') >> 'b' | lit('a') >> 'd' | "ac")));
+        BOOST_TEST((!test("ac", lit('a') >> 'b' | lit('a') > 'd' | "ac")));
+    }
+
+    { // Test expect in and predicate
+        BOOST_TEST((test("abc", lit('a') >> &(lit('b') > 'c') >> "bc")));
+        BOOST_TEST((!test("abc", lit('a') >> &(lit('b') > 'd') >> "bc")));
+    }
+
+    { // Test expect in difference
+        BOOST_TEST((test("bcac", *(char_ - (lit('a') >> 'b')))));
+        BOOST_TEST((test("bcab", *(char_ - (lit('a') > 'b')) >> "ab")));
+        BOOST_TEST((!test("bcac", *(char_ - (lit('a') > 'b')) >> "ab")));
+    }
+
+    { // Test expect in kleene
+        BOOST_TEST((test("abac", *(lit('a') >> 'b') >> "ac")));
+        BOOST_TEST((!test("abac", *(lit('a') > 'b') >> "ac")));
+        BOOST_TEST((test("abbc", *(lit('a') > 'b') >> "bc")));
+    }
+
+    { // Test expect in list
+        BOOST_TEST((test("ab::ab::ac", (lit('a') >> 'b') % (lit(':') >> ':') >> "::ac")));
+        BOOST_TEST((!test("ab::ab::ac", (lit('a') > 'b') % (lit(':') >> ':') >> "::ac")));
+        BOOST_TEST((test("ab::ab:ac", (lit('a') > 'b') % (lit(':') >> ':') >> ":ac")));
+        BOOST_TEST((!test("ab::ab:ab", (lit('a') >> 'b') % (lit(':') > ':') >> ":ab")));
+    }
+
+    { // Test expect in not predicate
+        BOOST_TEST((test("[ac]", lit('[') >> !(lit('a') >> 'b') >> +alpha >> ']')));
+        BOOST_TEST((test("[bc]", lit('[') >> !(lit('a') > 'b') >> +alpha >> ']')));
+        BOOST_TEST((!test("[ac]", lit('[') >> !(lit('a') > 'b') >> +alpha >> ']')));
+    }
+
+    { // Test expect in optional
+        BOOST_TEST((test("ac", -(lit('a') >> 'b') >> "ac")));
+        BOOST_TEST((test("ab", -(lit('a') > 'b'))));
+        BOOST_TEST((!test("ac", -(lit('a') > 'b') >> "ac")));
+    }
+
+    { // Test expect in plus
+        BOOST_TEST((test("abac", +(lit('a') >> 'b') >> "ac")));
+        BOOST_TEST((test("abbc", +(lit('a') > 'b') >> "bc")));
+        BOOST_TEST((!test("abac", +(lit('a') > 'b') >> "ac")));
+    }
+
+    { // Test fast expect (with bool injection)
+        using boost::spirit::x3::expectation_failure_tag;
+        BOOST_TEST((test("ade", with<expectation_failure_tag>(false)[lit('a') >> (lit('b') >> 'c' | lit('d') >> 'e')])));
+        BOOST_TEST((test("abc", with<expectation_failure_tag>(false)[lit('a') >> (lit('b') > 'c' | lit('d') > 'e')])));
+        BOOST_TEST((test("ade", with<expectation_failure_tag>(false)[lit('a') >> (lit('b') > 'c' | lit('d') > 'e')])));
+        BOOST_TEST((!test("abd", with<expectation_failure_tag>(false)[lit('a') >> (lit('b') > 'c' | lit('d') > 'e')])));
+        BOOST_TEST((!test("adc", with<expectation_failure_tag>(false)[lit('a') >> (lit('b') > 'c' | lit('d') > 'e')])));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Throwing expectation_failure is so much slower (around 1000 times with clang -O2 on my mac) than the equivalent parser with sequence operator. It will increase the parsing performance if we are giving the option to use expect operator without throwing exceptions yet still keep its semantics. It has the same speed in a simple straightforward parser with the equivalent parser using sequence operator. It becomes faster when the parser has alternatives.  

1. Allow user to use expect operator more aggressively without any performance loss brought by throwing expectation_failure. When nothrow expect is used, an expectation failure simply fails the whole parser without throwing expectation_failure.
2. Expect operator throwing expectation_failure is still the default way to handle expectation failures. Users can inject a false as default value to your parser's context to enable nothrow expect.
    `x3::parse(input.begin(), input.end(), x3::with<x3::expectation_failure_tag>(false)[...]);`
3. If expect operator is used and fails in skipper parser, the main parser should not fail (The skipper parser is a totally different parser with a different context. We should use it only to skip. If the skipper parser fails, it should mean no more skipping and should return to the main parser). We use nothrow expect as the default way to call skipper parser.
4. The default implementation injects a bool into the context and it carries the expectation failure information. Users can also overload handle_expectation_failure_impl and has_expectation_failure_impl functions with e.g. boost::optional to carry more information.
5. Add unit test for nothrow expect to test all existing parsers.