### PR TITLE
Karma: Fixed use after scope bug if ADT getter returns by value

### DIFF
--- a/include/boost/spirit/home/karma/detail/extract_from.hpp
+++ b/include/boost/spirit/home/karma/detail/extract_from.hpp
@@ -44,39 +44,44 @@ namespace boost { namespace spirit { namespace traits
     }
 
     // This is the default case: the plain attribute values
-    template <typename Attribute, typename Exposed, typename Enable/*= void*/>
-    struct extract_from_attribute
+    template <typename Attribute, typename Exposed
+      , bool IsOneElemSeq = traits::one_element_sequence<Attribute>::value>
+    struct extract_from_attribute_base
     {
-        typedef typename traits::one_element_sequence<Attribute>::type
-            is_one_element_sequence;
-
-        typedef typename mpl::eval_if<
-            is_one_element_sequence
-          , detail::value_at_c<Attribute, 0>
-          , mpl::identity<Attribute const&>
-        >::type type;
+        typedef Attribute const& type;
 
         template <typename Context>
-        static type call(Attribute const& attr, Context&, mpl::false_)
+        static type call(Attribute const& attr, Context&)
         {
             return attr;
         }
+    };
 
-        // This handles the case where the attribute is a single element fusion
-        // sequence. We silently extract the only element and treat it as the
-        // attribute to generate output from.
-        template <typename Context>
-        static type call(Attribute const& attr, Context& ctx, mpl::true_)
-        {
-            return extract_from<Exposed>(fusion::at_c<0>(attr), ctx);
-        }
+    // This handles the case where the attribute is a single element fusion
+    // sequence. We silently extract the only element and treat it as the
+    // attribute to generate output from.
+    template <typename Attribute, typename Exposed>
+    struct extract_from_attribute_base<Attribute, Exposed, true>
+    {
+        typedef typename remove_const<
+            typename remove_reference<
+                typename fusion::result_of::at_c<Attribute, 0>::type
+            >::type
+        >::type elem_type;
+
+        typedef typename result_of::extract_from<Exposed, elem_type>::type type;
 
         template <typename Context>
         static type call(Attribute const& attr, Context& ctx)
         {
-            return call(attr, ctx, is_one_element_sequence());
+            return extract_from<Exposed>(fusion::at_c<0>(attr), ctx);
         }
     };
+
+    template <typename Attribute, typename Exposed, typename Enable/*= void*/>
+    struct extract_from_attribute
+      : extract_from_attribute_base<Attribute, Exposed>
+    {};
 
     // This handles optional attributes.
     template <typename Attribute, typename Exposed>

--- a/include/boost/spirit/home/support/adapt_adt_attributes.hpp
+++ b/include/boost/spirit/home/support/adapt_adt_attributes.hpp
@@ -193,14 +193,25 @@ namespace boost { namespace spirit { namespace traits
     struct extract_from_attribute<
         fusion::extension::adt_attribute_proxy<T, N, Const>, Exposed>
     {
+        typedef
+            typename fusion::extension::adt_attribute_proxy<T, N, Const>::type
+        get_return_type;
         typedef typename remove_const<
             typename remove_reference<
-                typename fusion::extension::adt_attribute_proxy<T, N, Const>::type 
+                get_return_type
             >::type
         >::type embedded_type;
         typedef 
             typename spirit::result_of::extract_from<Exposed, embedded_type>::type
-        type;
+        extracted_type;
+
+        // If adt_attribute_proxy returned a value we must pass the attribute
+        // by value, otherwise we will end up with a reference to a temporary
+        // that will expire out of scope of the function call.
+        typedef typename mpl::if_c<is_reference<get_return_type>::value
+          , extracted_type
+          , typename remove_reference<extracted_type>::type
+        >::type type;
 
         template <typename Context>
         static type 

--- a/test/karma/regression_adapt_adt.cpp
+++ b/test/karma/regression_adapt_adt.cpp
@@ -31,8 +31,8 @@ public:
       : width_(width), height_(height) 
     {}
 
-    int const& width() const { return width_;}
-    int const& height() const { return height_;}
+    int width() const { return width_;}
+    int height() const { return height_;}
 
     void set_width(int width) { width_ = width;}
     void set_height(int height) { height_ = height;}
@@ -40,8 +40,8 @@ public:
 
 BOOST_FUSION_ADAPT_ADT(
     data1,
-    (int, int const&, obj.width(),  obj.set_width(val))
-    (int, int const&, obj.height(), obj.set_height(val))
+    (int, int, obj.width(),  obj.set_width(val))
+    (int, int, obj.height(), obj.set_height(val))
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -79,13 +79,13 @@ public:
       : data_(data) 
     {}
 
-    double const& data() const { return data_;}
+    double data() const { return data_;}
     void set_data(double data) { data_ = data;}
 };
 
 BOOST_FUSION_ADAPT_ADT(
     data3,
-    (double, double const&, obj.data(), obj.set_data(val))
+    (double, double, obj.data(), obj.set_data(val))
 )
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `extract_from_attribute` returns a reference to a temporary
value produced by calling Fusion ADT adapted sequence getter that
returns by value.

Was reported 6 years ago https://svn.boost.org/trac10/ticket/6126