### PR TITLE
Use endian macros from Predef

### DIFF
--- a/example/qi/reference.cpp
+++ b/example/qi/reference.cpp
@@ -17,6 +17,7 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/assert.hpp>
+#include <boost/predef/other/endian.h>
 #include <iostream>
 #include <string>
 #include <cstdlib>
@@ -1270,7 +1271,7 @@ main()
 //<-
 #endif
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
 //->
         //`Basic usage of the native binary parsers for little endian platforms:
         test_parser_attr("\x01", byte_, uc); assert(uc == 0x01);

--- a/include/boost/spirit/home/support/detail/endian/endian.hpp
+++ b/include/boost/spirit/home/support/detail/endian/endian.hpp
@@ -34,7 +34,7 @@
 #endif
 
 #include <boost/config.hpp>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #define BOOST_MINIMAL_INTEGER_COVER_OPERATORS
 #define BOOST_NO_IO_COVER_OPERATORS
 #include <boost/spirit/home/support/detail/endian/cover_operators.hpp>
@@ -381,13 +381,13 @@ namespace boost { namespace spirit
         typedef T value_type;
 #   ifndef BOOST_ENDIAN_NO_CTORS
         endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
-#     ifdef BOOST_BIG_ENDIAN
+#     if BOOST_ENDIAN_BIG_BYTE
         explicit endian(T val)    { detail::store_big_endian<T, n_bits/8>(m_value, val); }
 #     else
         explicit endian(T val)    { detail::store_little_endian<T, n_bits/8>(m_value, val); }
 #     endif
 #   endif
-#   ifdef BOOST_BIG_ENDIAN
+#   if BOOST_ENDIAN_BIG_BYTE
         endian & operator=(T val) { detail::store_big_endian<T, n_bits/8>(m_value, val); return *this; }
         operator T() const        { return detail::load_big_endian<T, n_bits/8>(m_value); }
 #   else
@@ -412,13 +412,13 @@ namespace boost { namespace spirit
         typedef T value_type;
 #   ifndef BOOST_ENDIAN_NO_CTORS
         endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
-#     ifdef BOOST_BIG_ENDIAN
+#     if BOOST_ENDIAN_BIG_BYTE
         endian(T val) : m_value(val) { }
 #     else
         explicit endian(T val)    { detail::store_big_endian<T, sizeof(T)>(&m_value, val); }
 #     endif
 #   endif
-#   ifdef BOOST_BIG_ENDIAN
+#   if BOOST_ENDIAN_BIG_BYTE
         endian & operator=(T val) { m_value = val; return *this; }
         operator T() const        { return m_value; }
 #   else
@@ -440,13 +440,13 @@ namespace boost { namespace spirit
         typedef T value_type;
 #   ifndef BOOST_ENDIAN_NO_CTORS
         endian() BOOST_ENDIAN_DEFAULT_CONSTRUCT
-#     ifdef BOOST_LITTLE_ENDIAN
+#     if BOOST_ENDIAN_LITTLE_BYTE
         endian(T val) : m_value(val) { }
 #     else
         explicit endian(T val)    { detail::store_little_endian<T, sizeof(T)>(&m_value, val); }
 #     endif
 #   endif
-#   ifdef BOOST_LITTLE_ENDIAN
+#   if BOOST_ENDIAN_LITTLE_BYTE
         endian & operator=(T val) { m_value = val; return *this; }
         operator T() const        { return m_value; }
     #else

--- a/test/karma/binary1.cpp
+++ b/test/karma/binary1.cpp
@@ -14,6 +14,8 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_statement.hpp>
 
+#include <boost/predef/other/endian.h>
+
 #include "test.hpp"
 
 using namespace spirit_test;
@@ -26,7 +28,7 @@ main()
     using namespace boost::phoenix;
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(binary_test("\x01", 1, byte_, 0x01));
         BOOST_TEST(binary_test("\x80", 1, byte_, 0x80));
         BOOST_TEST(binary_test("\x01\x82", 2, word, 0x8201));
@@ -55,7 +57,7 @@ main()
         BOOST_TEST(binary_test_delimited("\x00\x00\x00\x00\x00\x00\xf0\x3f", 8,
             bin_double, 1.0, pad(8)));
 
-#else // BOOST_LITTLE_ENDIAN
+#else // BOOST_ENDIAN_LITTLE_BYTE
 
         BOOST_TEST(binary_test("\x01", 1, byte_, 0x01));
         BOOST_TEST(binary_test("\x80", 1, byte_, 0x80));
@@ -88,7 +90,7 @@ main()
     }
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(binary_test("\x01", 1, byte_(0x01)));
         BOOST_TEST(binary_test("\x01\x02", 2, word(0x0201)));
         BOOST_TEST(binary_test("\x01\x02\x03\x04", 4, dword(0x04030201)));

--- a/test/karma/binary2.cpp
+++ b/test/karma/binary2.cpp
@@ -14,6 +14,8 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_statement.hpp>
 
+#include <boost/predef/other/endian.h>
+
 #include "test.hpp"
 
 using namespace spirit_test;
@@ -104,7 +106,7 @@ main()
         boost::optional<float> vf;
         boost::optional<double> vd;
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
 
         BOOST_TEST(!binary_test("", 0, byte_, v8));
         BOOST_TEST(!binary_test("", 0, word, v16));
@@ -116,7 +118,7 @@ main()
         BOOST_TEST(!binary_test("", 0, bin_float, vf));
         BOOST_TEST(!binary_test("", 0, bin_double, vd));
 
-#else // BOOST_LITTLE_ENDIAN
+#else // BOOST_ENDIAN_LITTLE_BYTE
 
         BOOST_TEST(!binary_test("", 0, byte_, v8));
         BOOST_TEST(!binary_test("", 0, word, v16));

--- a/test/karma/binary3.cpp
+++ b/test/karma/binary3.cpp
@@ -14,6 +14,8 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_statement.hpp>
 
+#include <boost/predef/other/endian.h>
+
 #include "test.hpp"
 
 using namespace spirit_test;
@@ -27,7 +29,7 @@ main()
 
     {   // test optional attributes
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         boost::optional<boost::uint8_t> v8 (0x01);
         BOOST_TEST(binary_test("\x01", 1, byte_, v8));
         boost::optional<boost::uint16_t> v16 (0x0201);
@@ -44,7 +46,7 @@ main()
         BOOST_TEST(binary_test("\x00\x00\x00\x00\x00\x00\xf0\x3f", 8,
             bin_double, vd));
 
-#else // BOOST_LITTLE_ENDIAN
+#else // BOOST_ENDIAN_LITTLE_BYTE
 
         boost::optional<boost::uint8_t> v8 (0x01);
         BOOST_TEST(binary_test("\x01", 1, byte_, v8));
@@ -71,7 +73,7 @@ main()
         // karma_phoenix_attributes.hpp is included
         namespace phoenix = boost::phoenix;
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(binary_test("\x01", 1, byte_, phoenix::val(0x01)));
         BOOST_TEST(binary_test("\x01\x02", 2, word, phoenix::val(0x0201)));
         BOOST_TEST(binary_test("\x01\x02\x03\x04", 4, dword, 
@@ -115,7 +117,7 @@ main()
         BOOST_TEST(binary_test("\x00\x00\x00\x00\x00\x00\x00\x40", 8,
             bin_double, ++phoenix::ref(vd)));
 
-#else // BOOST_LITTLE_ENDIAN
+#else // BOOST_ENDIAN_LITTLE_BYTE
 
         BOOST_TEST(binary_test("\x01", 1, byte_, phoenix::val(0x01)));
         BOOST_TEST(binary_test("\x01\x02", 2, word, phoenix::val(0x0102)));

--- a/test/qi/binary.cpp
+++ b/test/qi/binary.cpp
@@ -9,6 +9,7 @@
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/spirit/include/qi_binary.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/predef/other/endian.h>
 #include "test.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -48,7 +49,7 @@ int main()
     double d;
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(test_attr("\x01", byte_, uc) && uc == 0x01);
         BOOST_TEST(test_attr("\x01\x02", word, us) && us == 0x0201);
         BOOST_TEST(test_attr("\x01\x02\x03\x04", dword, ui) && ui == 0x04030201);
@@ -76,7 +77,7 @@ int main()
     }
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(test("\x01", byte_(0x01)));
         BOOST_TEST(test("\x01\x02", word(0x0201)));
         BOOST_TEST(test("\x01\x02\x03\x04", dword(0x04030201)));

--- a/test/qi/regression_binary_action.cpp
+++ b/test/qi/regression_binary_action.cpp
@@ -10,12 +10,13 @@
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
+#include <boost/predef/other/endian.h>
 #include "test.hpp"
 
 int main()
 {
 // This test assumes a little endian architecture
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
     using spirit_test::test_attr;
     using boost::spirit::qi::rule;
     using boost::spirit::qi::locals;

--- a/test/x3/binary.cpp
+++ b/test/x3/binary.cpp
@@ -9,6 +9,7 @@
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/spirit/home/x3/binary.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/predef/other/endian.h>
 #include "test.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -48,7 +49,7 @@ int main()
 //    double d;
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(test_attr("\x01", byte_, uc) && uc == 0x01);
         BOOST_TEST(test_attr("\x01\x02", word, us) && us == 0x0201);
         BOOST_TEST(test_attr("\x01\x02\x03\x04", dword, ui) && ui == 0x04030201);
@@ -76,7 +77,7 @@ int main()
     }
 
     {   // test native endian binaries
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
         BOOST_TEST(test("\x01", byte_(0x01)));
         BOOST_TEST(test("\x01\x02", word(0x0201)));
         BOOST_TEST(test("\x01\x02\x03\x04", dword(0x04030201)));


### PR DESCRIPTION
The `boost/detail/endian.hpp` header is deprecated.