### PR TITLE
Lex: Fixed C2001 'newline in constant' warning in generated lexers

### DIFF
--- a/include/boost/spirit/home/lex/lexer/lexertl/generate_static.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/generate_static.hpp
@@ -415,7 +415,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             {
                 os_ << "            std::size_t index = *curr_++\n";
             }
-            os_ << "            bol = (index == '\n') ? true : false;\n";
+            os_ << "            bol = (index == '\\n') ? true : false;\n";
             os_ << "            std::size_t const state_ = ptr_[\n";
             os_ << "                lookup_[static_cast<std::size_t>(index)]];\n";
 
@@ -442,7 +442,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             {
                 os_ << "            std::size_t index = *curr_++\n";
             }
-            os_ << "            bol = (index == '\n') ? true : false;\n";
+            os_ << "            bol = (index == '\\n') ? true : false;\n";
             os_ << "            std::size_t const state_ = ptr_[\n";
             os_ << "                lookup_[static_cast<std::size_t>(index)]];\n";
 
@@ -469,7 +469,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             {
                 os_ << "            std::size_t index = *curr_++\n";
             }
-            os_ << "            bol = (index == '\n') ? true : false;\n";
+            os_ << "            bol = (index == '\\n') ? true : false;\n";
             os_ << "            std::size_t const state_ = ptr_[\n";
             os_ << "                lookup_[static_cast<std::size_t>(index)]];\n";
 
@@ -577,7 +577,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
 
         if (sm_.data()._seen_BOL_assertion)
         {
-            os_ << "        bol_ = (*start_token_ == '\n') ? true : false;\n";
+            os_ << "        bol_ = (*start_token_ == '\\n') ? true : false;\n";
         }
 
         os_ << "        id_ = npos;\n";
@@ -749,7 +749,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
                     }
                     if (iter_->eol_index != boost::lexer::npos)
                     {
-                        os_ << "\n    if (ch_ == '\n') goto state" << dfa_
+                        os_ << "\n    if (ch_ == '\\n') goto state" << dfa_
                             << '_' << iter_->eol_index << ";\n";
                     }
                     os_ << "    ++curr_;\n";


### PR DESCRIPTION
Closes https://svn.boost.org/trac10/ticket/11540.

Actually this should have been caught by `regression_matlib_generate_switch`
test, but it is not complex enough to cover all cases. We do not have the
coverage reports yet, but the fix is trivial so I think it is ok.