### PR TITLE
ofz#4303 avoid signed integer overflow

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -108,6 +108,8 @@ namespace boost { namespace spirit { namespace traits
     inline bool
     scale(int exp, int frac, T& n, AccT acc_n)
     {
+        if (exp < std::numeric_limits<int>::min() + frac)
+            return false;
         return scale(exp - frac, n, acc_n);
     }
 


### PR DESCRIPTION
/usr/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp:110:26: runtime error: signed integer overflow: -2147483647 - 19 cannot be represented in type 'int'