### PR TITLE
Workaround qi_repo_keywords test fail on MSVC-14.1

### DIFF
--- a/repository/test/Jamfile
+++ b/repository/test/Jamfile
@@ -14,6 +14,16 @@ project spirit_v2_repository/test
     :
     ;
 
+import os ;
+
+local keywords_reqs ;
+
+if [ os.environ APPVEYOR ]
+{
+    # Workaround MSVC codegen bug. See #400 for the info.
+    keywords_reqs = <toolset>msvc-14.1:<inlining>off ;
+}
+
 # bring in rules for testing
 import testing ;
 
@@ -25,7 +35,7 @@ import testing ;
     [ run qi/confix.cpp                     : : : : qi_repo_confix ]
     [ run qi/distinct.cpp                   : : : : qi_repo_distinct ]
     [ run qi/subrule.cpp                    : : : : qi_repo_subrule ]
-    [ run qi/keywords.cpp                   : : : : qi_repo_keywords ]
+    [ run qi/keywords.cpp                   : : : $(keywords_reqs) : qi_repo_keywords ]
     [ run qi/seek.cpp                       : : : : qi_repo_seek ]
 
     # run Karma repository tests


### PR DESCRIPTION
ref #400