### PR TITLE
X3: Fixed iterator move_to to single item sequence

### DIFF
--- a/include/boost/spirit/home/x3/support/traits/move_to.hpp
+++ b/include/boost/spirit/home/x3/support/traits/move_to.hpp
@@ -171,6 +171,15 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
             else
                 append(dest, first, last);
         }
+
+        template <typename Iterator, typename Dest>
+        inline typename enable_if<
+            is_size_one_sequence<Dest>
+        >::type
+        move_to(Iterator first, Iterator last, Dest& dest, tuple_attribute)
+        {
+            traits::move_to(first, last, fusion::front(dest));
+        }
         
         template <typename Iterator>
         inline void

--- a/test/x3/lit1.cpp
+++ b/test/x3/lit1.cpp
@@ -7,6 +7,7 @@
 =============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
+#include <boost/fusion/include/vector.hpp>
 
 #include <string>
 #include "test.hpp"
@@ -72,6 +73,12 @@ main()
         s.clear();
         BOOST_TEST((test_attr("x", string("x"), s)));
         BOOST_TEST(s == "x");
+    }
+
+    { // single-element fusion vector tests
+        boost::fusion::vector<std::string> s;
+        BOOST_TEST(test_attr("kimpo", string("kimpo"), s));
+        BOOST_TEST(boost::fusion::at_c<0>(s) == "kimpo");
     }
 
     return boost::report_errors();


### PR DESCRIPTION
This affects lazy attribute constructing parsers, which exposes not an actual
attribute, but a pair of iterators (like `string` or `attr("...")`).