### PR TITLE
Qi.Repository: Fix `keywords` compilation on c++11

### DIFF
--- a/include/boost/spirit/repository/home/qi/operator/detail/keywords.hpp
+++ b/include/boost/spirit/repository/home/qi/operator/detail/keywords.hpp
@@ -164,9 +164,11 @@ namespace boost { namespace spirit { namespace repository { namespace qi { names
                             };
 
                         // never called, but needed for decltype-based result_of (C++0x)
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
                         template <typename Element>
                             typename result<element_char_type(Element)>::type
-                            operator()(Element&) const;
+                            operator()(Element&&) const;
+#endif
                     };
 
                     // Compute the list of character types of the child kwd directives
@@ -264,9 +266,11 @@ namespace boost { namespace spirit { namespace repository { namespace qi { names
                             };
 
                         // never called, but needed for decltype-based result_of (C++0x)
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
                         template <typename Element>
                             typename result<element_case_type(Element)>::type
-                            operator()(Element&) const;
+                            operator()(Element&&) const;
+#endif
                     };
 
                     // Compute the list of character types of the child kwd directives


### PR DESCRIPTION
Though `result` specializations should be symmetrical to `operator()`, in this particular case author used 'hacky' way and I did not touch this, only fixed compilation error and done it in the same way as it is in other places e.g. https://github.com/boostorg/spirit/blob/9a8cded55355644c749d6511504b59c048d64de3/include/boost/spirit/home/karma/operator/alternative.hpp#L65-L69