### PR TITLE
Include Repository and X3 docs in doc builds

### DIFF
--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -56,5 +56,10 @@ boostbook spirit2
 ###############################################################################
 alias boostdoc ;
 explicit boostdoc ;
-alias boostrelease : spirit2 ;
+alias boostrelease
+    :
+        spirit2
+        ../repository/doc//spirit2_repository
+        x3//spirit_x3
+    ;
 explicit boostrelease ;

--- a/doc/spirit2.qbk
+++ b/doc/spirit2.qbk
@@ -66,6 +66,7 @@
 [def __qi__                     /Spirit.Qi/]
 [def __karma__                  /Spirit.Karma/]
 [def __lex__                    /Spirit.Lex/]
+[def __x3__                     [@boost:/libs/spirit/doc/x3/html/index.html /Spirit.X3/]]
 
 [def __mpl_boolean_constant__   [@boost:/libs/mpl/doc/refmanual/integral-constant.html MPL Boolean Constant]]
 [def __mpl_int_constant__       [@boost:/libs/mpl/doc/refmanual/integral-constant.html MPL Integral Constant]]
@@ -455,9 +456,12 @@ For now, I'll put my stuff here ad-hoc (JDG). $$$]
 
 [/ Here we go ]
 
-This is the documentation of the newest version of __spirit__ (currently,
-__version__). If you're looking for the documentation of Spirit's previous version
-(formerly Spirit V1.8), see __classic__.
+[def __LTS__                        [@https://en.wikipedia.org/wiki/Long-term_support LTS]]
+
+This is the documentation of the latest __LTS__ (C++03) version of
+__spirit__ (currently, __version__). For the newest (C++14) version, please
+follow to __x3__. If you're looking for the documentation of Spirit's first
+generation version (formerly Spirit V1.8), see __classic__.
 
 [include preface.qbk]
 [include what_s_new.qbk]
@@ -475,4 +479,3 @@ __version__). If you're looking for the documentation of Spirit's previous versi
 [include repository.qbk]
 [include acknowledgments.qbk]
 [include references.qbk]
-

--- a/doc/x3/include.qbk
+++ b/doc/x3/include.qbk
@@ -24,6 +24,6 @@ using the preprocessor define
 It is a hex number where the first two digits determine the major version while
 the last two digits determine the minor version. For example:
 
-    #define SPIRIT_VERSION 0x3000 // version 3.0
+    #define SPIRIT_X3_VERSION 0x3000 // version 3.0
 
 [endsect] [/Include]

--- a/repository/doc/karma/confix.qbk
+++ b/repository/doc/karma/confix.qbk
@@ -111,7 +111,7 @@ illustrate its usage by generating different comment styles and a function
 prototype (for the full example code see here: 
 [@../../example/karma/confix.cpp confix.cpp])
 
-[import ../example/karma/confix.cpp]
+[import ../../example/karma/confix.cpp]
 
 [heading Prerequisites]
 

--- a/repository/doc/qi/advance.qbk
+++ b/repository/doc/qi/advance.qbk
@@ -72,7 +72,7 @@ illustrate its usage by generating parsers for some binary data (for the full
 example code see
 [@../../example/qi/advance.cpp advance.cpp])
 
-[import ../example/qi/advance.cpp]
+[import ../../example/qi/advance.cpp]
 
 [heading Prerequisites]
 

--- a/repository/doc/qi/confix.qbk
+++ b/repository/doc/qi/confix.qbk
@@ -97,7 +97,7 @@ illustrate its usage by generating parsers for different comment styles and
 for some simple tagged data (for the full example code see
 [@../../example/qi/confix.cpp confix.cpp])
 
-[import ../example/qi/confix.cpp]
+[import ../../example/qi/confix.cpp]
 
 [heading Prerequisites]
 

--- a/repository/doc/qi/distinct.qbk
+++ b/repository/doc/qi/distinct.qbk
@@ -44,7 +44,7 @@ as a separate parser construct. The following code snippet illustrates the idea
 (for the full code of this example please see 
 [@../../test/qi/distinct.cpp distinct.cpp]):
 
-[import ../test/qi/distinct.cpp]
+[import ../../test/qi/distinct.cpp]
 [qi_distinct_encapsulation]
 
 These definitions define a new Qi parser recognizing keywords! This allows to 
@@ -93,7 +93,7 @@ attribute type. If the `subject` does not expose any attribute (the type is
 The following example shows simple use cases of the `distinct` parser. 
 [@../../example/qi/distinct.cpp distinct.cpp])
 
-[import ../example/qi/distinct.cpp]
+[import ../../example/qi/distinct.cpp]
 
 [heading Prerequisites]
 

--- a/repository/doc/qi/flush_multi_pass.qbk
+++ b/repository/doc/qi/flush_multi_pass.qbk
@@ -54,7 +54,7 @@ We will illustrate its usage by generating different comment styles and a
 function prototype (for the full example code see here: 
 [@../../example/qi/flush_multi_pass.cpp flush_multi_pass.cpp])
 
-[import ../example/qi/flush_multi_pass.cpp]
+[import ../../example/qi/flush_multi_pass.cpp]
 
 [heading Prerequisites]
 

--- a/repository/doc/qi/keywords.qbk
+++ b/repository/doc/qi/keywords.qbk
@@ -71,7 +71,7 @@ sum of the complexities of its elements.]
 
 [heading Example]
 
-[import ../example/qi/keywords.cpp]
+[import ../../example/qi/keywords.cpp]
 
 [note The test harness for the example(s) below is presented in the
 __qi_basics_examples__ section.]


### PR DESCRIPTION
For some reason boost stopped building docs for 'sublibs' in 1.62. X3 docs were never integrated into build 
 system.

Also includes some fixed to Repository doc build errors and versions info adjustments.

Closes #357, [trac 12322](https://svn.boost.org/trac10/ticket/12322).