### PR TITLE
utree: Fixed negative value shift

### DIFF
--- a/include/boost/spirit/home/support/utree/detail/utree_detail2.hpp
+++ b/include/boost/spirit/home/support/utree/detail/utree_detail2.hpp
@@ -44,13 +44,15 @@ namespace boost { namespace spirit { namespace detail
 
     inline short fast_string::tag() const
     {
-        return (int(buff[small_string_size-2]) << 8) + (unsigned char)buff[small_string_size-1];
+        boost::int16_t tmp;
+        std::memcpy(&tmp, &buff[small_string_size-2], sizeof(tmp));
+        return tmp;
     }
 
     inline void fast_string::tag(short tag)
     {
-        buff[small_string_size-2] = tag >> 8;
-        buff[small_string_size-1] = tag & 0xff;
+        boost::int16_t tmp = tag;
+        std::memcpy(&buff[small_string_size-2], &tmp, sizeof(tmp));
     }
 
     inline bool fast_string::is_heap_allocated() const


### PR DESCRIPTION
Result of shifting a negative value is an implementation defined behavior.

UBSan output:
```
boost/spirit/home/support/utree/detail/utree_detail2.hpp:47:48: runtime error: left shift of negative value -128
    #0 0x45cc72 in boost::spirit::detail::fast_string::tag() const ~/boost-root/./boost/spirit/home/support/utree/detail/utree_detail2.hpp:47:48
    #1 0x45c94c in boost::spirit::utree::copy(boost::spirit::utree const&) ~/boost-root/./boost/spirit/home/support/utree/detail/utree_detail2.hpp:1502:31
    #2 0x440cc7 in boost::spirit::utree::operator=(boost::spirit::utree const&) ~/boost-root/./boost/spirit/home/support/utree/detail/utree_detail2.hpp:848:13
    #3 0x43ce6f in main ~/boost-root/libs/spirit/test/support/utree.cpp:492:16
    #4 0x7f5d472bc2e0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202e0)
    #5 0x4088c9 in _start (~/boost-root/bin.v2/libs/spirit/test/support/support_utree.test/undefined/clang-linux-7/debug/visibility-hidden/support_utree+0x4088c9)
```

The temporaries and memcpy calls will be completely optimized out.
