### PR TITLE
fix uint_parser<T(signed)> overflow problem

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -504,35 +504,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     };
 
 #undef SPIRIT_NUMERIC_INNER_LOOP
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Cast an signed integer to an unsigned integer
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T,
-        bool force_unsigned
-            = mpl::and_<is_integral<T>, is_signed<T> >::value>
-    struct cast_unsigned;
-
-    template <typename T>
-    struct cast_unsigned<T, true>
-    {
-        typedef typename make_unsigned<T>::type unsigned_type;
-        typedef typename make_unsigned<T>::type& unsigned_type_ref;
-
-        inline static unsigned_type_ref call(T& n)
-        {
-            return unsigned_type_ref(n);
-        }
-    };
-
-    template <typename T>
-    struct cast_unsigned<T, false>
-    {
-        inline static T& call(T& n)
-        {
-            return n;
-        }
-    };
 }}}}
 
 #if defined(BOOST_MSVC)

--- a/include/boost/spirit/home/qi/numeric/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/numeric_utils.hpp
@@ -69,8 +69,7 @@ namespace boost { namespace spirit { namespace qi
             extract_type;
 
             Iterator save = first;
-            if (!extract_type::parse(first, last,
-                detail::cast_unsigned<T>::call(attr_)))
+            if (!extract_type::parse(first, last, attr_))
             {
                 first = save;
                 return false;

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -474,35 +474,6 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     };
 
 #undef SPIRIT_NUMERIC_INNER_LOOP
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Cast an signed integer to an unsigned integer
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T,
-        bool force_unsigned
-            = mpl::and_<is_integral<T>, is_signed<T> >::value>
-    struct cast_unsigned;
-
-    template <typename T>
-    struct cast_unsigned<T, true>
-    {
-        typedef typename make_unsigned<T>::type unsigned_type;
-        typedef typename make_unsigned<T>::type& unsigned_type_ref;
-
-        inline static unsigned_type_ref call(T& n)
-        {
-            return unsigned_type_ref(n);
-        }
-    };
-
-    template <typename T>
-    struct cast_unsigned<T, false>
-    {
-        inline static T& call(T& n)
-        {
-            return n;
-        }
-    };
 }}}}
 
 #endif

--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_int.hpp
@@ -62,8 +62,7 @@ namespace boost { namespace spirit { namespace x3
             extract_type;
 
             Iterator save = first;
-            if (!extract_type::parse(first, last,
-                detail::cast_unsigned<T>::call(attr)))
+            if (!extract_type::parse(first, last, attr))
             {
                 first = save;
                 return false;

--- a/test/qi/uint1.cpp
+++ b/test/qi/uint1.cpp
@@ -174,6 +174,30 @@ main()
         BOOST_TEST(!test_attr("9999999999", uint32_, u32));
         BOOST_TEST(!test_attr("4294967296", uint32_, u32));
         BOOST_TEST(test_attr("4294967295", uint32_, u32));
+
+        boost::spirit::qi::uint_parser<boost::int8_t> u_int8_;
+
+        BOOST_TEST(!test_attr("999", u_int8_, u8));
+        BOOST_TEST(!test_attr("-1", u_int8_, u8));
+        BOOST_TEST(!test_attr("128", u_int8_, u8));
+        BOOST_TEST(test_attr("127", u_int8_, u8));
+        BOOST_TEST(test_attr("0", u_int8_, u8));
+
+        boost::spirit::qi::uint_parser<boost::int16_t> u_int16_;
+
+        BOOST_TEST(!test_attr("99999", u_int16_, u16));
+        BOOST_TEST(!test_attr("-1", u_int16_, u16));
+        BOOST_TEST(!test_attr("32768", u_int16_, u16));
+        BOOST_TEST(test_attr("32767", u_int16_, u16));
+        BOOST_TEST(test_attr("0", u_int16_, u16));
+
+        boost::spirit::qi::uint_parser<boost::int32_t> u_int32_;
+
+        BOOST_TEST(!test_attr("9999999999", u_int32_, u32));
+        BOOST_TEST(!test_attr("-1", u_int32_, u32));
+        BOOST_TEST(!test_attr("2147483648", u_int32_, u32));
+        BOOST_TEST(test_attr("2147483647", u_int32_, u32));
+        BOOST_TEST(test_attr("0", u_int32_, u32));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/test/x3/uint1.cpp
+++ b/test/x3/uint1.cpp
@@ -168,6 +168,30 @@ main()
         BOOST_TEST(!test_attr("9999999999", uint32_, u32));
         BOOST_TEST(!test_attr("4294967296", uint32_, u32));
         BOOST_TEST(test_attr("4294967295", uint32_, u32));
+
+        boost::spirit::x3::uint_parser<boost::int8_t> u_int8_;
+
+        BOOST_TEST(!test_attr("999", u_int8_, u8));
+        BOOST_TEST(!test_attr("-1", u_int8_, u8));
+        BOOST_TEST(!test_attr("128", u_int8_, u8));
+        BOOST_TEST(test_attr("127", u_int8_, u8));
+        BOOST_TEST(test_attr("0", u_int8_, u8));
+
+        boost::spirit::x3::uint_parser<boost::int16_t> u_int16_;
+
+        BOOST_TEST(!test_attr("99999", u_int16_, u16));
+        BOOST_TEST(!test_attr("-1", u_int16_, u16));
+        BOOST_TEST(!test_attr("32768", u_int16_, u16));
+        BOOST_TEST(test_attr("32767", u_int16_, u16));
+        BOOST_TEST(test_attr("0", u_int16_, u16));
+
+        boost::spirit::x3::uint_parser<boost::int32_t> u_int32_;
+
+        BOOST_TEST(!test_attr("9999999999", u_int32_, u32));
+        BOOST_TEST(!test_attr("-1", u_int32_, u32));
+        BOOST_TEST(!test_attr("2147483648", u_int32_, u32));
+        BOOST_TEST(test_attr("2147483647", u_int32_, u32));
+        BOOST_TEST(test_attr("0", u_int32_, u32));
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
According to spirit document,

  "All numeric parsers check for overflow conditions based on the type T the corresponding uint_parser<> has been instantiated with. If the parsed number overflows this type the parsing fails. Please be aware that the overflow check is not based on the type of the supplied attribute but solely depends on the template parameter T."

the valid input range of `x3::uint_parser<T>` should be `0` - `std::numeric_limits<T>::max()`. However, the current implementation takes values from `std::numeric_limits<T>::max()+1` - `std::numeric_limits<std::make_unsigned_t<T>>::max()` also as valid input when `T` is a signed integral.

Example:
  `x3::uint_parser<signed char>` should parse 0-127, but with current implementation 128-255 also works.

Test cases are added.

