### PR TITLE
Added missing copy assignment operator

### DIFF
--- a/include/boost/spirit/home/support/detail/hold_any.hpp
+++ b/include/boost/spirit/home/support/detail/hold_any.hpp
@@ -327,6 +327,11 @@ namespace boost { namespace spirit
             return assign(x);
         }
 #endif
+        // copy assignment operator
+        basic_hold_any& operator=(basic_hold_any const& x)
+        {
+            return assign(x);
+        }
 
         // utility functions
         basic_hold_any& swap(basic_hold_any& x)


### PR DESCRIPTION
The PR #36 does not fixed problem for C++03 and wide range of MSVC compilers.

Closes [trac 8268](https://svn.boost.org/trac10/ticket/8268).