### PR TITLE
X3.Tests: Added regression test for 379413a5 fix

### DIFF
--- a/test/x3/attr.cpp
+++ b/test/x3/attr.cpp
@@ -47,6 +47,11 @@ int main()
         std::string s;
         BOOST_TEST(test_attr("s", "s" >> attr(std::string("123")), s) &&
             s == "123");
+
+        s.clear();
+        using boost::spirit::x3::string;
+        BOOST_TEST(test_attr("123", string("123") >> attr(std::string("456")), s) &&
+            s == "123456");
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Fix 379413a50c93539aa432fa9f9fc94fec1d6aa60d did not add a regression test.

For the first time I thought it fixes `vector<std::string, std::string>`, but it run smooth after reverting and it got me some minutes to come up with the test you see in this commit.

@djowel I hope it is what you meant in the commit message and I did not find other bonded regression.