### PR TITLE
to_utf8: Fixed wchar_t handling on Windows

### DIFF
--- a/include/boost/spirit/home/support/utf8.hpp
+++ b/include/boost/spirit/home/support/utf8.hpp
@@ -67,6 +67,44 @@ namespace boost { namespace spirit
         }
         return result;
     }
+
+    // Assume wchar_t content is UTF-16 on Windows and UCS-4 on Unix
+#if defined(_WIN32) || defined(__CYGWIN__)
+    inline utf8_string to_utf8(wchar_t value)
+    {
+        utf8_string result;
+        typedef std::back_insert_iterator<utf8_string> insert_iter;
+        insert_iter out_iter(result);
+        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
+
+        u16_to_u32_iterator<wchar_t const*, ucs4_char> ucs4_iter(&value);
+        *utf8_iter++ = *ucs4_iter;
+
+        return result;
+    }
+
+    inline utf8_string to_utf8(wchar_t const* str)
+    {
+        utf8_string result;
+        typedef std::back_insert_iterator<utf8_string> insert_iter;
+        insert_iter out_iter(result);
+        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
+
+        u16_to_u32_iterator<wchar_t const*, ucs4_char> ucs4_iter(str);
+        for (ucs4_char c; (c = *ucs4_iter) != ucs4_char(); ++ucs4_iter) {
+            *utf8_iter++ = c;
+        }
+
+        return result;
+    }
+
+    template <typename Traits, typename Allocator>
+    inline utf8_string
+    to_utf8(std::basic_string<wchar_t, Traits, Allocator> const& str)
+    {
+        return to_utf8(str.c_str());
+    }
+#endif
 }}
 
 #endif

--- a/include/boost/spirit/home/x3/support/utility/utf8.hpp
+++ b/include/boost/spirit/home/x3/support/utility/utf8.hpp
@@ -62,6 +62,44 @@ namespace boost { namespace spirit { namespace x3
         }
         return result;
     }
+
+    // Assume wchar_t content is UTF-16 on Windows and UCS-4 on Unix
+#if defined(_WIN32) || defined(__CYGWIN__)
+    inline utf8_string to_utf8(wchar_t value)
+    {
+        utf8_string result;
+        typedef std::back_insert_iterator<utf8_string> insert_iter;
+        insert_iter out_iter(result);
+        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
+
+        u16_to_u32_iterator<wchar_t const*, ucs4_char> ucs4_iter(&value);
+        *utf8_iter++ = *ucs4_iter;
+
+        return result;
+    }
+
+    inline utf8_string to_utf8(wchar_t const* str)
+    {
+        utf8_string result;
+        typedef std::back_insert_iterator<utf8_string> insert_iter;
+        insert_iter out_iter(result);
+        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
+
+        u16_to_u32_iterator<wchar_t const*, ucs4_char> ucs4_iter(str);
+        for (ucs4_char c; (c = *ucs4_iter) != ucs4_char(); ++ucs4_iter) {
+            *utf8_iter++ = c;
+        }
+
+        return result;
+    }
+
+    template <typename Traits, typename Allocator>
+    inline utf8_string
+    to_utf8(std::basic_string<wchar_t, Traits, Allocator> const& str)
+    {
+        return to_utf8(str.c_str());
+    }
+#endif
 }}}
 
 #endif

--- a/test/qi/Jamfile
+++ b/test/qi/Jamfile
@@ -143,3 +143,5 @@ run regression_repeat.cpp ;
 run regression_transform_assignment.cpp ;
 run regression_binary_action.cpp ;
 run regression_stream_eof.cpp ;
+
+run to_utf8.cpp ;

--- a/test/qi/to_utf8.cpp
+++ b/test/qi/to_utf8.cpp
@@ -1,0 +1,28 @@
+/*=============================================================================
+    Copyright (c) 2018 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#include <boost/core/lightweight_test.hpp>
+#include <boost/spirit/home/support/utf8.hpp>
+
+int main()
+{
+    using boost::spirit::to_utf8;
+
+    // Assume wchar_t is 16-bit on Windows and 32-bit on Unix
+#if defined(_WIN32) || defined(__CYGWIN__)
+    BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(L'\uFFE1').c_str());
+#else
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(L'\U0001F9D0').c_str());
+#endif
+
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0",
+                       to_utf8(L"\U0001F9D0\U0001F9E0").c_str());
+
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0",
+                       to_utf8(std::wstring(L"\U0001F9D0\U0001F9E0")).c_str());
+
+    return boost::report_errors();
+}

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -122,3 +122,5 @@ run fusion_map.cpp ;
 run x3_variant.cpp ;
 run error_handler.cpp /boost//system /boost//filesystem ;
 run iterator_check.cpp ;
+
+run to_utf8.cpp ;

--- a/test/x3/to_utf8.cpp
+++ b/test/x3/to_utf8.cpp
@@ -1,0 +1,28 @@
+/*=============================================================================
+    Copyright (c) 2018 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#include <boost/core/lightweight_test.hpp>
+#include <boost/spirit/home/x3/support/utility/utf8.hpp>
+
+int main()
+{
+    using boost::spirit::x3::to_utf8;
+
+    // Assume wchar_t is 16-bit on Windows and 32-bit on Unix
+#if defined(_WIN32) || defined(__CYGWIN__)
+    BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(L'\uFFE1').c_str());
+#else
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(L'\U0001F9D0').c_str());
+#endif
+
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0",
+                       to_utf8(L"\U0001F9D0\U0001F9E0").c_str());
+
+    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0",
+                       to_utf8(std::wstring(L"\U0001F9D0\U0001F9E0")).c_str());
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Spirit were assuming that wchar_t is 32-bit and the content is UCS-4.
It is wrong, the actual representation is implementation defined [lex.ccon]/6.
However, on most Unix platforms this assumption is valid and gives the
expected outcome, but on Windows wchar_t is 16-bit and the content is UTF-16.

Fixes #395.