### PR TITLE
Classic.Tests: traverse_tests: Fixed an off by one error

### DIFF
--- a/classic/test/traverse_tests.cpp
+++ b/classic/test/traverse_tests.cpp
@@ -375,7 +375,7 @@ std::vector<std::string>::const_iterator end = trace_vector.get_output().end();
 std::vector<std::string>::const_iterator begin = trace_vector.get_output().begin();
 char const *expected = first[0];
 
-    for (size_t i = 0; i < cnt; expected = first[++i])
+    for (size_t i = 0; i < cnt; expected = first[i++])
     {
         if (std::find(begin, end, std::string(expected)) == end)
             std::cerr << "node in question: " << expected << std::endl;


### PR DESCRIPTION
Should fix the stack overflow error reported by ASAN.