### PR TITLE
X3: Dereference a single item view instead of unwrapping sequence

### DIFF
--- a/include/boost/spirit/home/x3/operator/detail/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/sequence.hpp
@@ -103,30 +103,30 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         }
     };
 
-    template <typename Parser, typename Attribute, bool pass_through>
+    template <typename Parser, typename Attribute>
     struct pass_sequence_attribute_used :
-        mpl::if_c<
-            (!pass_through && traits::is_size_one_sequence<Attribute>::value)
+        mpl::if_<
+            traits::is_size_one_sequence<Attribute>
           , pass_sequence_attribute_front<Attribute>
           , pass_through_sequence_attribute<Attribute>>::type {};
 
-    template <typename Parser, typename Attribute, bool pass_through = false, typename Enable = void>
+    template <typename Parser, typename Attribute, typename Enable = void>
     struct pass_sequence_attribute :
         mpl::if_<
             fusion::result_of::empty<Attribute>
           , pass_sequence_attribute_unused
-          , pass_sequence_attribute_used<Parser, Attribute, pass_through>>::type {};
+          , pass_sequence_attribute_used<Parser, Attribute>>::type {};
 
-    template <typename L, typename R, typename Attribute, bool pass_through>
-    struct pass_sequence_attribute<sequence<L, R>, Attribute, pass_through>
+    template <typename L, typename R, typename Attribute>
+    struct pass_sequence_attribute<sequence<L, R>, Attribute>
       : pass_through_sequence_attribute<Attribute> {};
 
     template <typename Parser, typename Attribute>
     struct pass_sequence_attribute_subject :
         pass_sequence_attribute<typename Parser::subject_type, Attribute> {};
 
-    template <typename Parser, typename Attribute, bool pass_through>
-    struct pass_sequence_attribute<Parser, Attribute, pass_through
+    template <typename Parser, typename Attribute>
+    struct pass_sequence_attribute<Parser, Attribute
       , typename enable_if_c<(Parser::is_pass_through_unary)>::type>
       : pass_sequence_attribute_subject<Parser, Attribute> {};
 
@@ -150,8 +150,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         typedef typename fusion::result_of::end<Attribute>::type r_end;
         typedef fusion::iterator_range<l_begin, l_end> l_part;
         typedef fusion::iterator_range<l_end, r_end> r_part;
