### PR TITLE
Qi: Permutations parser always initializes optionals

### DIFF
--- a/include/boost/spirit/home/qi/detail/permute_function.hpp
+++ b/include/boost/spirit/home/qi/detail/permute_function.hpp
@@ -43,22 +43,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             return false;
         }
 
-        template <typename Component, typename Attribute>
-        bool operator()(Component const& component, boost::optional<Attribute>& attr)
-        {
-            // return true if the parser succeeds and the slot is not yet taken
-            Attribute val;
-            if (!*taken && component.parse(first, last, context, skipper, val))
-            {
-                attr = val;
-                *taken = true;
-                ++taken;
-                return true;
-            }
-            ++taken;
-            return false;
-        }
-
         template <typename Component>
         bool operator()(Component const& component)
         {

--- a/test/qi/permutation.cpp
+++ b/test/qi/permutation.cpp
@@ -54,6 +54,12 @@ main()
         BOOST_TEST((!test("cca", char_('a') ^ char_('b') ^ char_('c'))));
     }
 
+    {   // test optional must stay uninitialized
+        optional<int> i;
+        BOOST_TEST((test_attr("", -int_ ^ int_, i)));
+        BOOST_TEST(!i);
+    }
+
     {
         vector<optional<int>, optional<char> > attr;
 


### PR DESCRIPTION
Closes https://svn.boost.org/trac10/ticket/12473

Optional parser never fails so `attr = val;` always triggers and initializes
the `attr` value. The special case for optional attributes could be safely
removed as any underlying parser must already correctly handle optionals.