### PR TITLE
x3::error_handler::position() CR+LF lines wrongly counted.

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -178,7 +178,7 @@ namespace boost { namespace spirit { namespace x3
                 if (prev != '\r') ++line;
                 break;
             case '\r':
-                if (prev != '\n') ++line;
+                ++line;
                 break;
             default:
                 break;


### PR DESCRIPTION
On systems where a line is terminated by CR+LF, the position() function only
counts as one a sequence of empty lines.

Because the most common line terminations (according to Wikipedia) are \n, \r
and \r\n, I propose to only check previous char for \n. Unfortunately, this will
more or less double the counted number of lines on any system using \n\r
(but I don't this is worth doing something smarter!)

MD
