### PR TITLE
Avoid -Wlogical-op warning/error in radix_traits::is_valid

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -101,11 +101,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Char>
         inline static bool is_valid(Char ch)
         {
-            if (Radix <= 10)
-                return (ch >= '0' && ch <= static_cast<Char>('0' + Radix -1));
-            return (ch >= '0' && ch <= '9')
-                || (ch >= 'a' && ch <= static_cast<Char>('a' + Radix -10 -1))
-                || (ch >= 'A' && ch <= static_cast<Char>('A' + Radix -10 -1));
+            return (ch >= '0' && ch <= (Radix > 10 ? '9' : static_cast<Char>('0' + Radix -1)))
+                || (Radix > 10 && ch >= 'a' && ch <= static_cast<Char>('a' + Radix -10 -1))
+                || (Radix > 10 && ch >= 'A' && ch <= static_cast<Char>('A' + Radix -10 -1));
         }
 
         template <typename Char>


### PR DESCRIPTION
With -Wlogical-op, gcc warns in radix_traits::is_valid with Radix <= 10:

```
boost/spirit/home/qi/numeric/detail/numeric_utils.hpp: In instantiation of ‘static bool boost::spirit::qi::detail::radix_traits<10u>::is_valid<char>(char)’:
[...]
boost/spirit/home/qi/numeric/detail/numeric_utils.hpp:107:31: warning: logical ‘and’ of mutually exclusive tests is always false [-Wlogical-op]
                 || (ch >= 'a' && ch <= static_cast<Char>('a' + Radix -10 -1))
                               ^
boost/spirit/home/qi/numeric/detail/numeric_utils.hpp:108:31: warning: logical ‘and’ of mutually exclusive tests is always false [-Wlogical-op]
                 || (ch >= 'A' && ch <= static_cast<Char>('A' + Radix -10 -1));
                               ^
```

Rather than suppressing the warning (https://github.com/boostorg/spirit/pull/77), refactor the test so that the warning is not triggered.