### PR TITLE
X3: Use traits to test if container is empty

### DIFF
--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -257,7 +257,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
           , Iterator& first, Iterator const& last
           , Context const& context, RContext& rcontext, Attribute& attr, mpl::true_)
         {
-            if (attr.empty())
+            if (traits::is_empty(attr))
                 return parser.parse(first, last, context, rcontext, attr);
             Attribute rest;
             bool r = parser.parse(first, last, context, rcontext, rest);


### PR DESCRIPTION
::empty() is called on the Attribute in parse_into_container_impl. If Attribute has no ::empty(), if fails to compile. Probably instead it should use traits::is_empty(...).