### PR TITLE
Support: Endian problems

### DIFF
--- a/include/boost/spirit/home/support/detail/endian/endian.hpp
+++ b/include/boost/spirit/home/support/detail/endian/endian.hpp
@@ -52,10 +52,10 @@
 #   error Platforms with CHAR_BIT != 8 are not supported
 # endif
 
-# define BOOST_ENDIAN_DEFAULT_CONSTRUCT {}          // C++03
+# define BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT {}          // C++03
 
-# if defined(BOOST_ENDIAN_FORCE_PODNESS)
-#   define BOOST_ENDIAN_NO_CTORS
+# if defined(BOOST_ENDIAN_NO_CTORS) || defined(BOOST_ENDIAN_FORCE_PODNESS)
+#   define BOOST_SPIRIT_ENDIAN_NO_CTORS
 # endif
 
 
@@ -315,8 +315,8 @@ namespace boost { namespace spirit
         BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
       public:
         typedef T value_type;
-#     ifndef BOOST_ENDIAN_NO_CTORS
-        endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
+#     ifndef BOOST_SPIRIT_ENDIAN_NO_CTORS
+        endian() BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
         explicit endian(T val)
         {
 #       ifdef BOOST_ENDIAN_LOG
@@ -347,8 +347,8 @@ namespace boost { namespace spirit
         BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
       public:
         typedef T value_type;
-#     ifndef BOOST_ENDIAN_NO_CTORS
-        endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
+#     ifndef BOOST_SPIRIT_ENDIAN_NO_CTORS
+        endian() BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
         explicit endian(T val)
         {
 #       ifdef BOOST_ENDIAN_LOG
@@ -379,8 +379,8 @@ namespace boost { namespace spirit
         BOOST_STATIC_ASSERT( (n_bits/8)*8 == n_bits );
       public:
         typedef T value_type;
-#   ifndef BOOST_ENDIAN_NO_CTORS
-        endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
+#   ifndef BOOST_SPIRIT_ENDIAN_NO_CTORS
+        endian() BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
 #     if BOOST_ENDIAN_BIG_BYTE
         explicit endian(T val)    { detail::store_big_endian<T, n_bits/8>(m_value, val); }
 #     else
@@ -410,8 +410,8 @@ namespace boost { namespace spirit
         BOOST_STATIC_ASSERT( sizeof(T) == n_bits/8 );
       public:
         typedef T value_type;
-#   ifndef BOOST_ENDIAN_NO_CTORS
-        endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
+#   ifndef BOOST_SPIRIT_ENDIAN_NO_CTORS
+        endian() BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
 #     if BOOST_ENDIAN_BIG_BYTE
         endian(T val) : m_value(val) { }
 #     else
@@ -438,8 +438,8 @@ namespace boost { namespace spirit
         BOOST_STATIC_ASSERT( sizeof(T) == n_bits/8 );
       public:
         typedef T value_type;
-#   ifndef BOOST_ENDIAN_NO_CTORS
-        endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
+#   ifndef BOOST_SPIRIT_ENDIAN_NO_CTORS
+        endian() BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
 #     if BOOST_ENDIAN_LITTLE_BYTE
         endian(T val) : m_value(val) { }
 #     else

--- a/include/boost/spirit/home/support/detail/endian/endian.hpp
+++ b/include/boost/spirit/home/support/detail/endian/endian.hpp
@@ -523,10 +523,6 @@ namespace boost { namespace spirit
     typedef endian< endianness::native, uint_least64_t, 56 >     unative56_t;
     typedef endian< endianness::native, uint_least64_t, 64 >     unative64_t;
 
-#define BOOST_HAS_INT16_T
-#define BOOST_HAS_INT32_T
-#define BOOST_HAS_INT64_T
-
   //  These types only present if platform has exact size integers:
   //     aligned big endian signed integer types
   //     aligned big endian unsigned integer types
@@ -536,26 +532,26 @@ namespace boost { namespace spirit
   //     aligned native endian typedefs are not provided because
   //     <cstdint> types are superior for this use case
 
-# if defined(BOOST_HAS_INT16_T)
+#ifdef INT16_MAX
     typedef endian< endianness::big, int16_t, 16, alignment::aligned >      aligned_big16_t;
     typedef endian< endianness::big, uint16_t, 16, alignment::aligned >     aligned_ubig16_t;
     typedef endian< endianness::little, int16_t, 16, alignment::aligned >   aligned_little16_t;
     typedef endian< endianness::little, uint16_t, 16, alignment::aligned >  aligned_ulittle16_t;
-# endif
+#endif
 
-# if defined(BOOST_HAS_INT32_T)
+#ifdef INT32_MAX
     typedef endian< endianness::big, int32_t, 32, alignment::aligned >      aligned_big32_t;
     typedef endian< endianness::big, uint32_t, 32, alignment::aligned >     aligned_ubig32_t;
     typedef endian< endianness::little, int32_t, 32, alignment::aligned >   aligned_little32_t;
     typedef endian< endianness::little, uint32_t, 32, alignment::aligned >  aligned_ulittle32_t;
-# endif
+#endif
 
-# if defined(BOOST_HAS_INT64_T)
+#ifdef INT64_MAX
     typedef endian< endianness::big, int64_t, 64, alignment::aligned >      aligned_big64_t;
     typedef endian< endianness::big, uint64_t, 64, alignment::aligned >     aligned_ubig64_t;
     typedef endian< endianness::little, int64_t, 64, alignment::aligned >   aligned_little64_t;
     typedef endian< endianness::little, uint64_t, 64, alignment::aligned >  aligned_ulittle64_t;
-# endif
+#endif
 
   } // namespace endian
 }} // namespace boost::spirit

--- a/include/boost/spirit/home/support/detail/endian/endian.hpp
+++ b/include/boost/spirit/home/support/detail/endian/endian.hpp
@@ -566,6 +566,9 @@ namespace boost { namespace endian
     using namespace boost::spirit::endian;
 }}
 
+#undef BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT
+#undef BOOST_SPIRIT_ENDIAN_NO_CTORS
+
 #if defined(__BORLANDC__) || defined( __CODEGEARC__)
 # pragma pack(pop)
 #endif

--- a/include/boost/spirit/home/support/detail/endian/endian.hpp
+++ b/include/boost/spirit/home/support/detail/endian/endian.hpp
@@ -35,8 +35,12 @@
 
 #include <boost/config.hpp>
 #include <boost/predef/other/endian.h>
+#ifndef BOOST_MINIMAL_INTEGER_COVER_OPERATORS
 #define BOOST_MINIMAL_INTEGER_COVER_OPERATORS
+#endif
+#ifndef BOOST_NO_IO_COVER_OPERATORS
 #define BOOST_NO_IO_COVER_OPERATORS
+#endif
 #include <boost/spirit/home/support/detail/endian/cover_operators.hpp>
 #undef  BOOST_NO_IO_COVER_OPERATORS
 #undef  BOOST_MINIMAL_INTEGER_COVER_OPERATORS


### PR DESCRIPTION
- Fixed macro redefinition:
  - `BOOST_MINIMAL_INTEGER_COVER_OPERATORS`
  - `BOOST_NO_IO_COVER_OPERATORS`
  - `BOOST_SPIRIT_ENDIAN_NO_CTORS`
  - `BOOST_SPIRIT_ENDIAN_DEFAULT_CONSTRUCT`
- Undef internal macros.
- Fixed-width integer detection.

Closes #348