### PR TITLE
subrule: Fixed a huge use after scope bug

### DIFF
--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -54,46 +54,22 @@
 namespace boost { namespace spirit { namespace repository { namespace qi
 {
     ///////////////////////////////////////////////////////////////////////////
-    // subrule_group:
+    // subrule_group_parser:
     // - parser representing a group of subrule definitions (one or more),
     //   invokes first subrule on entry,
-    // - also a Proto terminal, so that a group behaves like any Spirit
-    //   expression.
     ///////////////////////////////////////////////////////////////////////////
     template <typename Defs>
-    struct subrule_group
-      : proto::extends<
-            typename proto::terminal<
-                spirit::qi::reference<subrule_group<Defs> const>
-            >::type
-          , subrule_group<Defs>
-        >
-      , spirit::qi::parser<subrule_group<Defs> >
+    struct subrule_group_parser
+      : spirit::qi::parser<subrule_group_parser<Defs> >
     {
         // Fusion associative sequence, associating each subrule ID in this
         // group (as an MPL integral constant) with its definition
         typedef Defs defs_type;
 
-        typedef subrule_group<Defs> this_type;
-        typedef spirit::qi::reference<this_type const> reference_;
-        typedef typename proto::terminal<reference_>::type terminal;
-        typedef proto::extends<terminal, this_type> base_type;
+        typedef subrule_group_parser<Defs> this_type;
 
-        static size_t const params_size =
-            // Forward to first subrule.
-            remove_reference<
-                typename fusion::result_of::front<Defs>::type
-            >::type::second_type::params_size;
-
-        subrule_group(subrule_group const& rhs)
-          : base_type(terminal::make(reference_(*this)))
-          , defs(rhs.defs)
-        {
-        }
-
-        explicit subrule_group(Defs const& defs)
-          : base_type(terminal::make(reference_(*this)))
-          , defs(defs)
+        explicit subrule_group_parser(Defs const& defs)
+          : defs(defs)
         {
         }
 
@@ -287,6 +263,41 @@ namespace boost { namespace spirit { namespace repository { namespace qi
             return fusion::front(defs).second.binder.p.what(context);
         }
 
+        Defs defs;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // subrule_group:
+    // - a Proto terminal, so that a group behaves like any Spirit
+    //   expression.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Defs>
+    struct subrule_group
+      : proto::extends<
+            typename proto::terminal<
+                subrule_group_parser<Defs>
+            >::type
+          , subrule_group<Defs>
+        >
+    {
+        typedef subrule_group_parser<Defs> parser_type;
+        typedef typename proto::terminal<parser_type>::type terminal;
+
+        static size_t const params_size =
+            // Forward to first subrule.
+            remove_reference<
+                typename fusion::result_of::front<Defs>::type
+            >::type::second_type::params_size;
+
+        explicit subrule_group(Defs const& defs)
+          : subrule_group::proto_extends(terminal::make(parser_type(defs)))
+        {
+        }
+
+        parser_type const& parser() const { return proto::value(*this); }
+
+        Defs const& defs() const { return parser().defs; }
+
         template <typename Defs2>
         subrule_group<
             typename fusion::result_of::as_map<
@@ -298,7 +309,7 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 typename fusion::result_of::as_map<
                     typename fusion::result_of::join<
                         Defs const, Defs2 const>::type>::type> result_type;
-            return result_type(fusion::as_map(fusion::join(defs, other.defs)));
+            return result_type(fusion::as_map(fusion::join(defs(), other.defs())));
         }
 
         // non-const versions needed to suppress proto's comma op kicking in
@@ -318,11 +329,9 @@ namespace boost { namespace spirit { namespace repository { namespace qi
         }
 
         // bring in the operator() overloads
-        this_type const& get_parameterized_subject() const { return *this; }
-        typedef this_type parameterized_subject_type;
+        parser_type const& get_parameterized_subject() const { return parser(); }
+        typedef parser_type parameterized_subject_type;
         #include <boost/spirit/home/qi/nonterminal/detail/fcall.hpp>
-
-        Defs defs;
     };
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It took me 3 days of pulling my hair to debug and fix the bug. The subrule's author put a big bomb under it and I caught the exposition only in a single test, with modern versions of Clang/GCC and enabled optimizations (most of boost regression test runners does not use `variant=release`). Valgrind did not catch any problems. Enabling address sanitizer causes the bug to disappear (now I understand why, it places big gaps between stack pointers). `-fsanitize-address-use-after-scope` catches the bug, but I have discovered that it is turned off in Clang by default after already having a repro.

The bug could be easily reproduced if you use any parser that invalidates it's state in the destructor.

I used `literal_char` with added `~literal_char() { ch = char_type(0); }`.

Reproduction code:

```cpp

    rule<char const*> r;
    subrule<0> entry;
    r = (entry = 'a');
    BOOST_TEST(test("a", r));
```

It will fail because after assignment to `r` a temporary `subrule_group` is destroyed and rule is binded to the already destroyed object.

The cause is in usage of `reference` parser. I am 100% sure the code was copy-pasted from  `rule`/`grammar`. They store an expression within their body, while `subrule` actually used only as a placeholder.

I have split `subrule_group` into an actual parser/generator that stores the expression and a Proto terminal that contains the parser/generator.

Tested on:
 - VS 2008, 2010, 2015, 2017
 - Clang 3.8, 3.9, 4.0, 5.0
 - GCC 4.8, 7