### PR TITLE
X3: Reenable fusion::map support

### DIFF
--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -17,6 +17,7 @@
 #include <boost/spirit/home/x3/support/traits/is_substitute.hpp>
 #include <boost/spirit/home/x3/support/traits/move_to.hpp>
 #include <boost/mpl/and.hpp>
+#include <boost/fusion/include/at_key.hpp>
 #include <boost/fusion/include/front.hpp>
 #include <boost/fusion/include/back.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -37,10 +38,6 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         }
     };
 
-/*	$$$ clang reports: warning: class template partial specialization contains
- *	a template parameter that can not be deduced; this partial specialization
- *	will never be used $$$
- *
     // save to associative fusion container where Key
     // is variant over possible keys
     template <typename ...T>
@@ -54,7 +51,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             apply_visitor(saver_visitor<Attribute, Value>(attr, value), key);
         }
     };
-*/
+
     template <typename Attribute, typename Value>
     struct saver_visitor  : boost::static_visitor<void>
     {

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -116,6 +116,7 @@ run confix.cpp ;
 run repeat.cpp ;
 run seek.cpp ;
 
+run fusion_map.cpp ;
 run x3_variant.cpp ;
 run error_handler.cpp /boost//system /boost//filesystem ;
 run iterator_check.cpp ;

--- a/test/x3/fusion_map.cpp
+++ b/test/x3/fusion_map.cpp
@@ -6,6 +6,7 @@
   =============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
+#include <boost/fusion/include/at_key.hpp>
 #include <boost/fusion/include/make_map.hpp>
 #include <boost/fusion/adapted/struct.hpp>
 
@@ -32,12 +33,6 @@ bool test_attr(const std::string in,Parser const& p, Attribute& attr) {
     auto it = in.begin();
     return boost::spirit::x3::parse(it,in.end(), p, attr);
 }
-
-// force tratis::move_to to overwrite destination, insteadof appending
-namespace boost { namespace spirit { namespace x3 { namespace traits {
-template <>
-struct build_container<char> : mpl::identity<std::string> {};
-}}}}
 
 int
 main()


### PR DESCRIPTION
`build_container<char>` specialization was added in 84c0c075 (#5)