### PR TITLE
X3: skip_over: Remove redundant check

### DIFF
--- a/include/boost/spirit/home/x3/core/skip_over.hpp
+++ b/include/boost/spirit/home/x3/core/skip_over.hpp
@@ -62,7 +62,7 @@ namespace boost { namespace spirit { namespace x3
         inline void skip_over(
             Iterator& first, Iterator const& last, Skipper const& skipper)
         {
-            while (first != last && skipper.parse(first, last, unused, unused, unused))
+            while (skipper.parse(first, last, unused, unused, unused))
                 /***/;
         }
 


### PR DESCRIPTION
End iterator check is redundant here because it is done in skipper.