### PR TITLE
X3: Workaround VS2015 bugs

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -151,6 +151,21 @@ namespace boost { namespace spirit { namespace x3
     BOOST_SPIRIT_DECLARE_, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))            \
     /***/
 
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
+#define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
+    using BOOST_PP_CAT(rule_name, _synonym) = decltype(rule_name);              \
+    template <typename Iterator, typename Context, typename Attribute>          \
+    inline bool parse_rule(                                                     \
+        BOOST_PP_CAT(rule_name, _synonym) /* rule_ */                           \
+      , Iterator& first, Iterator const& last                                   \
+      , Context const& context, Attribute& attr)                                \
+    {                                                                           \
+        using boost::spirit::x3::unused;                                        \
+        static auto const def_ = (rule_name = BOOST_PP_CAT(rule_name, _def));   \
+        return def_.parse(first, last, context, unused, attr);                  \
+    }                                                                           \
+    /***/
+#else
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     template <typename Iterator, typename Context, typename Attribute>          \
     inline bool parse_rule(                                                     \
@@ -163,6 +178,7 @@ namespace boost { namespace spirit { namespace x3
         return def_.parse(first, last, context, unused, attr);                  \
     }                                                                           \
     /***/
+#endif
 
 #define BOOST_SPIRIT_DEFINE(...) BOOST_PP_SEQ_FOR_EACH(                         \
     BOOST_SPIRIT_DEFINE_, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))             \

--- a/include/boost/spirit/home/x3/support/ast/variant.hpp
+++ b/include/boost/spirit/home/x3/support/ast/variant.hpp
@@ -143,7 +143,7 @@ namespace boost { namespace spirit { namespace x3
             : var(rhs) {}
 
         template <typename T, class = non_self_t<T>>
-        explicit variant(T&& rhs) BOOST_NOEXCEPT_IF((std::is_nothrow_constructible<variant_type, T&&>{}))
+        explicit variant(T&& rhs) BOOST_NOEXCEPT_IF((std::is_nothrow_constructible<variant_type, T&&>::value))  // `::value` is a workaround for the VS2015 bug
             : var(std::forward<T>(rhs)) {}
 
         variant(variant const& rhs) BOOST_NOEXCEPT_IF(std::is_nothrow_copy_constructible<variant_type>{})
@@ -175,7 +175,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename T, class = non_self_t<T>>
-        variant& operator=(T&& rhs) BOOST_NOEXCEPT_IF((std::is_nothrow_assignable<variant_type, T&&>{}))
+        variant& operator=(T&& rhs) BOOST_NOEXCEPT_IF((std::is_nothrow_assignable<variant_type, T&&>::value))  // `::value` is a workaround for the VS2015 bug
         {
             var = std::forward<T>(rhs);
             return *this;

--- a/test/x3/confix.cpp
+++ b/test/x3/confix.cpp
@@ -35,8 +35,9 @@ int main()
                 test_attr(" /* 123 */ ", comment[x3::uint_], value, x3::space));
             BOOST_TEST(value == 123);
 
+            using x3::_attr;
             value = 0;
-            const auto lambda = [&value](auto& ctx ){ value = x3::_attr(ctx) + 1; };
+            const auto lambda = [&value](auto& ctx ){ value = _attr(ctx) + 1; };
             BOOST_TEST(test_attr("/*123*/", comment[x3::uint_][lambda], value));
             BOOST_TEST(value == 124);
         }


### PR DESCRIPTION
These workarounds are enough to make X3 pass all the tests on VS2015 (19.00.24210).
I think they are not too awful. Otherwise VS2015 should be banned as unusable.