### PR TITLE
Qi.Tests: uint1: Fixed `uint8_t` usage

### DIFF
--- a/test/qi/uint1.cpp
+++ b/test/qi/uint1.cpp
@@ -126,7 +126,7 @@ main()
         BOOST_TEST(!test_attr("1", uint4, u));
         BOOST_TEST(test_attr("014567", uint4, u, false) && u == 145);
 
-        uint_parser<uint8_t, 10, 1, 3> uchar_3;
+        uint_parser<boost::uint8_t, 10, 1, 3> uchar_3;
         unsigned char uc;
         BOOST_TEST(test_attr("255", uchar_3, uc, true));
         BOOST_TEST(uc == 255);


### PR DESCRIPTION
Fixes compilation problem on MSVC 8/9