### PR TITLE
Boost spirit instantiate

### DIFF
--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -120,3 +120,4 @@ run fusion_map.cpp ;
 run x3_variant.cpp ;
 run error_handler.cpp /boost//system /boost//filesystem ;
 run iterator_check.cpp ;
+run [ glob linker_error_test/*.cpp ] : : : : linker_error ;

--- a/test/x3/linker_error_test/ast.hpp
+++ b/test/x3/linker_error_test/ast.hpp
@@ -1,0 +1,76 @@
+//
+// Created by lukas on 11.11.16.
+//
+
+#ifndef LINKER_ERROR_EXAMPLE_AST_HPP_HPP
+#define LINKER_ERROR_EXAMPLE_AST_HPP_HPP
+
+#include <boost/fusion/adapted/struct.hpp>
+//#define BOOST_SPIRIT_X3_DEBUG
+//#define PRAGMA_X3_DEBUG
+#ifdef PRAGMA_X3_DEBUG
+#ifdef BOOST_SPIRIT_X3_DEBUG
+    #pragma message "yesdef(BOOST_SPIRIT_X3_DEBUG)"
+#else
+    #pragma message "notdef(BOOST_SPIRIT_X3_DEBUG)"
+#endif
+#endif//PRAGMA_X3_DEBUG
+#include <boost/spirit/home/x3.hpp>
+#include <boost/spirit/home/x3/support/ast/variant.hpp>
+#define VARIABLE_DEC_OPTIONAL
+  //The reason for this macro is apparent
+  //in example_def.hpp
+//#define PRAGMA_VARIABLE_OPTIONAL
+#ifdef PRAGMA_VARIABLE_OPTIONAL
+#ifdef VARIABLE_DEC_OPTIONAL
+    #pragma message "yesdef(VARIABLE_DEC_OPTIONAL)"
+    #include <boost/optional/optional_io.hpp>//in response to compile-time err msg.
+#else
+    #pragma message "notdef(VARIABLE_DEC_OPTIONAL)"
+#endif
+#endif//PRAGMA_VARIABLE_OPTIONAL
+
+#include <vector>
+#include <string>
+
+namespace client { namespace ast {
+
+namespace x3 = boost::spirit::x3;
+
+struct LambdaType;
+struct ClassType;
+struct nil{};
+
+typedef x3::variant <
+    nil,
+    x3::forward_ast<LambdaType>,
+    x3::forward_ast<ClassType>
+> Type;
+
+struct LambdaType {
+    std::vector<Type> parameters_;
+    Type return_type_;
+};
+
+struct ClassType {
+    std::vector<std::string> name_;
+    std::vector<Type> template_args_;
+};
+
+struct VariableDec {
+    std::string _name;
+  #ifdef VARIABLE_DEC_OPTIONAL
+      boost::optional<Type> 
+  #else
+      Type
+  #endif
+    _type;
+};
+
+}}
+
+BOOST_FUSION_ADAPT_STRUCT(client::ast::LambdaType, parameters_, return_type_)
+BOOST_FUSION_ADAPT_STRUCT(client::ast::ClassType, name_, template_args_)
+BOOST_FUSION_ADAPT_STRUCT(client::ast::VariableDec, _name, _type)
+
+#endif //LINKER_ERROR_EXAMPLE_AST_HPP_HPP

--- a/test/x3/linker_error_test/config.hpp
+++ b/test/x3/linker_error_test/config.hpp
@@ -1,0 +1,18 @@
+#ifndef LINKER_ERROR_EXAMPLE_CONFIG_HPP
+#define LINKER_ERROR_EXAMPLE_CONFIG_HPP
+
+#include <boost/spirit/home/x3.hpp>
+
+namespace client{
+namespace parser{
+
+namespace x3 = boost::spirit::x3;
+
+
+typedef std::string::const_iterator iterator_type;
+typedef x3::phrase_parse_context<x3::ascii::space_type>::type context_type;
+
+}
+}
+
+#endif //LINKER_ERROR_EXAMPLE_CONFIG_HPP

--- a/test/x3/linker_error_test/example.cpp
+++ b/test/x3/linker_error_test/example.cpp
@@ -1,0 +1,8 @@
+#include "example_def.hpp"
+#include "config.hpp"
+
+namespace client { namespace parser {
+
+BOOST_SPIRIT_INSTANTIATE(var_dec_type, iterator_type, context_type)
+
+}}

--- a/test/x3/linker_error_test/example.hpp
+++ b/test/x3/linker_error_test/example.hpp
@@ -1,0 +1,24 @@
+#ifndef LINKER_ERROR_EXAMPLE_EXAMPLE_HPP
+#define LINKER_ERROR_EXAMPLE_EXAMPLE_HPP
+
+#include "ast.hpp"
+#include <boost/spirit/home/x3.hpp>
+
+namespace client { namespace parser {
+
+namespace x3 = boost::spirit::x3;
+
+class var_dec_class {};
+
+typedef x3::rule<var_dec_class, ast::VariableDec> var_dec_type;
+
+BOOST_SPIRIT_DECLARE(var_dec_type)
+
+}}
+
+namespace client {
+
+const parser::var_dec_type& var_dec();
+
+}
+#endif //LINKER_ERROR_EXAMPLE_EXAMPLE_HPP

--- a/test/x3/linker_error_test/example_def.hpp
+++ b/test/x3/linker_error_test/example_def.hpp
@@ -1,0 +1,36 @@
+#ifndef LINKER_ERROR_EXAMPLE_EXAMPLE_DEF_HPP
+#define LINKER_ERROR_EXAMPLE_EXAMPLE_DEF_HPP
+
+#include "example.hpp"
+#include "types.hpp"
+
+namespace client { namespace parser {
+
+const var_dec_type& var_dec_rule()
+{ static const var_dec_type rule = "var_dec";
+  return rule;
+}
+const auto var_dec=var_dec_rule();
+
+auto const var_dec_def = x3::lexeme["var "]
+                         > +x3::alnum
+                         > ":"
+                         >> type() //<- this gets linker error without patch.
+                         > ";";
+
+BOOST_SPIRIT_DEFINE(
+  var_dec
+)
+
+}}
+
+namespace client {
+
+const parser::var_dec_type& var_dec()
+{
+    return parser::var_dec_rule();
+}
+
+}
+
+#endif //LINKER_ERROR_EXAMPLE_EXAMPLE_DEF_HPP

--- a/test/x3/linker_error_test/main.cpp
+++ b/test/x3/linker_error_test/main.cpp
@@ -1,0 +1,31 @@
+//Purpose:
+//  Test solution to the link problem reported in post:
+/*
+http://boost.2283326.n4.nabble.com/Linking-error-when-changing-gt-to-gt-gt-tc4689820.html
+ */
+//    
+//===========================================
+#include <boost/detail/lightweight_test.hpp>
+#include <iostream>
+#include "types.hpp"
+#include "example.hpp"
+
+template<typename Parser, typename Attribute>
+bool test(const std::string& str, Parser const& p, Attribute& attr)
+{
+    using iterator_type = std::string::const_iterator;
+    iterator_type in = str.begin();
+    iterator_type end = str.end();
+
+    bool ret = boost::spirit::x3::phrase_parse(in, end, p, boost::spirit::x3::ascii::space, attr);
+    ret &= (in == end);
+    return ret;
+}
+
+int main()
+{
+    client::ast::VariableDec attr;
+    bool result=test("var foo : foo<bar, baz<bahama>> ;", client::var_dec() , attr);
+    BOOST_TEST(result);
+    return boost::report_errors();
+}

--- a/test/x3/linker_error_test/types.cpp
+++ b/test/x3/linker_error_test/types.cpp
@@ -1,0 +1,12 @@
+#include "config.hpp"
+#include "types_def.hpp"
+#include <iostream>
+
+namespace client {namespace parser {
+
+BOOST_SPIRIT_INSTANTIATE(type_type, iterator_type, context_type);
+
+BOOST_SPIRIT_INSTANTIATE(class_type_type, iterator_type, context_type);
+}}
+
+

--- a/test/x3/linker_error_test/types.hpp
+++ b/test/x3/linker_error_test/types.hpp
@@ -1,0 +1,30 @@
+#ifndef KYLE_PARSER_TYPES_HPP
+#define KYLE_PARSER_TYPES_HPP
+
+#include "ast.hpp"
+#include <boost/spirit/home/x3.hpp>
+
+namespace client { namespace parser {
+namespace x3 = boost::spirit::x3;
+
+struct class_type_class;
+struct type_class;
+
+typedef x3::rule<class_type_class, ast::ClassType> class_type_type;
+typedef x3::rule<type_class, ast::Type> type_type;
+
+BOOST_SPIRIT_DECLARE(class_type_type,
+                     type_type)
+
+
+}}
+
+
+namespace client {
+
+const parser::class_type_type& class_type();
+const parser::type_type& type();
+
+}
+
+#endif

--- a/test/x3/linker_error_test/types_def.hpp
+++ b/test/x3/linker_error_test/types_def.hpp
@@ -1,0 +1,65 @@
+#ifndef KYLE_TYPES_DEF_HPP
+#define KYLE_TYPES_DEF_HPP
+
+#include "types.hpp"
+
+
+namespace client { namespace parser {
+namespace x3 = boost::spirit::x3;
+
+
+typedef x3::rule<struct lambda_type_class, ast::LambdaType> lambda_type_type;
+
+
+const auto& class_type_rule()
+{ static class_type_type rule = "class_type";
+  return rule;
+}
+const auto& lambda_type_rule()
+{ static lambda_type_type rule = "lambda_type";
+  return rule;
+}
+const auto& type_rule()
+{
+  static const type_type rule = "type";
+  return rule;
+}
+const auto class_type=class_type_rule();
+const auto lambda_type=lambda_type_rule();
+const auto type=type_rule();
+
+auto const identifier = +x3::alnum;
+
+auto const type_def =
+        (lambda_type | class_type);
+
+auto const lambda_type_def =
+        ("(" > -(type % ",") > ")" > "=>" > type)
+        | ((x3::repeat(1)[class_type] >> "=>") > type);
+
+
+auto const class_type_def =
+        (identifier % "::") >> -("<" > type % "," > ">");
+
+BOOST_SPIRIT_DEFINE(
+  lambda_type,
+  class_type,
+  type
+)
+
+}}
+
+namespace client {
+
+const parser::class_type_type& class_type()
+{
+    return parser::class_type_rule();
+}
+const parser::type_type& type()
+{
+    return parser::type_rule();
+}
+
+}
+
+#endif //KYLE_TYPES_DEF_HPP


### PR DESCRIPTION
* Problem:

    Separate compilation of grammar rules using the
    `BOOST_SPIRIT_INSTANTIATE` macro, under some
    circumstances( maybe when attribute is *not* of type
    unused_type *and* there's no semantic action?) leads
    to link error.
    
    The problem occurs because the
    `BOOST_SPIRIT_INSTANTIATE` macro generates a
    `parse_rule` instantiation requiring a specific type,
    `rule_type::attribute_type`, for the rule's attribute
    argument. In contrast, the `rule<ID,Attribute>::parse`
    function takes an arugment `ActualAttribute& attr` and
    passes that to the `parse_rule` function.  When
    `Attribute != ActualAttribute`, the link error occurs.
    
* Interest in solution.
    * [Exagon.linking-error-when](http://boost.2283326.n4.nabble.com/Linking-error-when-changing-to-tp4689820.html)
    * [OlafPeter.linkerr-separate-tu](https://stackoverflow.com/questions/43791079/x3-linker-error-with-separate-tu)
    * [Halvorsen.instant-linkerr](http://boost.2283326.n4.nabble.com/X3-declare-define-instantiate-linker-error-tp4694282.html)

* Method of solution.

  In the current `spirit` method, the `ActualAttribute&
  attr` that is passed to the `parse_rule` function that
  is called by `rule<ID,Attribute>::parse` is transformed,
  after a few intervening function calls, into `Attribute&
  _attr` by code at the beginning of the:
  
    > `detail::rule_parser<...>::call_rule_definition` 
  
  function.  This `attribute transform code` extends
  [from here](https://github.com/boostorg/spirit/blob/master/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp#L306)
  [to here](https://github.com/boostorg/spirit/blob/master/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp#L347), 
  execept for the `parsing/debugging code` actually doing the
  parsing.  This `parsing/debugging code` extends
  [from here](https://github.com/boostorg/spirit/blob/master/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp#L319)
  [to here](https://github.com/boostorg/spirit/blob/master/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp#L341)
  and separates the `attribute pre-transform code` from
  the `attribute post-transform code`.
    
  The link problem solution requires doing the attribute
  transformation in different places.
  To avoid code duplicaton, the combination of the `attribute transform code`
  and the `parsing/debugging code` mentioned in the
  previous paragraph has been replaced by the
  `rule_attr_transform_f` function in `detail/rule.hpp`.
  The `parsing` part of the `parsing/debugging code`
  mentioned in the previous paragraph is passed to this
  function by the `parser` argument.
  
  The link problem is solved by calling the
  `rule_attr_transform_f` in `rule<...>::parse` instead of
  calling `parse_rule` and removing it from
  `detail::rule_parser<...>::call_rule_definition`.
  However, without this transformation called from within,
  indirectly, `rule_definition<...>::parse`, using an
  instance of `rule_definition<...>` on the rhs of a
  grammar expression would result in no attribute
  transformation, which of course would be invalid.  But
  the transformation cannot be put in
  `rule_definition<...>::parse` because that would
  duplicate the transformation in `rule<...>::parse` when
  it calls, indirectly, the `rule_definition<...>::parse`
  via the `parse_rule` generated by the
  `BOOST_SPIRIT_DEFINE` macro.  The solution is to have
  this generated `parse_rule` call instead the new
  function `rule_definition<...>::parse_no_xform` which
  does no attribute transform.
  
* test code:
    * [test3/linker_error_example](https://github.com/cppljevans/spirit-experiments/blob/get_rhs/test/x3/linker_error_example/)
  