-        typedef pass_sequence_attribute<L, l_part, false> l_pass;
-        typedef pass_sequence_attribute<R, r_part, false> r_pass;
+        typedef pass_sequence_attribute<L, l_part> l_pass;
+        typedef pass_sequence_attribute<R, r_part> r_pass;
 
         static l_part left(Attribute& s)
         {
@@ -175,7 +175,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         typedef unused_type l_part;
         typedef Attribute& r_part;
         typedef pass_sequence_attribute_unused l_pass;
-        typedef pass_sequence_attribute<R, Attribute, true> r_pass;
+        typedef pass_sequence_attribute<R, Attribute> r_pass;
 
         static unused_type left(Attribute&)
         {
@@ -195,7 +195,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         typedef Attribute& l_part;
         typedef unused_type r_part;
-        typedef pass_sequence_attribute<L, Attribute, true> l_pass;
+        typedef pass_sequence_attribute<L, Attribute> l_pass;
         typedef pass_sequence_attribute_unused r_pass;
 
         static Attribute& left(Attribute& s)

--- a/include/boost/spirit/home/x3/operator/detail/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/sequence.hpp
@@ -13,11 +13,13 @@
 #include <boost/spirit/home/x3/support/traits/has_attribute.hpp>
 #include <boost/spirit/home/x3/support/traits/is_substitute.hpp>
 #include <boost/spirit/home/x3/support/traits/container_traits.hpp>
+#include <boost/spirit/home/x3/support/traits/tuple_traits.hpp>
 #include <boost/spirit/home/x3/core/detail/parse_into_container.hpp>
 
 #include <boost/fusion/include/begin.hpp>
 #include <boost/fusion/include/end.hpp>
 #include <boost/fusion/include/advance.hpp>
+#include <boost/fusion/include/deref.hpp>
 #include <boost/fusion/include/empty.hpp>
 #include <boost/fusion/include/front.hpp>
 #include <boost/fusion/include/iterator_range.hpp>
@@ -79,14 +81,16 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     };
 
     template <typename Attribute>
-    struct pass_sequence_attribute_front
+    struct pass_sequence_attribute_size_one_view
     {
-        typedef typename fusion::result_of::front<Attribute>::type type;
+        typedef typename fusion::result_of::deref<
+            typename fusion::result_of::begin<Attribute>::type
+        >::type type;
 
         static typename add_reference<type>::type
         call(Attribute& attr)
         {
-            return fusion::front(attr);
+            return fusion::deref(fusion::begin(attr));
         }
     };
 
@@ -106,8 +110,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     template <typename Parser, typename Attribute>
     struct pass_sequence_attribute_used :
         mpl::if_<
-            traits::is_size_one_sequence<Attribute>
-          , pass_sequence_attribute_front<Attribute>
+            traits::is_size_one_view<Attribute>
+          , pass_sequence_attribute_size_one_view<Attribute>
           , pass_through_sequence_attribute<Attribute>>::type {};
 
     template <typename Parser, typename Attribute, typename Enable = void>

--- a/include/boost/spirit/home/x3/support/traits/tuple_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/tuple_traits.hpp
@@ -8,6 +8,7 @@
 #define BOOST_SPIRIT_X3_TUPLE_TRAITS_JANUARY_2012_1132PM
 
 #include <boost/fusion/include/is_sequence.hpp>
+#include <boost/fusion/include/is_view.hpp>
 #include <boost/fusion/include/size.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/and.hpp>
@@ -41,6 +42,14 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
       : mpl::and_<
             fusion::traits::is_sequence<Seq>
           , has_size<Seq, 1>
+        >
+    {};
+
+    template <typename View>
+    struct is_size_one_view
+      : mpl::and_<
+            fusion::traits::is_view<View>
+          , has_size<View, 1>
         >
     {};
 }}}}

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -117,6 +117,7 @@ run confix.cpp ;
 run repeat.cpp ;
 run seek.cpp ;
 
+run attribute_type_check.cpp ;
 run fusion_map.cpp ;
 run x3_variant.cpp ;
 run error_handler.cpp /boost//system /boost//filesystem ;

