### PR TITLE
Spirit accidentally relays on `types` typedef of `boost::optional`

### DIFF
--- a/include/boost/spirit/home/karma/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/karma/detail/alternative_function.hpp
@@ -90,7 +90,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
             component; // suppresses warning: C4100: 'component' : unreferenced formal parameter
 #endif
             return call(component, sink, ctx, d, attr
-              , spirit::traits::not_is_variant<Attribute, karma::domain>());
+              , spirit::traits::not_is_variant_or_variant_in_optional<Attribute, karma::domain>());
         }
 
         template <typename OutputIterator, typename Context, typename Delimiter>

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -138,9 +138,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Component>
         bool call(Component const& component, mpl::false_) const
         {
-            // fix for alternative.cpp test case, FHE 2016-07-28
             return call_optional_or_variant(
-                component, mpl::not_<spirit::traits::not_is_optional<Attribute, qi::domain> >());
+                component, spirit::traits::not_is_variant<Attribute, qi::domain>());
         }
 
         template <typename Component>

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -279,11 +279,6 @@ namespace boost { namespace spirit { namespace traits
       : mpl::false_
     {};
 
-    template <typename T, typename Domain>
-    struct not_is_variant<boost::optional<T>, Domain>
-      : not_is_variant<T, Domain>
-    {};
-
     // we treat every type as if it where the variant (as this meta function is
     // invoked for variant types only)
     template <typename T>
@@ -294,6 +289,11 @@ namespace boost { namespace spirit { namespace traits
     template <typename T>
     struct variant_type<boost::optional<T> >
       : variant_type<T>
+    {};
+
+    template <typename T, typename Domain>
+    struct not_is_variant_or_variant_in_optional
+      : not_is_variant<typename variant_type<T>::type, Domain>
     {};
 
     ///////////////////////////////////////////////////////////////////////////
@@ -339,7 +339,7 @@ namespace boost { namespace spirit { namespace traits
 
     template <typename Variant, typename Expected>
     struct compute_compatible_component_variant<Variant, Expected, mpl::false_
-      , typename enable_if<detail::has_types<Variant> >::type>
+      , typename enable_if<detail::has_types<typename variant_type<Variant>::type> >::type>
     {
         typedef typename traits::variant_type<Variant>::type variant_type;
         typedef typename variant_type::types types;
@@ -372,7 +372,7 @@ namespace boost { namespace spirit { namespace traits
     template <typename Expected, typename Attribute, typename Domain>
     struct compute_compatible_component
       : compute_compatible_component_variant<Attribute, Expected
-          , typename spirit::traits::not_is_variant<Attribute, Domain>::type> {};
+          , typename not_is_variant_or_variant_in_optional<Attribute, Domain>::type> {};
 
     template <typename Expected, typename Domain>
     struct compute_compatible_component<Expected, unused_type, Domain>


### PR DESCRIPTION
Replaces #201, fixes #249.

New `boost:optional` implementation does not contain `types` what caused a compilation error for Qi and wrong results for Karma.

Other problem is that `not_is_variant<optional<variant<T...>>>` results in `mpl::false_` what is unclear from it's name. While Karma relays on exactly this behavior, Qi wrongly considers that it `mpl::true_`. I have fixed this name ambiguity and updated Karma for the new `not_is_variant` behavior.

P.S: I am bad at naming things but I do not see any shorter name for `not_is_variant_or_variant_in_optional`