### PR TITLE
Parse into range

### DIFF
--- a/include/boost/spirit/home/x3/operator/detail/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/sequence.hpp
@@ -369,6 +369,16 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         return parse_sequence_plain(parser, first, last, context, rcontext, attr);
     }
 
+    template <typename Parser, typename Iterator, typename Context
+      , typename RContext, typename Attribute>
+    bool parse_sequence(
+        Parser const& parser, Iterator& first, Iterator const& last
+      , Context const& context, RContext& rcontext, Attribute& attr
+      , traits::range_attribute)
+    {
+        return parse_sequence_plain(parser, first, last, context, rcontext, attr);
+    }
+
     template <typename Left, typename Right, typename Iterator
       , typename Context, typename RContext, typename Attribute>
     bool parse_sequence(

--- a/include/boost/spirit/home/x3/support/traits/attribute_category.hpp
+++ b/include/boost/spirit/home/x3/support/traits/attribute_category.hpp
@@ -15,6 +15,7 @@
 #include <boost/fusion/include/is_sequence.hpp>
 #include <boost/fusion/support/category_of.hpp>
 #include <boost/spirit/home/x3/support/traits/is_variant.hpp>
+#include <boost/spirit/home/x3/support/traits/is_range.hpp>
 #include <boost/spirit/home/x3/support/traits/container_traits.hpp>
 #include <boost/spirit/home/x3/support/traits/optional_traits.hpp>
 
@@ -32,6 +33,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     struct associative_attribute {};
     struct variant_attribute {};
     struct optional_attribute {};
+    struct range_attribute {};
 
     template <typename T, typename Enable = void>
     struct attribute_category
@@ -47,21 +49,21 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
     template <typename T>
     struct attribute_category< T
-	, typename enable_if<
-	      typename mpl::eval_if< 
-		  fusion::traits::is_sequence<T>
-		  , fusion::traits::is_associative<T>
-		  , mpl::false_
-		  >::type >::type >
+    , typename enable_if<
+          typename mpl::eval_if<
+          fusion::traits::is_sequence<T>
+          , fusion::traits::is_associative<T>
+          , mpl::false_
+          >::type >::type >
         : mpl::identity<associative_attribute> {};
 
     template <typename T>
     struct attribute_category< T
-	, typename enable_if<
-	      mpl::and_<
-		  fusion::traits::is_sequence<T>
-		  , mpl::not_<fusion::traits::is_associative<T> > 
-		  > >::type >
+    , typename enable_if<
+          mpl::and_<
+          fusion::traits::is_sequence<T>
+          , mpl::not_<fusion::traits::is_associative<T> >
+          > >::type >
         : mpl::identity<tuple_attribute> {};
 
     template <typename T>
@@ -76,7 +78,16 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
     template <typename T>
     struct attribute_category<T,
-        typename enable_if<traits::is_container<T>>::type>
+        typename enable_if<traits::is_range<T>>::type>
+        : mpl::identity<range_attribute> {};
+
+    template <typename T>
+    struct attribute_category< T
+    , typename enable_if<
+          mpl::and_<
+          traits::is_container<T>
+          , mpl::not_<traits::is_range<T> >
+          > >::type >
         : mpl::identity<container_attribute> {};
 
 }}}}

--- a/include/boost/spirit/home/x3/support/traits/is_range.hpp
+++ b/include/boost/spirit/home/x3/support/traits/is_range.hpp
@@ -1,0 +1,27 @@
+/*=============================================================================
+    Copyright (c) 2001-2014 Joel de Guzman
+    http://spirit.sourceforge.net/
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#if !defined(BOOST_SPIRIT_X3_IS_RANGE_DEC_06_2017_1900PM)
+#define BOOST_SPIRIT_X3_IS_RANGE_DEC_06_2017_1900PM
+
+#include <boost/range/iterator_range.hpp>
+#include <boost/mpl/bool.hpp>
+
+namespace boost { namespace spirit { namespace x3 { namespace traits
+{
+    template <typename T, typename Enable = void>
+    struct is_range
+      : mpl::false_
+    {};
+
+    template <typename T>
+    struct is_range<boost::iterator_range<T>>
+      : mpl::true_
+    {};
+}}}}
+
+#endif

--- a/include/boost/spirit/home/x3/support/traits/move_to.hpp
+++ b/include/boost/spirit/home/x3/support/traits/move_to.hpp
@@ -17,7 +17,6 @@
 #include <boost/fusion/include/size.hpp>
 #include <boost/fusion/include/move.hpp>
 #include <boost/fusion/include/is_sequence.hpp>
-#include <boost/range/iterator_range.hpp>
 #include <utility>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
@@ -175,7 +174,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         
         template <typename Iterator>
         inline void
-        move_to(Iterator first, Iterator last, boost::iterator_range<Iterator>& rng, container_attribute)
+        move_to(Iterator first, Iterator last, boost::iterator_range<Iterator>& rng, range_attribute)
         {
             rng = {first, last};
         }

--- a/test/x3/raw.cpp
+++ b/test/x3/raw.cpp
@@ -18,6 +18,7 @@ int main()
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::raw;
     using boost::spirit::x3::eps;
+    using boost::spirit::x3::lit;
     using boost::spirit::x3::_attr;
 
     {
@@ -45,6 +46,13 @@ int main()
         boost::iterator_range<char const*> range;
         BOOST_TEST((test("x", raw[alpha][ ([&](auto& ctx){ range = _attr(ctx); }) ])));
         BOOST_TEST(range.size() == 1 && *range.begin() == 'x');
+    }
+
+    {
+        boost::iterator_range<char const*> range;
+        BOOST_TEST((test("x123x", lit('x') >> raw[+digit] >> lit('x'))));
+        BOOST_TEST((test_attr("x123x", lit('x') >> raw[+digit] >> lit('x'), range)));
+        BOOST_TEST((std::string(range.begin(), range.end()) == "123"));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
See https://svn.boost.org/trac10/ticket/12928

```cpp
    std::string str("x123x"); 
    boost::iterator_range<boost::range_iterator<decltype(str)>::type> attr; 
    if( x3::parse( boost::begin(str), boost::end(str), x3::lit('x') >> x3::raw[+x3::digit] >> x3::lit('x'), attr ) ) { 
        std::cout<<"Match! attr = "<<attr<<std::endl; 
    } else { 
        std::cout<<"Not match!"<<std::endl; 
    }
```
produces compile error
```
/usr/local/include/boost/spirit/home/x3/support/traits/container_traits.hpp:176:15: error: no member named 'insert' in 'boost::iterator_range<__gnu_cxx::__normal_iterator<char *, std::__cxx11::basic_string<char> > >'

            c.insert(c.end(), first, last);

            ~ ^
```
The iterator_range is no container and must not go to container_traits.