### PR TITLE
X3: Pass container attribute through sequence

### DIFF
--- a/include/boost/spirit/home/x3/operator/detail/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/sequence.hpp
@@ -391,6 +391,32 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
       , Context const& context, RContext& rcontext, Attribute& attr
       , traits::container_attribute);
 
+    template <typename Parser, typename Context>
+    constexpr bool pass_sequence_container_attribute
+        = sequence_size<Parser, Context>::value > 1;
+
+    template <typename Parser, typename Iterator, typename Context
+      , typename RContext, typename Attribute>
+    typename enable_if_c<pass_sequence_container_attribute<Parser, Context>, bool>::type
+    parse_sequence_container(
+        Parser const& parser
+      , Iterator& first, Iterator const& last, Context const& context
+      , RContext& rcontext, Attribute& attr)
+    {
+        return parser.parse(first, last, context, rcontext, attr);
+    }
+
+    template <typename Parser, typename Iterator, typename Context
+      , typename RContext, typename Attribute>
+    typename disable_if_c<pass_sequence_container_attribute<Parser, Context>, bool>::type
+    parse_sequence_container(
+        Parser const& parser
+      , Iterator& first, Iterator const& last, Context const& context
+      , RContext& rcontext, Attribute& attr)
+    {
+        return parse_into_container(parser, first, last, context, rcontext, attr);
+    }
+
     template <typename Parser, typename Iterator, typename Context
       , typename RContext, typename Attribute>
     bool parse_sequence(
@@ -399,8 +425,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
       , traits::container_attribute)
     {
         Iterator save = first;
-        if (parse_into_container(parser.left, first, last, context, rcontext, attr)
-            && parse_into_container(parser.right, first, last, context, rcontext, attr))
+        if (parse_sequence_container(parser.left, first, last, context, rcontext, attr)
+            && parse_sequence_container(parser.right, first, last, context, rcontext, attr))
             return true;
         first = save;
         return false;

--- a/test/x3/sequence.cpp
+++ b/test/x3/sequence.cpp
@@ -179,6 +179,22 @@ main()
         BOOST_TEST((!test("BEGIN END", no_case[lit("begin") >> "nend"], space)));
     }
 
+    { // check attribute is passed through unary to another sequence
+        using boost::spirit::x3::eps;
+        std::string s;
+        BOOST_TEST(test_attr("ab", eps >> no_case[char_ >> char_], s));
+        BOOST_TEST("ab" == s);
+        s.clear();
+        BOOST_TEST(test_attr("ab", no_case[char_ >> char_] >> eps, s));
+        BOOST_TEST("ab" == s);
+        s.clear();
+        BOOST_TEST(test_attr("abc", char_ >> no_case[char_ >> char_], s));
+        BOOST_TEST("abc" == s);
+        s.clear();
+        BOOST_TEST(test_attr("abc", no_case[char_ >> char_] >> char_, s));
+        BOOST_TEST("abc" == s);
+    }
+
     {
 #ifdef SPIRIT_NO_COMPILE_CHECK
         char_ >> char_ = char_ >> char_; // disallow this!


### PR DESCRIPTION
If underlying parser of sequence is sequence or unary ending down
to a sequence the container attribute should be passed through.

TODO:
  - I have a naming problem, hope to receive a feedback.
  - I don't like SFINAE, but other solutions will have more boilerplate.
    Any suggestions?

Fixes https://svn.boost.org/trac10/ticket/12085