### PR TITLE
Store id as promoted type to allow out-of-enum values

### DIFF
--- a/include/boost/spirit/home/lex/lexer/lexertl/token.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/token.hpp
@@ -33,6 +33,7 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
+#include <boost/type_traits/integral_promotion.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/static_assert.hpp>
@@ -155,10 +156,10 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         //  this default conversion operator is needed to allow the direct 
         //  usage of tokens in conjunction with the primitive parsers defined 
         //  in Qi
-        operator id_type() const { return id_; }
+        operator id_type() const { return static_cast<id_type>(id_); }
 
         //  Retrieve or set the token id of this token instance. 
-        id_type id() const { return id_; }
+        id_type id() const { return static_cast<id_type>(id_); }
         void id(id_type newid) { id_ = newid; }
 
         std::size_t state() const { return 0; }   // always '0' (INITIAL state)
@@ -187,7 +188,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
 #endif
 
     protected:
-        id_type id_;            // token id, 0 if nothing has been matched
+        typename boost::integral_promotion<id_type>::type id_;            // token id, 0 if nothing has been matched
     };
 
 #if defined(BOOST_SPIRIT_DEBUG)


### PR DESCRIPTION
When compiling with -fsanitize=undefined, `lexertl::token::id()` fails in lex_id_type_enum-p3:
```
../../../boost/spirit/home/lex/lexer/lexertl/token.hpp:161:37: runtime error: load of value 4294967295, which is not a valid value for type 'token_id'
    #0 0x41b212 in boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::proto::exprns_::expr<boost::proto::tagns_::tag::terminal, boost::proto::argsns_::term<boost::spirit::tag::omit>, 0l>, mpl_::bool_<false>, token_id>::id() const ../../../boost/spirit/home/lex/lexer/lexertl/token.hpp:161
    #1 0x4503c4 in bool boost::spirit::lex::lexertl::operator==<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>(boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id> const&, boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id> const&) ../../../boost/spirit/home/lex/lexer/lexertl/token.hpp:400
    #2 0x440a15 in bool boost::spirit::iterator_policies::split_functor_input::unique<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, true>::input_at_eof<boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> > >(boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterato
    #3 0x4367e3 in bool boost::spirit::iterator_policies::multi_pass_unique<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::ref_counted::unique, boost::spirit::iterator_policies::no_check::unique, boost::spirit::iterator_policies::split_functor_input::unique<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, true>, boost::spirit::iterator_policies::split_std_deque::unique<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id> >, true, true, true>::input_at_eof<boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_st
    #4 0x42e2b9 in bool boost::spirit::iterator_policies::split_std_deque::unique<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id> >::is_eof<boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> > >(boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> > const&) ../../../boost/spirit/home/support/iterators/detail/split_std_deque_policy.hpp:128
    #5 0x423b95 in boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> >::is_eof() const ../../../boost/spirit/home/support/iterators/multi_pass.hpp:174
    #6 0x41b25c in boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> >::operator==(boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> > const&) const ../../../boost/spirit/home/support/iterators/multi_pass.hpp:139
    #7 0x41b0e2 in boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> >::operator!=(boost::spirit::multi_pass<std::pair<boost::spirit::lex::lexertl::functor<boost::spirit::lex::lexertl::token<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, mpl_::bool_<true>, token_id>, boost::spirit::lex::lexertl::detail::data, boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true> >, boost::spirit::lex::lexertl::detail::data<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, mpl_::bool_<true>, mpl_::bool_<true>, boost::iterator_range<boost::spirit::classic::position_iterator2<boost::spirit::multi_pass<std::istreambuf_iterator<char, std::char_traits<char> >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::buffering_input_iterator, boost::spirit::iterator_policies::split_std_deque> >, boost::spirit::classic::file_position_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input, boost::spirit::iterator_policies::split_std_deque> > const&) const ../../../boost/spirit/home/support/iterators/multi_pass.hpp:153
    #8 0x404856 in main lex/id_type_enum.cpp:88
    #9 0x7f5956c4cd5c in __libc_start_main (/lib64/libc.so.6+0x1ed5c)
    #10 0x4045c8  (boost/develop/bin.v2/libs/spirit/test/lex_id_type_enum-p3.test/gcc-gnu-5.4.0/debug/lex_id_type_enum-p3+0x4045c8)
```

lex_regression_wide-p3 fails similarly.

`token` uses 0 and boost::lexer::npos as special values, which may be outside the enum.

A simple workaround is to store the promoted type and cast to `id_type` where necessary.