### PR TITLE
Make calc4b actually compile

### DIFF
--- a/example/x3/Jamfile
+++ b/example/x3/Jamfile
@@ -33,6 +33,7 @@ build-project rexpr/rexpr_full ;
 exe x3_calc1 : calc/calc1.cpp ;
 exe x3_calc2 : calc/calc2.cpp ;
 exe x3_calc4 : calc/calc4.cpp ;
+exe x3_calc4b : calc/calc4b.cpp ;
 exe x3_calc5 : calc/calc5.cpp ;
 exe x3_calc6 : calc/calc6.cpp ;
 

--- a/example/x3/calc/calc4b.cpp
+++ b/example/x3/calc/calc4b.cpp
@@ -188,27 +188,28 @@ namespace client
         x3::rule<class term, ast::program> const term("term");
         x3::rule<class factor, ast::operand> const factor("factor");
 
-        BOOST_SPIRIT_DEFINE(
-            expression =
+        auto const expression_def =
                 term
                 >> *(   (char_('+') >> term)
                     |   (char_('-') >> term)
                     )
-                ,
+                ;
 
-            term =
+        auto const term_def =
                 factor
                 >> *(   (char_('*') >> factor)
                     |   (char_('/') >> factor)
                     )
-                ,
+                ;
 
-            factor =
+        auto const factor_def =
                     uint_
                 |   '(' >> expression >> ')'
                 |   (char_('-') >> factor)
                 |   (char_('+') >> factor)
-        );
+                ;
+
+        BOOST_SPIRIT_DEFINE(expression, term, factor);
         
         auto calculator = expression;
     }


### PR DESCRIPTION
I'm not sure whether this is a regression or whether `BOOST_SPIRIT_DEFINE(rule1 = ... , rule2 = ... , ...)` never worked.  At least I have never seen this anywhere else.