### PR TITLE
Karma.Examples: Fix complex_number_adapt compilation

### DIFF
--- a/example/karma/complex_number_adapt.cpp
+++ b/example/karma/complex_number_adapt.cpp
@@ -22,6 +22,7 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/fusion/include/adapt_adt.hpp>
+#include <boost/spirit/include/support_adapt_adt_attributes.hpp>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Added missing `boost/spirit/include/support_adapt_adt_attributes.hpp` include