### PR TITLE
Classic: utility/loops.hpp: Added missing includes

### DIFF
--- a/include/boost/spirit/home/classic/utility/loops.hpp
+++ b/include/boost/spirit/home/classic/utility/loops.hpp
@@ -14,6 +14,8 @@
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/parser.hpp>
 #include <boost/spirit/home/classic/core/composite/composite.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit {


### PR DESCRIPTION
```
In file included from typeof_support/typeof_utility.cpp:13:
In file included from ../../../../boost/spirit/include/classic_utility.hpp:11:
In file included from ../../../../boost/spirit/home/classic/utility.hpp:30:
../../../../boost/spirit/home/classic/utility/loops.hpp:269:30: error: no template named 'if_' in namespace 'boost::mpl'; did you mean 'move_detail::if_'?
            typedef typename mpl::if_<
                             ^~~~~~~~
                             move_detail::if_
../../../../boost/move/detail/meta_utils_core.hpp:49:8: note: 'move_detail::if_' declared here
struct if_ : if_c<0 != T1::value, T2, T3>
       ^
1 error generated.
```