### PR TITLE
Qi.Examples: reference: Fixed lazy example

### DIFF
--- a/example/qi/reference.cpp
+++ b/example/qi/reference.cpp
@@ -770,7 +770,7 @@ main()
         test_parser("Hello", lazy(val(string("Hello"))));
 
         //` The above is equivalent to:
-        test_parser("Hello", val(string("Hello")));
+        test_parser("Hello", string("Hello"));
         //]
     }
 


### PR DESCRIPTION
Phoenix expression used like it is a Qi expression.

I suspect it had been legal when they were belong to the same Proto domain but not now.

Closes #260