--- a/test/x3/attribute_type_check.cpp
+++ b/test/x3/attribute_type_check.cpp
@@ -1,0 +1,113 @@
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/spirit/home/x3.hpp>
+#include <boost/fusion/include/vector.hpp>
+#include <boost/fusion/include/make_vector.hpp>
+#include <boost/fusion/include/equal_to.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/optional.hpp>
+#include <string>
+
+namespace x3 = boost::spirit::x3;
+
+// just an `attr` with added type checker
+template <typename Value, typename Expected>
+struct checked_attr_parser : x3::attr_parser<Value>
+{
+    using base_t = x3::attr_parser<Value>;
+
+    checked_attr_parser(Value const& value) : base_t(value) {}
+    checked_attr_parser(Value&& value) : base_t(std::move(value)) {}
+
+    template <typename Iterator, typename Context
+      , typename RuleContext, typename Attribute>
+    bool parse(Iterator& first, Iterator const& last
+      , Context const& ctx, RuleContext& rctx, Attribute& attr_) const
+    {
+        static_assert(boost::is_same<Expected, Attribute>::value,
+            "attribute type check failed");
+        return base_t::parse(first, last, ctx, rctx, attr_);
+    }
+};
+
+template <typename Expected, typename Value>
+static inline checked_attr_parser<boost::decay_t<Value>, Expected>
+checked_attr(Value&& value) { return { std::forward<Value>(value) }; }
+
+// instantiate our type checker
+// (checks attribute value just to be sure we are ok)
+template <typename Value, typename Expr>
+static void test_expr(Value const& v, Expr&& expr)
+{
+    char const* it = "";
+    Value r;
+    BOOST_TEST((x3::parse(it, it, std::forward<Expr>(expr), r)));
+    BOOST_TEST((r == v));
+}
+
+template <typename Expr, typename Attribute>
+static void gen_sequence(Attribute const& attribute, Expr&& expr)
+{
+    test_expr(attribute, expr);
+    test_expr(attribute, expr >> x3::eps);
+}
+
+template <typename Expected, typename... ExpectedTail, typename Attribute, typename Expr, typename Value, typename... Tail>
+static void gen_sequence(Attribute const& attribute, Expr&& expr, Value const& v, Tail const&... tail)
+{
+    gen_sequence<ExpectedTail...>(attribute, expr >> checked_attr<Expected>(v), tail...);
+    gen_sequence<ExpectedTail...>(attribute, expr >> x3::eps >> checked_attr<Expected>(v), tail...);
+    gen_sequence<ExpectedTail...>(attribute, expr >> (x3::eps >> checked_attr<Expected>(v)), tail...);
+}
+
+template <typename Expected, typename... ExpectedTail, typename Attribute, typename Value, typename... Tail>
+static void gen_sequence_tests(Attribute const& attribute, Value const& v, Tail const&... tail)
+{
+    gen_sequence<ExpectedTail...>(attribute, checked_attr<Expected>(v), tail...);
+    gen_sequence<ExpectedTail...>(attribute, x3::eps >> checked_attr<Expected>(v), tail...);
+}
+
+template <typename Expected, typename Value>
+static void gen_single_item_tests(Value const& v)
+{
+    Expected attribute(v);
+    gen_sequence(attribute, checked_attr<Expected>(v));
+    gen_sequence(attribute, x3::eps >> checked_attr<Expected>(v));
+}
+
+template <typename Expected, typename... ExpectedTail, typename Value, typename... Tail>
+static void gen_single_item_tests(Value const& v, Tail const&... tail)
+{
+    gen_single_item_tests<Expected>(v);
+    gen_single_item_tests<ExpectedTail...>(tail...);
+}
+
+template <typename... Expected, typename... Values>
+static void gen_tests(Values const&... values)
+{
+    gen_single_item_tests<Expected...>(values...);
+
+    boost::fusion::vector<Expected...> attribute = boost::fusion::make_vector(values...);
+    gen_sequence_tests<Expected...>(attribute, values...);
+}
+
+template <typename... Attributes>
+void make_test(Attributes const&... attrs)
+{
+    // I would like to place all of this in a single call
+    // but it requires tremendous amount of heap to compile
+    gen_tests<Attributes...>(attrs...);
+    gen_tests<
+        boost::optional<Attributes>...
+      , boost::fusion::vector<Attributes>...
+    >(attrs..., attrs...);
+    gen_tests<
+        boost::optional<boost::fusion::vector<Attributes>>...
+      , boost::fusion::vector<boost::optional<Attributes>>...
+    >(boost::fusion::vector<Attributes>(attrs)..., attrs...);
+}
+
+int main()
+{
+    make_test<int, std::string>(123, "hello");
+    return boost::report_errors();
+}


### PR DESCRIPTION
Most of discussion happened in https://github.com/boostorg/spirit/pull/219#issuecomment-352905393.
Brief overall: Currently we do not know what a8e391b was fixing (and it seems partly redundant), but it introduced an unwanted behavior of passing `fusion::iterator_range` to attribute-generating parsers.

This PR reimplements a spirit of a8e391b commit. It tries to pass through as many attributes as
possible. For example: a single item sequences like `fusion::vector<T>` will be passed through,
while fusion iterators, fusion iterator range or view of size one will be dereferenced before passing
to underlying parsers of sequence parser.

TODO:
  - Tests? It is not that easy to test, but I can make a custom parser and check attribute type in it.
  - Should `tuple_traits.hpp` be renamed? The name already does not reflect the content.
