### PR TITLE
Repository: subrule: Fixed partial ordering problem

### DIFF
--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -458,90 +458,34 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 def_type(compile<spirit::karma::domain>(expr), name_)));
         }
 
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr const& expr)
-        {
-            typedef group_type_helper<Expr, true> helper;
-            typedef typename helper::def_type def_type;
-            typedef typename helper::type result_type;
-            return result_type(fusion::make_map<id_type>(
-                def_type(compile<spirit::karma::domain>(expr), sr.name_)));
-        }
+#define SUBRULE_MODULUS_ASSIGN_OPERATOR(lhs_ref, rhs_ref)                     \
+        template <typename Expr>                                              \
+        friend typename group_type_helper<Expr, true>::type                   \
+        operator%=(subrule lhs_ref sr, Expr rhs_ref expr)                     \
+        {                                                                     \
+            typedef group_type_helper<Expr, true> helper;                     \
+            typedef typename helper::def_type def_type;                       \
+            typedef typename helper::type result_type;                        \
+            return result_type(fusion::make_map<id_type>(                     \
+                def_type(compile<spirit::karma::domain>(expr), sr.name_)));   \
+        }                                                                     \
+        /**/
 
         // non-const versions needed to suppress proto's %= kicking in
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, const&)
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr&& expr)
-        {
-            return operator%=(
-                sr
-              , static_cast<Expr const&>(expr));
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, &&)
+#else
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, &)
 #endif
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr& expr)
-        {
-            return operator%=(
-                sr
-              , static_cast<Expr const&>(expr));
-        }
-        //
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr const& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , expr);
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, const&)
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr&& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, &&)
+#else
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, &)
 #endif
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        //
-#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr const& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr&& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-#endif
+
+#undef SUBRULE_MODULUS_ASSIGN_OPERATOR
 
         std::string const& name() const
         {

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -484,90 +484,34 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 def_type(compile<spirit::qi::domain>(expr), name_)));
         }
 
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr const& expr)
-        {
-            typedef group_type_helper<Expr, true> helper;
-            typedef typename helper::def_type def_type;
-            typedef typename helper::type result_type;
-            return result_type(fusion::make_map<id_type>(
-                def_type(compile<spirit::qi::domain>(expr), sr.name_)));
-        }
+#define SUBRULE_MODULUS_ASSIGN_OPERATOR(lhs_ref, rhs_ref)                     \
+        template <typename Expr>                                              \
+        friend typename group_type_helper<Expr, true>::type                   \
+        operator%=(subrule lhs_ref sr, Expr rhs_ref expr)                     \
+        {                                                                     \
+            typedef group_type_helper<Expr, true> helper;                     \
+            typedef typename helper::def_type def_type;                       \
+            typedef typename helper::type result_type;                        \
+            return result_type(fusion::make_map<id_type>(                     \
+                def_type(compile<spirit::qi::domain>(expr), sr.name_)));      \
+        }                                                                     \
+        /**/
 
         // non-const versions needed to suppress proto's %= kicking in
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, const&)
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr&& expr)
-        {
-            return operator%=(
-                sr
-              , static_cast<Expr const&>(expr));
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, &&)
+#else
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(const&, &)
 #endif
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule const& sr, Expr& expr)
-        {
-            return operator%=(
-                sr
-              , static_cast<Expr const&>(expr));
-        }
-        //
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr const& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , expr);
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, const&)
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr&& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, &&)
+#else
+        SUBRULE_MODULUS_ASSIGN_OPERATOR(&, &)
 #endif
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule& sr, Expr& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        //
-#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr const& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr&& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-        template <typename Expr>
-        friend typename group_type_helper<Expr, true>::type
-        operator%=(subrule&& sr, Expr& expr)
-        {
-            return operator%=(
-                static_cast<subrule const&>(sr)
-              , static_cast<Expr const&>(expr));
-        }
-#endif
+
+#undef SUBRULE_MODULUS_ASSIGN_OPERATOR
 
         std::string const& name() const
         {


### PR DESCRIPTION
The problem is that `f(T&)` and `f(T&&)` overloads had the same priority
http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1164

Affected compilers are:
 - MSVC 9/10/11
 - GCC 4.7.2, 4.8.4 with `-std=c++1x`