### PR TITLE
Fix integer overflow when negating smallest signed value

### DIFF
--- a/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp
@@ -68,7 +68,11 @@ namespace boost { namespace spirit { namespace traits
             typedef unsignedtype type;                                        \
             static type call(signedtype n)                                    \
             {                                                                 \
-                return static_cast<unsignedtype>((n >= 0) ? n : -n);          \
+                if (n >= 0)                                                   \
+                    return n;                                                 \
+                if (n == std::numeric_limits<signedtype>::min())              \
+                    return (unsignedtype)n;                                   \
+                return (unsignedtype)(-n);                                    \
             }                                                                 \
         }                                                                     \
     /**/


### PR DESCRIPTION
`-INT_MIN` cannot be represented as `int` so results in an undefined overflow.

Testcase from https://bugzilla.redhat.com/show_bug.cgi?id=1545092#c4

````
#include <cassert>
#include <boost/spirit/include/karma.hpp>

bool karma_to_string(std::string & str, int value) __attribute__((noinline));

bool karma_to_string(std::string & str, int value)
{
  namespace karma = boost::spirit::karma;
  std::back_insert_iterator<std::string> sink(str);
  return karma::generate(sink, value);
}

int main(int argc, char **argv)
{
  std::string out;
  karma_to_string(out, int(-2147483648));
  assert(out == "-2147483648");
  return 0;
}
````

With UBSan this shows:

/usr/include/boost/spirit/home/karma/numeric/detail/numeric_utils.hpp:90:5: runtime error: negation of -2147483648 cannot be represented in type 'int'; cast to an unsigned type to negate this value to itself
