### PR TITLE
Add Appveyor-CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,111 @@
+clone_depth: 50
+
+environment:
+  global:
+    PROJECT: libs\spirit
+    TEST_LINK_DEPS: date_time,filesystem,regex,system
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
+    CLCACHE_HARDLINK: 1
+    CLCACHE_CACHESIZE: 2123123123  # Appveyor allows us to store 1Gb of 7zipped cache but
+                                   # object files could be compressed 10:1 using fastest mode
+
+  matrix:
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017', ADDRMDL: 64, TOOLSET: 'msvc-14.1' }
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015', ADDRMDL: 64, TOOLSET: 'msvc-14.0' }
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015', ADDRMDL: 64, TOOLSET: 'msvc-12.0' }
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015', ADDRMDL: 32, TOOLSET: 'msvc-11.0' }
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015', ADDRMDL: 32, TOOLSET: 'msvc-10.0' }
+    - { APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015', ADDRMDL: 32, TOOLSET: 'msvc-9.0' }
+
+cache:
+  - '%USERPROFILE%\clcache'
+  - '%LOCALAPPDATA%\pip\Cache'
+
+init:
+  - set BOOST_ROOT=%APPVEYOR_BUILD_FOLDER%\..\boost
+  - set BOOST_BUILD_PATH=%BOOST_ROOT%\..\boost-build
+  - set B2_ARGS=-j%NUMBER_OF_PROCESSORS% link=shared threading=multi
+                variant=release address-model=%ADDRMDL% toolset=%TOOLSET%
+                define=BOOST_ALL_NO_LIB
+
+before_build:
+  - set PATH=%BOOST_ROOT%;C:\Python36-x64\Scripts;%PATH%
+  - ps: |
+      # Creating %USERPROFILE%/user-config.jam file
+      @'
+      
+      import feature os regex toolset ;
+      
+      # clcache
+      local toolset = [ regex.split [ os.environ TOOLSET ] "-" ] ;
+      
+      using $(toolset[1]) : $(toolset[2-]:J="-") : : <compiler>clcache ;
+      
+      # Ignore some warnings
+      feature.feature known-warnings : suppress : optional incidental propagated ;
+      toolset.flags msvc.compile OPTIONS <known-warnings>suppress :
+          -wd4244  # lit1.cpp(31): wchar_t to char truncation
+          -wd4996  # Call to 'std::copy' with parameters that may be unsafe
+          -wd4521  # x3/support/ast/variant.hpp(224): multiple copy constructors defined
+          -wd4003  # Fusion adapt_adt: not enough actual parameters for macro
+          -wd4127  # conditional expression is constant
+          -wd4459  # declaration of 'varname' hides global declaration
+        : unchecked ;
+      
+      '@ | sc "$env:USERPROFILE/user-config.jam"
+
+  - set BRANCH=%APPVEYOR_REPO_BRANCH%
+  # TODO: Determine the root branch when PR targeted/build from not our main branches.
+  - if not "%BRANCH%" == "master"
+    if not "%BRANCH%" == "develop"
+       set BRANCH=develop
+  - echo Root branch is %BRANCH%
+
+  # Sadly git's --shallow-submodules has hardcoded depth of 1 commit
+  # Patch the git binary with a little more depth to deal with boost-commitbot's lag
+  - ps: |
+      $git = Get-Command git | Select-Object -ExpandProperty Definition
+      $git = Split-Path -Parent $git | Split-Path -Parent
+      $git = [io.path]::combine($git, 'mingw64', 'bin', 'git.exe')
+      (Get-Content -Raw $git).Replace("--depth=1","--depth=9") | Set-Content $git
+
+  # Checkout Boost
+  - git clone -j10 --branch=%BRANCH% --depth=1 --quiet
+      --recurse-submodules=":(exclude)%PROJECT%" --shallow-submodules
+      https://github.com/boostorg/boost.git %BOOST_ROOT%
+  - pushd %BOOST_ROOT%
+  # Remove empty folder
+  - rmdir /S /Q %PROJECT%
+  # Move the repository to boost/libs and make a link to previous place
+  - move %APPVEYOR_BUILD_FOLDER% %PROJECT%
+  - mklink /J %APPVEYOR_BUILD_FOLDER% %PROJECT%
+
+  # Install clcache
+  - pip install git+https://github.com/frerich/clcache.git
+  - clcache -M %CLCACHE_CACHESIZE%
+  # Run clcache-server
+  - set CLCACHE_SERVER=1
+  - ps: Start-Process clcache-server.exe -PassThru
+
+build_script:
+  - bootstrap.bat --with-toolset=msvc
+    || ( echo === bootstrap.log === && cat bootstrap.log )
+
+  # bootstrap.bat does not support --with-libraries
+  - echo libraries = >> project-config.jam
+  - for %%a in ("%TEST_LINK_DEPS:,=" "%") do (
+      echo --with-%%~a >> project-config.jam
+    )
+  - echo ; >> project-config.jam
+
+  # Let's have less noise (Appveyor cannot collapse command output)
+  - b2 headers 2>&1 >> deps_build.log &&
+    b2 %B2_ARGS% warnings=off 2>&1 >> deps_build.log
+    || ( echo === deps_build.log === && cat deps_build.log )
+
+test_script:
+  - set B2_ARGS=%B2_ARGS% warnings=on known-warnings=suppress warnings-as-errors=on
+  - echo B2 argumets %B2_ARGS%
+  - b2 %B2_ARGS% %PROJECT%\classic\test
+  - b2 %B2_ARGS% %PROJECT%\repository\test
+  - b2 %B2_ARGS% %PROJECT%\test


### PR DESCRIPTION
Mostly the same as #291.

There is no `ccache` on Windows, so I am using `clcache`.
VS2017 build with `/std:c++latest` might be added later.

The build times are disaster.