### PR TITLE
silence coverity discovery of ignored return code from at_end

### DIFF
--- a/include/boost/spirit/home/classic/core/composite/actions.hpp
+++ b/include/boost/spirit/home/classic/core/composite/actions.hpp
@@ -11,6 +11,7 @@
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/parser.hpp>
 #include <boost/spirit/home/classic/core/composite/composite.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace spirit {
 
@@ -107,7 +108,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             typedef typename ScannerT::iterator_t iterator_t;
             typedef typename parser_result<self_t, ScannerT>::type result_t;
 
-            scan.at_end(); // allow skipper to take effect
+            ignore_unused(scan.at_end()); // allow skipper to take effect
             iterator_t save = scan.first;
             result_t hit = this->subject().parse(scan);
             if (hit)

--- a/include/boost/spirit/home/classic/dynamic/impl/switch.ipp
+++ b/include/boost/spirit/home/classic/dynamic/impl/switch.ipp
@@ -12,6 +12,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/inc.hpp>
@@ -445,7 +446,7 @@ inline typename parser_result<
 compound_case_parser<LeftT, RightT, IsDefault>::
     parse(ScannerT const& scan, CondT const &cond) const
 {
-    scan.at_end();    // allow skipper to take effect
+    ignore_unused(scan.at_end());    // allow skipper to take effect
     return parse_switch<value, case_chain<self_t>::depth, is_default>::
         do_(*this, scan, cond(scan), scan.first);
 }


### PR DESCRIPTION
Discovered in a boost uuid coverity scan:

https://scan4.coverity.com/reports.htm#v17121/p12449/fileInstanceId=27630727&defectInstanceId=5505434&mergedDefectId=58160&eventId=5505434-0