### PR TITLE
Classic: Fix compilation with BOOST_DISABLE_THREADS defined

### DIFF
--- a/classic/test/Jamfile
+++ b/classic/test/Jamfile
@@ -143,6 +143,7 @@ local multi-threading = <library>/boost/thread//boost_thread
     test-suite "spirit.classic.utility.support"
         # This test doesn't actually use multiple threads
         : [ spirit-run scoped_lock_tests.cpp : : : $(multi-threading) ]
+          [ compile threads_disabled_compile.cpp ]
         ;
 
     test-suite "spirit.classic.iterator"

--- a/classic/test/threads_disabled_compile.cpp
+++ b/classic/test/threads_disabled_compile.cpp
@@ -1,0 +1,19 @@
+/*=============================================================================
+    Copyright (c) 2017 Nikita Kniazev
+    http://spirit.sourceforge.net/
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+// Spirit should not include any Boost.Thread header until user explicitly
+// requested threadsafe support with BOOST_SPIRIT_THREADSAFE defined.
+
+#undef BOOST_SPIRIT_THREADSAFE
+#ifndef BOOST_DISABLE_THREADS
+# define BOOST_DISABLE_THREADS
+#endif
+#include <boost/spirit/include/classic.hpp>
+
+int main() { return 0; }

--- a/include/boost/spirit/home/classic/utility.hpp
+++ b/include/boost/spirit/home/classic/utility.hpp
@@ -34,7 +34,9 @@
 
 // Utility.Support
 #include <boost/spirit/home/classic/utility/flush_multi_pass.hpp>
+#ifdef BOOST_SPIRIT_THREADSAFE
 #include <boost/spirit/home/classic/utility/scoped_lock.hpp>
+#endif
 
 
 #endif // !defined(BOOST_SPIRIT_UTILITY_MAIN_HPP)


### PR DESCRIPTION
Closes https://svn.boost.org/trac10/ticket/12639

Spirit should not include any Boost.Thread header until user explicitly
requested threadsafe support with BOOST_SPIRIT_THREADSAFE defined.