### PR TITLE
Inheriting std::iterator is deprecated in c++17

### DIFF
--- a/classic/test/position_iterator_tests.cpp
+++ b/classic/test/position_iterator_tests.cpp
@@ -13,7 +13,8 @@
 #include <string>
 #include <list>
 #include <algorithm>
-#include <boost/iterator.hpp>
+#include <iterator>
+#include <cstddef>
 #include <boost/config.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/mpl/list.hpp>
@@ -479,12 +480,16 @@ void CheckDistance(void)
 namespace test_impl {
 
     class check_singular_iterator
-        : public boost::iterator<std::forward_iterator_tag, int>
     {
         bool singular_;
         int count_;
 
     public:
+        typedef std::forward_iterator_tag iterator_category;
+        typedef int value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef int* pointer;
+        typedef int& reference;
 
         check_singular_iterator() : singular_(true), count_(0) {}
         explicit check_singular_iterator(int x) : singular_(false), count_(x) {}

--- a/include/boost/spirit/home/classic/iterator/multi_pass.hpp
+++ b/include/boost/spirit/home/classic/iterator/multi_pass.hpp
@@ -16,7 +16,6 @@
 #include <algorithm>    // for std::swap
 #include <exception>    // for std::exception
 #include <boost/limits.hpp>
-#include <boost/iterator.hpp>
 
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/assert.hpp> // for BOOST_SPIRIT_ASSERT
@@ -760,24 +759,19 @@ class inner
 
 namespace iterator_ { namespace impl {
 
-// Meta-function to generate a std::iterator<> base class for multi_pass. This
-//  is used mainly to improve conformance of compilers not supporting PTS
-//  and thus relying on inheritance to recognize an iterator.
-// We are using boost::iterator<> because it offers an automatic workaround
-//  for broken std::iterator<> implementations.
+// Meta-function to generate a std::iterator<>-like base class for multi_pass.
 template <typename InputPolicyT, typename InputT>
 struct iterator_base_creator
 {
     typedef typename InputPolicyT::BOOST_NESTED_TEMPLATE inner<InputT> input_t;
 
-    typedef boost::iterator
-    <
-        std::forward_iterator_tag,
-        typename input_t::value_type,
-        typename input_t::difference_type,
-        typename input_t::pointer,
-        typename input_t::reference
-    > type;
+    struct type {
+        typedef std::forward_iterator_tag iterator_category;
+        typedef typename input_t::value_type value_type;
+        typedef typename input_t::difference_type difference_type;
+        typedef typename input_t::pointer pointer;
+        typedef typename input_t::reference reference;
+    };
 };
 
 }}

--- a/include/boost/spirit/home/karma/stream/ostream_iterator.hpp
+++ b/include/boost/spirit/home/karma/stream/ostream_iterator.hpp
@@ -25,9 +25,13 @@ namespace boost { namespace spirit { namespace karma
         typename T, typename Elem = char
       , typename Traits = std::char_traits<Elem> >
     class ostream_iterator 
-      : public std::iterator<std::output_iterator_tag, void, void, void, void>
     {
     public:
+        typedef std::output_iterator_tag iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
         typedef Elem char_type;
         typedef Traits traits_type;
         typedef std::basic_ostream<Elem, Traits> ostream_type;

--- a/include/boost/spirit/home/support/iterators/detail/multi_pass.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/multi_pass.hpp
@@ -9,7 +9,6 @@
 
 #include <boost/config.hpp>
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
-#include <boost/iterator.hpp>
 #include <boost/mpl/bool.hpp>
 #include <iterator>
 #include <algorithm> 


### PR DESCRIPTION
Boost's iterator.hpp is deprecated, too. It does nothing but pulling std::iterator into namespace boost and including standard headers 'iterator' and 'cstddef'. Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.