### PR TITLE
Fix `subrule` compilation

### DIFF
--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -351,13 +351,20 @@ namespace boost { namespace spirit { namespace repository { namespace karma
 
         typedef mpl::vector<T1, T2> template_params;
 
-        // locals_type is a sequence of types to be used as local variables
+        // The subrule's locals_type: a sequence of types to be used as local variables
         typedef typename
             spirit::detail::extract_locals<template_params>::type
         locals_type;
 
+        // The subrule's encoding type
         typedef typename
-            spirit::detail::extract_sig<template_params>::type
+            spirit::detail::extract_encoding<template_params>::type
+        encoding_type;
+
+        // The subrule's signature
+        typedef typename
+            spirit::detail::extract_sig<template_params, encoding_type
+              , spirit::karma::domain>::type
         sig_type;
 
         // This is the subrule's attribute type

--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -269,6 +269,22 @@ namespace boost { namespace spirit { namespace repository { namespace karma
             return result_type(fusion::as_map(fusion::join(defs, other.defs)));
         }
 
+        // non-const versions needed to suppress proto's comma op kicking in
+        template <typename Defs2>
+        friend subrule_group<
+            typename fusion::result_of::as_map<
+                typename fusion::result_of::join<
+                    Defs const, Defs2 const>::type>::type>
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        operator,(subrule_group&& left, subrule_group<Defs2>&& other)
+#else
+        operator,(subrule_group& left, subrule_group<Defs2>& other)
+#endif
+        {
+            return static_cast<subrule_group const&>(left)
+                .operator,(static_cast<subrule_group<Defs2> const&>(other));
+        }
+
         // bring in the operator() overloads
         this_type const& get_parameterized_subject() const { return *this; }
         typedef this_type parameterized_subject_type;
@@ -454,6 +470,16 @@ namespace boost { namespace spirit { namespace repository { namespace karma
         }
 
         // non-const versions needed to suppress proto's %= kicking in
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule const& sr, Expr&& expr)
+        {
+            return operator%=(
+                sr
+              , static_cast<Expr const&>(expr));
+        }
+#endif
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule const& sr, Expr& expr)
@@ -462,6 +488,7 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 sr
               , static_cast<Expr const&>(expr));
         }
+        //
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule& sr, Expr const& expr)
@@ -470,6 +497,16 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 static_cast<subrule const&>(sr)
               , expr);
         }
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule& sr, Expr&& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+#endif
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule& sr, Expr& expr)
@@ -478,6 +515,33 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 static_cast<subrule const&>(sr)
               , static_cast<Expr const&>(expr));
         }
+        //
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr const& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr&& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+#endif
 
         std::string const& name() const
         {

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -301,6 +301,22 @@ namespace boost { namespace spirit { namespace repository { namespace qi
             return result_type(fusion::as_map(fusion::join(defs, other.defs)));
         }
 
+        // non-const versions needed to suppress proto's comma op kicking in
+        template <typename Defs2>
+        friend subrule_group<
+            typename fusion::result_of::as_map<
+                typename fusion::result_of::join<
+                    Defs const, Defs2 const>::type>::type>
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        operator,(subrule_group&& left, subrule_group<Defs2>&& other)
+#else
+        operator,(subrule_group& left, subrule_group<Defs2>& other)
+#endif
+        {
+            return static_cast<subrule_group const&>(left)
+                .operator,(static_cast<subrule_group<Defs2> const&>(other));
+        }
+
         // bring in the operator() overloads
         this_type const& get_parameterized_subject() const { return *this; }
         typedef this_type parameterized_subject_type;
@@ -480,6 +496,16 @@ namespace boost { namespace spirit { namespace repository { namespace qi
         }
 
         // non-const versions needed to suppress proto's %= kicking in
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule const& sr, Expr&& expr)
+        {
+            return operator%=(
+                sr
+              , static_cast<Expr const&>(expr));
+        }
+#endif
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule const& sr, Expr& expr)
@@ -488,6 +514,7 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 sr
               , static_cast<Expr const&>(expr));
         }
+        //
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule& sr, Expr const& expr)
@@ -496,6 +523,16 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 static_cast<subrule const&>(sr)
               , expr);
         }
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule& sr, Expr&& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+#endif
         template <typename Expr>
         friend typename group_type_helper<Expr, true>::type
         operator%=(subrule& sr, Expr& expr)
@@ -504,6 +541,33 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 static_cast<subrule const&>(sr)
               , static_cast<Expr const&>(expr));
         }
+        //
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr const& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr&& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+        template <typename Expr>
+        friend typename group_type_helper<Expr, true>::type
+        operator%=(subrule&& sr, Expr& expr)
+        {
+            return operator%=(
+                static_cast<subrule const&>(sr)
+              , static_cast<Expr const&>(expr));
+        }
+#endif
 
         std::string const& name() const
         {

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -378,13 +378,20 @@ namespace boost { namespace spirit { namespace repository { namespace qi
 
         typedef mpl::vector<T1, T2> template_params;
 
-        // locals_type is a sequence of types to be used as local variables
+        // The subrule's locals_type: a sequence of types to be used as local variables
         typedef typename
             spirit::detail::extract_locals<template_params>::type
         locals_type;
 
+        // The subrule's encoding type
         typedef typename
-            spirit::detail::extract_sig<template_params>::type
+            spirit::detail::extract_encoding<template_params>::type
+        encoding_type;
+
+        // The subrule's signature
+        typedef typename
+            spirit::detail::extract_sig<template_params, encoding_type
+              , spirit::qi::domain>::type
         sig_type;
 
         // This is the subrule's attribute type


### PR DESCRIPTION
This fixes a long standing bugs persisted in `subrule` for years.
Those `%=` operator overloads are awful, but I do not know other solution (It should be possible to [tell proto to disable operators](http://www.boost.org/doc/libs/1_65_1/doc/html/proto/users_guide.html#boost_proto.users_guide.front_end.customizing_expressions_in_your_domain.inhibiting_overloads) but I do not know spirit's internals well enough for doing that).

Tested on VS2017, clang 5.0 c++03/1y, gcc 6 c++03/1y