### PR TITLE
V2: Fixed transform_attribute ambiguity

### DIFF
--- a/include/boost/spirit/home/karma/detail/attributes.hpp
+++ b/include/boost/spirit/home/karma/detail/attributes.hpp
@@ -95,14 +95,12 @@ namespace boost { namespace spirit { namespace karma
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace boost { namespace spirit { namespace traits
+namespace boost { namespace spirit { namespace traits { namespace detail
 {
     template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed, Transformed, karma::domain>
+    struct transform_attribute_base<Exposed, Transformed, karma::domain>
       : karma::transform_attribute<Exposed, Transformed>
     {};
-}}}
+}}}}
 
 #endif
-
-

--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -143,10 +143,12 @@ namespace boost { namespace spirit { namespace qi
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace traits
 {
-    template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed, Transformed, qi::domain>
-      : qi::transform_attribute<Exposed, Transformed>
-    {};
+    namespace detail {
+        template <typename Exposed, typename Transformed>
+        struct transform_attribute_base<Exposed, Transformed, qi::domain>
+          : qi::transform_attribute<Exposed, Transformed>
+        {};
+    }
 
     template <typename Exposed, typename Transformed>
     struct transform_attribute<Exposed&, Transformed, qi::domain>

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -923,6 +923,14 @@ namespace boost { namespace spirit { namespace traits
         type;
     };
 
+    namespace detail {
+        // Domain-agnostic class template partial specializations and
+        // type agnostic domain partial specializations are ambious.
+        // To resolve the ambiguity type agnostic domain partial
+        // specializations are dispatched via intermediate type.
+        template <typename Exposed, typename Transformed, typename Domain>
+        struct transform_attribute_base;
+    }
     ///////////////////////////////////////////////////////////////////////////
     //  transform_attribute
     //
@@ -933,7 +941,9 @@ namespace boost { namespace spirit { namespace traits
     ///////////////////////////////////////////////////////////////////////////
     template <typename Exposed, typename Transformed, typename Domain
       , typename Enable/* = void*/>
-    struct transform_attribute;
+    struct transform_attribute
+      : detail::transform_attribute_base<Exposed, Transformed, Domain>
+    {};
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Domain, typename Transformed, typename Exposed>

--- a/test/qi/regression_adapt_adt.cpp
+++ b/test/qi/regression_adapt_adt.cpp
@@ -92,5 +92,12 @@ int main()
             data.str == "Hello" && !data.optstr);
     }
 
+    { // GH#396
+        qi::rule<char const*, unsigned()> uint_r = qi::uint_;
+        test1 data;
+        BOOST_TEST(test_attr("123@999", uint_r >> -('@' >> uint_r), data) &&
+            data.var == 123 && data.opt && data.opt.get() == 999);
+    }
+
     return boost::report_errors();
 }


### PR DESCRIPTION
Domain-wide transforms on the main template produce ambiguity with
user template type partial specializations. To overcome the issue
we hide our domain dispatcher under this intermediate template.

Fixes #396.