### PR TITLE
Qi.Examples: Fixed `parse_frac_n` in `reference.cpp`

### DIFF
--- a/example/qi/reference.cpp
+++ b/example/qi/reference.cpp
@@ -123,10 +123,19 @@ struct ts_real_policies : boost::spirit::qi::ureal_policies<T>
     //  2 decimal places Max
     template <typename Iterator, typename Attribute>
     static bool
-    parse_frac_n(Iterator& first, Iterator const& last, Attribute& attr)
+    parse_frac_n(Iterator& first, Iterator const& last, Attribute& attr,
+                 int& frac_digits)
     {
-        return boost::spirit::qi::
+        Iterator savef = first;
+        bool r = boost::spirit::qi::
             extract_uint<T, 10, 1, 2, true>::call(first, last, attr);
+        if (r) {
+            // Optimization note: don't compute frac_digits if T is
+            // an unused_type. This should be optimized away by the compiler.
+            if (!boost::is_same<T, boost::spirit::unused_type>::value)
+                frac_digits = static_cast<int>(std::distance(savef, first));
+        }
+        return r;
     }
 
     //  No exponent


### PR DESCRIPTION
Error message:

```
qi/reference.cpp:126:5: note: candidate function template not viable: requires 3 arguments, but 4 were provided
    parse_frac_n(Iterator& first, Iterator const& last, Attribute& attr)
```

The issue had been introduced in 6832dc229872d7f9573a506cfe1ed640dc79871e where `parse_frac_n` signature was changed.