### PR TITLE
extract_int: Custom integers support

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -30,7 +30,6 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/limits.hpp>
-#include <boost/integer_traits.hpp>
 #include <iterator> // for std::iterator_traits
 
 #if defined(BOOST_MSVC)
@@ -114,12 +113,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             return spirit::char_encoding::ascii::tolower(ch) - 'a' + 10;
         }
     };
-    
-    template <typename T, T Val>
-    struct constexpr_int
-    {
-        BOOST_STATIC_CONSTEXPR T value = Val; 
-    };
 
     ///////////////////////////////////////////////////////////////////////////
     //  positive_accumulator/negative_accumulator: Accumulator policies for
@@ -140,17 +133,17 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         inline static bool add(T& n, Char ch, mpl::true_) // checked add
         {
             // Ensure n *= Radix will not overflow
-            typedef constexpr_int<T, boost::integer_traits<T>::const_max> max;
-            typedef constexpr_int<T, max::value / Radix> val;
+            T const max = (std::numeric_limits<T>::max)();
+            T const val = max / Radix;
 
-            if (n > val::value)
+            if (n > val)
                 return false;
 
             n *= Radix;
 
             // Ensure n += digit will not overflow
             const int digit = radix_traits<Radix>::digit(ch);
-            if (n > max::value - digit)
+            if (n > max - digit)
                 return false;
 
             n += static_cast<T>(digit);
@@ -172,17 +165,17 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         inline static bool add(T& n, Char ch, mpl::true_) // checked subtract
         {
             // Ensure n *= Radix will not underflow
-            typedef constexpr_int<T, boost::integer_traits<T>::const_min> min;
-            typedef constexpr_int<T, (min::value + 1) / T(Radix)> val;
+            T const min = (std::numeric_limits<T>::min)();
+            T const val = (min + 1) / T(Radix);
 
-            if (n < val::value)
+            if (n < val)
                 return false;
 
             n *= Radix;
 
             // Ensure n -= digit will not underflow
             int const digit = radix_traits<Radix>::digit(ch);
-            if (n < min::value + digit)
+            if (n < min + digit)
                 return false;
 
             n -= static_cast<T>(digit);
@@ -200,9 +193,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         inline static bool
         call(Char ch, std::size_t count, T& n, mpl::true_)
         {
-            typedef constexpr_int<std::size_t, digits_traits<T, Radix>::value - 1> overflow_free;
+            std::size_t const overflow_free = digits_traits<T, Radix>::value - 1;
 
-            if (!AlwaysCheckOverflow && (count < overflow_free::value))
+            if (!AlwaysCheckOverflow && (count < overflow_free))
             {
                 Accumulator::add(n, ch, mpl::false_());
             }

--- a/include/boost/spirit/home/support/numeric_traits.hpp
+++ b/include/boost/spirit/home/support/numeric_traits.hpp
@@ -11,9 +11,8 @@
 #endif
 
 #include <boost/config.hpp>
+#include <boost/limits.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/integer_traits.hpp>
-#include <boost/utility/enable_if.hpp>
 
 namespace boost { namespace spirit { namespace traits
 {
@@ -115,13 +114,9 @@ namespace boost { namespace spirit { namespace traits
 
     template <typename T, typename Enable = void>
     struct is_infinite;
-    
+
     template <typename T, typename Enable = void>
-    struct check_overflow : mpl::false_ {};
-        
-    template <typename T>
-    struct check_overflow<T, typename enable_if_c<integer_traits<T>::is_integral>::type>
-        : mpl::true_ {};
+    struct check_overflow : mpl::bool_<std::numeric_limits<T>::is_bounded> {};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -133,8 +133,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         inline static bool add(T& n, Char ch, mpl::true_) // checked add
         {
             // Ensure n *= Radix will not overflow
-            T constexpr max = (std::numeric_limits<T>::max)();
-            T constexpr val = max / Radix;
+            T const max = (std::numeric_limits<T>::max)();
+            T const val = max / Radix;
             if (n > val)
                 return false;
 
@@ -164,8 +164,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         inline static bool add(T& n, Char ch, mpl::true_) // checked subtract
         {
             // Ensure n *= Radix will not underflow
-            T constexpr min = (std::numeric_limits<T>::min)();
-            T constexpr val = (min + 1) / T(Radix);
+            T const min = (std::numeric_limits<T>::min)();
+            T const val = (min + 1) / T(Radix);
             if (n < val)
                 return false;
 

--- a/include/boost/spirit/home/x3/support/traits/numeric_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/numeric_traits.hpp
@@ -8,9 +8,8 @@
 #define BOOST_SPIRIT_X3_NUMERIC_TRAITS_JAN_07_2011_0722AM
 
 #include <boost/config.hpp>
-#include <boost/integer_traits.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <limits>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
@@ -112,13 +111,9 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
     template <typename T, typename Enable = void>
     struct is_infinite;
-    
+
     template <typename T, typename Enable = void>
-    struct check_overflow : mpl::false_ {};
-        
-    template <typename T>
-    struct check_overflow<T, typename enable_if_c<integer_traits<T>::is_integral>::type>
-        : mpl::true_ {};
+    struct check_overflow : mpl::bool_<std::numeric_limits<T>::is_bounded> {};
 }}}}
 
 #endif

--- a/test/qi/Jamfile
+++ b/test/qi/Jamfile
@@ -69,6 +69,7 @@ run end.cpp ;
 run eps.cpp ;
 run expect.cpp ;
 run expectd.cpp ;
+run extract_int.cpp ;
 run grammar.cpp ;
 run int1.cpp ;
 run int2.cpp ;

--- a/test/qi/extract_int.cpp
+++ b/test/qi/extract_int.cpp
@@ -1,0 +1,132 @@
+/*=============================================================================
+  Copyright (c) 2018 Nikita Kniazev
+
+  Distributed under the Boost Software License, Version 1.0. (See accompanying
+  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/spirit/home/qi/numeric/numeric_utils.hpp>
+#include <boost/static_assert.hpp>
+#include <iosfwd>
+#include <limits>
+#include <sstream>
+
+struct custom_int
+{
+    BOOST_DEFAULTED_FUNCTION(custom_int(), {})
+    BOOST_CONSTEXPR custom_int(int value) : value_(value) {}
+
+    custom_int operator+(custom_int x) const { return value_ + x.value_; }
+    custom_int operator-(custom_int x) const { return value_ - x.value_; }
+    custom_int operator*(custom_int x) const { return value_ * x.value_; }
+    custom_int operator/(custom_int x) const { return value_ / x.value_; }
+
+    custom_int& operator+=(custom_int x) { value_ += x.value_; return *this; }
+    custom_int& operator-=(custom_int x) { value_ -= x.value_; return *this; }
+    custom_int& operator*=(custom_int x) { value_ *= x.value_; return *this; }
+    custom_int& operator/=(custom_int x) { value_ /= x.value_; return *this; }
+    custom_int& operator++() { ++value_; return *this; }
+    custom_int& operator--() { --value_; return *this; }
+    custom_int operator++(int) { return value_++; }
+    custom_int operator--(int) { return value_--; }
+
+    custom_int operator+() { return +value_; }
+    custom_int operator-() { return -value_; }
+
+    bool operator< (custom_int x) const { return value_ <  x.value_; }
+    bool operator> (custom_int x) const { return value_ >  x.value_; }
+    bool operator<=(custom_int x) const { return value_ <= x.value_; }
+    bool operator>=(custom_int x) const { return value_ >= x.value_; }
+    bool operator==(custom_int x) const { return value_ == x.value_; }
+    bool operator!=(custom_int x) const { return value_ != x.value_; }
+
+    template <typename Char, typename Traits>
+    friend std::basic_ostream<Char, Traits>&
+    operator<<(std::basic_ostream<Char, Traits>& os, custom_int x) {
+        return os << x.value_;
+    }
+
+    BOOST_STATIC_CONSTEXPR int max = 10;
+    BOOST_STATIC_CONSTEXPR int min = -11;
+
+private:
+    int value_;
+};
+
+namespace std {
+
+template <>
+class numeric_limits<custom_int> : public numeric_limits<int>
+{
+public:
+    static BOOST_CONSTEXPR custom_int max() BOOST_NOEXCEPT_OR_NOTHROW { return custom_int::max; }
+    static BOOST_CONSTEXPR custom_int min() BOOST_NOEXCEPT_OR_NOTHROW { return custom_int::min; }
+    static BOOST_CONSTEXPR custom_int lowest() BOOST_NOEXCEPT_OR_NOTHROW { return min(); }
+    BOOST_STATIC_CONSTEXPR int digits = 4;
+    BOOST_STATIC_CONSTEXPR int digits10 = 1;
+};
+
+}
+
+int main()
+{
+    namespace qi = boost::spirit::qi;
+
+    for (int i = -20; i <= 20; ++i) {
+        int initial = i > 0 ? -9 : 9;
+        custom_int x = initial;
+        std::ostringstream oss;
+        oss << i;
+        std::string s = oss.str();
+        char const* begin = s.data(), * it = begin, *const end = it + s.size();
+
+        // Test prerequest: Limits::is_bounded == true
+        // Check that parser fails on overflow
+        bool r = qi::extract_int<custom_int, 10, 1, -1>::call(it, end, x);
+        if (custom_int::min <= i && i <= custom_int::max) {
+            BOOST_TEST(r);
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            BOOST_TEST(!r);
+            BOOST_TEST(it == begin);
+        }
+
+        // Test prerequest: MaxDigits == log10(Limits::digits)
+        //                  MaxDigits > Limits::digits10
+        // Check that MaxDigits > digits10 behave like MaxDigits=-1
+        it = begin;
+        x = initial;
+        r = qi::extract_int<custom_int, 10, 1, 2>::call(it, end, x);
+        if (custom_int::min <= i && i <= custom_int::max) {
+            BOOST_TEST(r);
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            BOOST_TEST(!r);
+            BOOST_TEST(it == begin);
+        }
+
+        // Test prerequest: MaxDigits < Limits::digits10
+        // Check that unparsed digits are not consumed
+        it = begin;
+        x = initial;
+        r = qi::extract_int<custom_int, 10, 1, 1>::call(it, end, x);
+        BOOST_STATIC_ASSERT(custom_int::min < -9 && custom_int::max > 9);
+        BOOST_TEST(r);
+        if (-9 <= i && i <= 9) {
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            BOOST_ASSERT(-100 < i && i < 100);
+            BOOST_TEST_EQ(end - it, 1);
+            BOOST_TEST_EQ(x, i / 10);
+        }
+    }
+
+    return boost::report_errors();
+}

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -79,6 +79,7 @@ run eoi.cpp ;
 run eol.cpp ;
 run eps.cpp ;
 run expect.cpp ;
+run extract_int.cpp ;
 run int1.cpp ;
 run kleene.cpp ;
 run lexeme.cpp ;

--- a/test/x3/extract_int.cpp
+++ b/test/x3/extract_int.cpp
@@ -1,0 +1,128 @@
+/*=============================================================================
+  Copyright (c) 2018 Nikita Kniazev
+
+  Distributed under the Boost Software License, Version 1.0. (See accompanying
+  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/spirit/home/x3/support/numeric_utils/extract_int.hpp>
+#include <cstdio>
+#include <iosfwd>
+#include <limits>
+
+struct custom_int
+{
+    custom_int() = default;
+    constexpr custom_int(int value) : value_{value} {}
+
+    custom_int operator+(custom_int x) const { return value_ + x.value_; }
+    custom_int operator-(custom_int x) const { return value_ - x.value_; }
+    custom_int operator*(custom_int x) const { return value_ * x.value_; }
+    custom_int operator/(custom_int x) const { return value_ / x.value_; }
+
+    custom_int& operator+=(custom_int x) { value_ += x.value_; return *this; }
+    custom_int& operator-=(custom_int x) { value_ -= x.value_; return *this; }
+    custom_int& operator*=(custom_int x) { value_ *= x.value_; return *this; }
+    custom_int& operator/=(custom_int x) { value_ /= x.value_; return *this; }
+    custom_int& operator++() { ++value_; return *this; }
+    custom_int& operator--() { --value_; return *this; }
+    custom_int operator++(int) { return value_++; }
+    custom_int operator--(int) { return value_--; }
+
+    custom_int operator+() { return +value_; }
+    custom_int operator-() { return -value_; }
+
+    bool operator< (custom_int x) const { return value_ <  x.value_; }
+    bool operator> (custom_int x) const { return value_ >  x.value_; }
+    bool operator<=(custom_int x) const { return value_ <= x.value_; }
+    bool operator>=(custom_int x) const { return value_ >= x.value_; }
+    bool operator==(custom_int x) const { return value_ == x.value_; }
+    bool operator!=(custom_int x) const { return value_ != x.value_; }
+
+    template <typename Char, typename Traits>
+    friend std::basic_ostream<Char, Traits>&
+    operator<<(std::basic_ostream<Char, Traits>& os, custom_int x) {
+        return os << x.value_;
+    }
+
+    static constexpr int max = 10;
+    static constexpr int min = -11;
+
+private:
+    int value_;
+};
+
+template <>
+class std::numeric_limits<custom_int> : public std::numeric_limits<int>
+{
+public:
+    static constexpr custom_int max() noexcept { return custom_int::max; }
+    static constexpr custom_int min() noexcept { return custom_int::min; }
+    static constexpr custom_int lowest() noexcept { return min(); }
+    static constexpr int digits = 4;
+    static constexpr int digits10 = 1;
+};
+
+int main()
+{
+    namespace x3 = boost::spirit::x3;
+
+    for (int i = -20; i <= 20; ++i) {
+        int initial = i > 0 ? -9 : 9;
+        custom_int x = initial;
+        char s[4];
+        std::snprintf(s, 4, "%d", i);
+        auto begin = &s[0], it = begin, end = it + std::strlen(it);
+
+        // Test prerequest: Limits::is_bounded == true
+        // Check that parser fails on overflow
+        bool r = x3::extract_int<custom_int, 10, 1, -1>::call(it, end, x);
+        if (custom_int::min <= i && i <= custom_int::max) {
+            BOOST_TEST(r);
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            BOOST_TEST(!r);
+            BOOST_TEST(it == begin);
+        }
+
+        // Test prerequest: MaxDigits == log10(Limits::digits)
+        //                  MaxDigits > Limits::digits10
+        // Check that MaxDigits > digits10 behave like MaxDigits=-1
+        it = begin;
+        x = initial;
+        r = x3::extract_int<custom_int, 10, 1, 2>::call(it, end, x);
+        if (custom_int::min <= i && i <= custom_int::max) {
+            BOOST_TEST(r);
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            /* TODO: Looks like a regression. See #430
+            BOOST_TEST(!r);
+            BOOST_TEST(it == begin);
+            */
+        }
+
+        // Test prerequest: MaxDigits < Limits::digits10
+        // Check that unparsed digits are not consumed
+        it = begin;
+        x = initial;
+        r = x3::extract_int<custom_int, 10, 1, 1>::call(it, end, x);
+        static_assert(custom_int::min < -9 && custom_int::max > 9, "");
+        BOOST_TEST(r);
+        if (-9 <= i && i <= 9) {
+            BOOST_TEST(it == end);
+            BOOST_TEST_EQ(x, i);
+        }
+        else {
+            BOOST_ASSERT(-100 < i && i < 100);
+            BOOST_TEST_EQ(end - it, 1);
+            BOOST_TEST_EQ(x, i / 10);
+        }
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
It will allow to test `extract_int` properly.

Changed default `check_overflow` trait implementation to be `is_bounded`
as it also covers float types and user data types.

Replacing `boost::integer_traits` with `std::numeric_limits` will not hurt
performance because even MSVC 9/GCC 4.1/Clang 3.0 folds `min`/`max` calls
to a constant at compile time and since C++11 they are even constexpr.