### PR TITLE
Remove as, as_string, and as_wstring from X3's documentation.

### DIFF
--- a/doc/x3/quick_reference.qbk
+++ b/doc/x3/quick_reference.qbk
@@ -197,10 +197,6 @@ pages and pages of reference documentation.
     [[__x3_omit__`[a]`]             [`Unused`]                      [Ignores the attribute type of `a`]]
     [[__x3_matches__`[a]`]          [`bool`]                        [Return if the embedded parser `a` matched its input]]
 
-    [[__x3_as__`()[a]`]             [`A`]                           [Force atomic assignment for arbitrary attribute types]]
-    [[__x3_as_string__`[a]`]        [`A`]                           [Force atomic assignment for string attributes]]
-    [[__x3_as_wstring__`[a]`]       [`A`]                           [Force atomic assignment for wide character string attributes]]
-
     [[__x3_raw__`[a]`]              [__boost_iterator_range__`<I>`] [Presents the transduction of `a` as an iterator range]]
 
     [[[x3_repeat `repeat[a]`]]      [`vector<A>`]                   [Repeat `a` zero or more times]]

--- a/doc/x3/spirit_x3.qbk
+++ b/doc/x3/spirit_x3.qbk
@@ -145,9 +145,6 @@
 [def __x3_skip__                    [/ link spirit.x3.reference.directive.skip] `skip`]
 [template x3_no_skip[str]           [[/ link spirit.x3.reference.directive.no_skip] str]]
 [def __x3_hold__                    [/ link spirit.x3.reference.directive.hold] `hold`]
-[def __x3_as__                      [/ link spirit.x3.reference.directive.as] `as<T>[]`]
-[def __x3_as_string__               [/ link spirit.x3.reference.directive.as] `as_string[]`]
-[def __x3_as_wstring__              [/ link spirit.x3.reference.directive.as] `as_wstring[]`]
 
 [/ operator]
 [def __x3_alternative__             [/ link spirit.x3.reference.operator.alternative] `a | b`]


### PR DESCRIPTION
As far as I can tell, `as`, `as_string`, and `as_wstring` are not part of X3.