### PR TITLE
X3.Examples: Fix `no template named 'with_context'` error

### DIFF
--- a/example/x3/calc/calc8/config.hpp
+++ b/example/x3/calc/calc8/config.hpp
@@ -16,10 +16,10 @@ namespace client { namespace parser
     typedef x3::phrase_parse_context<x3::ascii::space_type>::type phrase_context_type;
     typedef error_handler<iterator_type> error_handler_type;
 
-    typedef x3::with_context<
+    typedef x3::context<
         error_handler_tag
       , std::reference_wrapper<error_handler_type> const
-      , phrase_context_type>::type
+      , phrase_context_type>
     context_type;
 }}
 

--- a/example/x3/calc/calc9/config.hpp
+++ b/example/x3/calc/calc9/config.hpp
@@ -16,10 +16,10 @@ namespace client { namespace parser
     typedef x3::phrase_parse_context<x3::ascii::space_type>::type phrase_context_type;
     typedef error_handler<iterator_type> error_handler_type;
 
-    typedef x3::with_context<
+    typedef x3::context<
         error_handler_tag
       , std::reference_wrapper<error_handler_type> const
-      , phrase_context_type>::type
+      , phrase_context_type>
     context_type;
 }}
 

--- a/example/x3/rexpr/rexpr_full/rexpr/config.hpp
+++ b/example/x3/rexpr/rexpr_full/rexpr/config.hpp
@@ -25,10 +25,10 @@ namespace rexpr { namespace parser
     typedef error_handler<iterator_type> error_handler_type;
 
     // Combined Error Handler and Phrase Parse Context
-    typedef x3::with_context<
+    typedef x3::context<
         error_handler_tag
       , std::reference_wrapper<error_handler_type> const
-      , phrase_context_type>::type
+      , phrase_context_type>
     context_type;
 }}
 


### PR DESCRIPTION
`with_context` was removed in 361b12eeeb703fb8daa6ecc4e8714653b4c8dbe8 (#239) but the examples had not been adjusted.