### PR TITLE
The `boost/detail/iterator.hpp` header is obsolete

### DIFF
--- a/doc/advanced/customization_points.qbk
+++ b/doc/advanced/customization_points.qbk
@@ -2113,7 +2113,7 @@ types returned by the embedded typedef `type`:
 [table
     [[Template Parameters]     [Semantics]]
     [[`Iterator`]              [The metafunction result `type` evaluates to 
-              `boost::detail::iterator_traits<Iterator>::reference` and the 
+              `std::iterator_traits<Iterator>::reference` and the 
               function `call()` returns `*it`.]]
     [[__unused_type__` const*`][The metafunction result `type` evaluates to 
               __unused_type__ and the function `call()` returns `unused`.]]

--- a/example/lex/static_lexer/word_count_lexer_static.hpp
+++ b/example/lex/static_lexer/word_count_lexer_static.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_WCL_NOV_10_2009_17_20_29)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_WCL_NOV_10_2009_17_20_29
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/example/lex/static_lexer/word_count_static.hpp
+++ b/example/lex/static_lexer/word_count_static.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_WC_NOV_10_2009_17_20_04)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_WC_NOV_10_2009_17_20_04
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/example/qi/compiler_tutorial/conjure2/conjure_static_lexer.hpp
+++ b/example/qi/compiler_tutorial/conjure2/conjure_static_lexer.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_JUL_25_2011_07_03_08)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_JUL_25_2011_07_03_08
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/example/qi/compiler_tutorial/conjure2/conjure_static_switch_lexer.hpp
+++ b/example/qi/compiler_tutorial/conjure2/conjure_static_switch_lexer.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_SWITCH_JUL_25_2011_07_03_08)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_SWITCH_JUL_25_2011_07_03_08
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/example/qi/compiler_tutorial/conjure3/conjure_static_lexer.hpp
+++ b/example/qi/compiler_tutorial/conjure3/conjure_static_lexer.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_JUL_25_2011_07_25_53)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_JUL_25_2011_07_25_53
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/example/qi/compiler_tutorial/conjure3/conjure_static_switch_lexer.hpp
+++ b/example/qi/compiler_tutorial/conjure3/conjure_static_switch_lexer.hpp
@@ -9,7 +9,6 @@
 #if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_SWITCH_JUL_25_2011_07_25_53)
 #define BOOST_SPIRIT_LEXER_NEXT_TOKEN_CONJURE_STATIC_SWITCH_JUL_25_2011_07_25_53
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/classic/core/scanner/scanner.hpp
+++ b/include/boost/spirit/home/classic/core/scanner/scanner.hpp
@@ -13,7 +13,6 @@
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/match.hpp>
 #include <boost/spirit/home/classic/core/non_terminal/parser_id.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 
 #include <boost/spirit/home/classic/core/scanner/scanner_fwd.hpp>
 
@@ -219,9 +218,9 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         typedef IteratorT iterator_t;
         typedef PoliciesT policies_t;
 
-        typedef typename boost::detail::
+        typedef typename std::
             iterator_traits<IteratorT>::value_type value_t;
-        typedef typename boost::detail::
+        typedef typename std::
             iterator_traits<IteratorT>::reference ref_t;
         typedef typename boost::
             call_traits<IteratorT>::param_type iter_param_t;

--- a/include/boost/spirit/home/classic/iterator/impl/position_iterator.ipp
+++ b/include/boost/spirit/home/classic/iterator/impl/position_iterator.ipp
@@ -17,7 +17,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/spirit/home/classic/core/nil.hpp>  // for nil_t
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit {
 
@@ -114,7 +114,7 @@ template <typename MainIterT, typename ForwardIterT, typename PositionT>
 struct position_iterator_base_generator
 {
 private:
-    typedef boost::detail::iterator_traits<ForwardIterT> traits;
+    typedef std::iterator_traits<ForwardIterT> traits;
     typedef typename traits::value_type value_type;
     typedef typename traits::iterator_category iter_category_t;
     typedef typename traits::reference reference;

--- a/include/boost/spirit/home/classic/iterator/multi_pass.hpp
+++ b/include/boost/spirit/home/classic/iterator/multi_pass.hpp
@@ -20,7 +20,6 @@
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/assert.hpp> // for BOOST_SPIRIT_ASSERT
 #include <boost/spirit/home/classic/iterator/fixed_size_queue.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 
 #include <boost/spirit/home/classic/iterator/multi_pass_fwd.hpp>
 
@@ -491,7 +490,7 @@ class inner
 {
     private:
         typedef
-            typename boost::detail::iterator_traits<InputT>::value_type
+            typename std::iterator_traits<InputT>::value_type
             result_type;
 
     public:
@@ -516,13 +515,13 @@ class inner
 
     public:
         typedef
-            typename boost::detail::iterator_traits<InputT>::difference_type
+            typename std::iterator_traits<InputT>::difference_type
             difference_type;
         typedef
-            typename boost::detail::iterator_traits<InputT>::pointer
+            typename std::iterator_traits<InputT>::pointer
             pointer;
         typedef
-            typename boost::detail::iterator_traits<InputT>::reference
+            typename std::iterator_traits<InputT>::reference
             reference;
 
     protected:
@@ -550,7 +549,7 @@ class inner
         }
 
         typedef
-            typename boost::detail::iterator_traits<InputT>::value_type
+            typename std::iterator_traits<InputT>::value_type
             value_t;
         void swap(inner& x)
         {

--- a/include/boost/spirit/home/classic/iterator/position_iterator_fwd.hpp
+++ b/include/boost/spirit/home/classic/iterator/position_iterator_fwd.hpp
@@ -10,7 +10,7 @@
 #define BOOST_SPIRIT_POSITION_ITERATOR_FWD_HPP
 
 #include <string>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
+#include <iterator> // for std::iterator_traits
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/nil.hpp>
 
@@ -32,7 +32,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         typename ForwardIteratorT,
         typename PositionT = file_position_base<
             std::basic_string<
-                typename boost::detail::iterator_traits<ForwardIteratorT>::value_type
+                typename std::iterator_traits<ForwardIteratorT>::value_type
             > 
         >,
         typename SelfT = nil_t
@@ -44,7 +44,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         typename ForwardIteratorT,
         typename PositionT = file_position_base<
             std::basic_string<
-                typename boost::detail::iterator_traits<ForwardIteratorT>::value_type
+                typename std::iterator_traits<ForwardIteratorT>::value_type
             > 
         >
     >

--- a/include/boost/spirit/home/classic/tree/common.hpp
+++ b/include/boost/spirit/home/classic/tree/common.hpp
@@ -26,7 +26,6 @@
 #include <boost/call_traits.hpp>
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 #include <boost/assert.hpp>
 
 #if defined(BOOST_SPIRIT_DEBUG) && \
@@ -36,6 +35,8 @@
 #endif
 
 #include <boost/spirit/home/classic/tree/common_fwd.hpp>
+
+#include <iterator> // for std::iterator_traits, std::distance
 
 namespace boost { namespace spirit {
 
@@ -242,7 +243,7 @@ template <typename IteratorT = char const*, typename ValueT = nil_t>
 struct node_val_data
 {
     typedef
-        typename boost::detail::iterator_traits<IteratorT>::value_type
+        typename std::iterator_traits<IteratorT>::value_type
         value_type;
 
 #if !defined(BOOST_SPIRIT_USE_BOOST_ALLOCATOR_FOR_TREES)

--- a/include/boost/spirit/home/classic/utility/regex.hpp
+++ b/include/boost/spirit/home/classic/utility/regex.hpp
@@ -47,7 +47,7 @@
 #include <boost/spirit/home/classic/meta/as_parser.hpp>
 #include <boost/spirit/home/classic/core/parser.hpp>
 #include <boost/spirit/home/classic/utility/impl/regex.ipp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
+#include <iterator> // for std::iterator_traits
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit {
@@ -75,7 +75,7 @@ struct rxstrlit : public parser<rxstrlit<CharT> > {
     //  forward iterators do not work here.
         typedef typename ScannerT::iterator_t iterator_t;
         typedef
-            typename boost::detail::iterator_traits<iterator_t>::iterator_category
+            typename std::iterator_traits<iterator_t>::iterator_category
             iterator_category;
 
         BOOST_STATIC_ASSERT((

--- a/include/boost/spirit/home/karma/detail/indirect_iterator.hpp
+++ b/include/boost/spirit/home/karma/detail/indirect_iterator.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/iterator/iterator_facade.hpp>
+#include <iterator> // for std::iterator_traits
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace karma { namespace detail
@@ -23,13 +24,13 @@ namespace boost { namespace spirit { namespace karma { namespace detail
     class indirect_iterator
       : public boost::iterator_facade<
             indirect_iterator<Iterator>
-          , typename boost::detail::iterator_traits<Iterator>::value_type
+          , typename std::iterator_traits<Iterator>::value_type
           , boost::forward_traversal_tag
-          , typename boost::detail::iterator_traits<Iterator>::reference>
+          , typename std::iterator_traits<Iterator>::reference>
     {
-        typedef typename boost::detail::iterator_traits<Iterator>::value_type
+        typedef typename std::iterator_traits<Iterator>::value_type
             base_value_type;
-        typedef typename boost::detail::iterator_traits<Iterator>::reference
+        typedef typename std::iterator_traits<Iterator>::reference
             base_reference_type;
 
         typedef boost::iterator_facade<

--- a/include/boost/spirit/home/lex/lexer/lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexer.hpp
@@ -20,10 +20,10 @@
 #include <boost/spirit/home/lex/lexer/token_def.hpp>
 #include <boost/assert.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range/iterator_range.hpp>
+#include <iterator> // for std::iterator_traits
 #include <string>
 
 namespace boost { namespace spirit { namespace lex
@@ -83,7 +83,7 @@ namespace boost { namespace spirit { namespace lex
 
                 if (first != last) {
                     typedef typename 
-                        boost::detail::iterator_traits<Iterator>::value_type 
+                        std::iterator_traits<Iterator>::value_type 
                     token_type;
 
                     token_type const& t = *first;

--- a/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
@@ -11,10 +11,10 @@
 #endif
 
 #include <boost/mpl/bool.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/spirit/home/lex/lexer/pass_flags.hpp>
 #include <boost/assert.hpp>
+#include <iterator> // for std::iterator_traits
 
 #if 0 != __COMO_VERSION__ || !BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
 #define BOOST_SPIRIT_STATIC_EOF 1
@@ -66,7 +66,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
     {
     public:
         typedef typename 
-            boost::detail::iterator_traits<Iterator>::value_type 
+            std::iterator_traits<Iterator>::value_type 
         char_type;
 
     private:

--- a/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
@@ -19,6 +19,7 @@
 #include <boost/spirit/home/lex/lexer/lexertl/wrap_action.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/optional.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace lex { namespace lexertl
 { 
@@ -36,7 +37,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         {
         protected:
             typedef typename 
-                boost::detail::iterator_traits<Iterator>::value_type 
+                std::iterator_traits<Iterator>::value_type 
             char_type;
 
         public:

--- a/include/boost/spirit/home/lex/lexer/lexertl/generate_static.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/generate_static.hpp
@@ -908,7 +908,6 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         os_ << "#if !defined(BOOST_SPIRIT_LEXER_NEXT_TOKEN_" << guard << ")\n";
         os_ << "#define BOOST_SPIRIT_LEXER_NEXT_TOKEN_" << guard << "\n\n";
 
-        os_ << "#include <boost/detail/iterator.hpp>\n";
         os_ << "#include <boost/spirit/home/support/detail/lexer/char_traits.hpp>\n\n";
 
         generate_delimiter(os_);

--- a/include/boost/spirit/home/lex/lexer/lexertl/iterator_tokenizer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/iterator_tokenizer.hpp
@@ -10,11 +10,11 @@
 #pragma once
 #endif
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/detail/lexer/state_machine.hpp>
 #include <boost/spirit/home/support/detail/lexer/consts.hpp>
 #include <boost/spirit/home/support/detail/lexer/size_t.hpp>
 #include <boost/spirit/home/support/detail/lexer/char_traits.hpp>
+#include <iterator> // for std::iterator_traits
 #include <vector>
 
 namespace boost { namespace spirit { namespace lex { namespace lexertl
@@ -25,8 +25,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
     {
     public:
         typedef std::vector<std::size_t> size_t_vector;
-        typedef typename boost::detail::iterator_traits<Iterator>::value_type 
-            char_type;
+        typedef typename std::iterator_traits<Iterator>::value_type char_type;
 
         static std::size_t next (
             boost::lexer::basic_state_machine<char_type> const& state_machine_
@@ -74,7 +73,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
                 else
                 {
                     typedef typename 
-                        boost::detail::iterator_traits<Iterator>::value_type 
+                        std::iterator_traits<Iterator>::value_type 
                     value_type;
                     typedef typename 
                         boost::lexer::char_traits<value_type>::index_type 
@@ -188,7 +187,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
                 else
                 {
                     typedef typename 
-                        boost::detail::iterator_traits<Iterator>::value_type 
+                        std::iterator_traits<Iterator>::value_type 
                     value_type;
                     typedef typename 
                         boost::lexer::char_traits<value_type>::index_type 

--- a/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
@@ -27,6 +27,8 @@
 
 #include <boost/foreach.hpp>
 
+#include <iterator> // for std::iterator_traits
+
 namespace boost { namespace spirit { namespace lex { namespace lexertl
 {
     ///////////////////////////////////////////////////////////////////////////
@@ -158,8 +160,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         operator safe_bool() const
             { return initialized_dfa_ ? &dummy::true_ : 0; }
 
-        typedef typename boost::detail::iterator_traits<Iterator>::value_type
-            char_type;
+        typedef typename std::iterator_traits<Iterator>::value_type char_type;
         typedef std::basic_string<char_type> string_type;
 
         typedef boost::lexer::basic_rules<char_type> basic_rules_type;

--- a/include/boost/spirit/home/lex/lexer/lexertl/position_token.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/position_token.hpp
@@ -23,7 +23,6 @@
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/value_at.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/variant.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/bool.hpp>

--- a/include/boost/spirit/home/lex/lexer/lexertl/static_functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/static_functor_data.hpp
@@ -18,6 +18,7 @@
 #include <boost/spirit/home/lex/lexer/lexertl/wrap_action.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace lex { namespace lexertl
 { 
@@ -48,7 +49,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         {
         protected:
             typedef typename 
-                boost::detail::iterator_traits<Iterator>::value_type 
+                std::iterator_traits<Iterator>::value_type 
             char_type;
 
         public:

--- a/include/boost/spirit/home/lex/lexer/lexertl/static_lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/static_lexer.hpp
@@ -18,6 +18,7 @@
 #if defined(BOOST_SPIRIT_DEBUG)
 #include <boost/spirit/home/support/detail/lexer/debug.hpp>
 #endif
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace lex { namespace lexertl
 { 
@@ -119,8 +120,7 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         // object is always valid
         operator safe_bool() const { return &dummy::true_; }
 
-        typedef typename boost::detail::iterator_traits<Iterator>::value_type 
-            char_type;
+        typedef typename std::iterator_traits<Iterator>::value_type char_type;
         typedef std::basic_string<char_type> string_type;
 
         //  Every lexer type to be used as a lexer for Spirit has to conform to 

--- a/include/boost/spirit/home/lex/lexer/lexertl/token.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/token.hpp
@@ -23,7 +23,6 @@
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/value_at.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/variant.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/vector.hpp>

--- a/include/boost/spirit/home/lex/lexer/token_def.hpp
+++ b/include/boost/spirit/home/lex/lexer/token_def.hpp
@@ -24,10 +24,10 @@
 
 #include <boost/fusion/include/vector.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/variant.hpp>
 
+#include <iterator> // for std::iterator_traits
 #include <string>
 #include <cstdlib>
 
@@ -92,7 +92,7 @@ namespace boost { namespace spirit { namespace lex
 
             if (first != last) {
                 typedef typename 
-                    boost::detail::iterator_traits<Iterator>::value_type 
+                    std::iterator_traits<Iterator>::value_type 
                 token_type;
 
                 //  If the following assertion fires you probably forgot to  

--- a/include/boost/spirit/home/lex/qi/plain_raw_token.hpp
+++ b/include/boost/spirit/home/lex/qi/plain_raw_token.hpp
@@ -26,6 +26,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/lexical_cast.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit
 {
@@ -85,7 +86,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 

--- a/include/boost/spirit/home/lex/qi/plain_token.hpp
+++ b/include/boost/spirit/home/lex/qi/plain_token.hpp
@@ -27,6 +27,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/lexical_cast.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit
 {
@@ -102,7 +103,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 
@@ -154,7 +155,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 

--- a/include/boost/spirit/home/lex/qi/plain_tokenid.hpp
+++ b/include/boost/spirit/home/lex/qi/plain_tokenid.hpp
@@ -27,6 +27,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/lexical_cast.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit
 {
@@ -104,7 +105,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 
@@ -155,7 +156,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 

--- a/include/boost/spirit/home/lex/qi/plain_tokenid_mask.hpp
+++ b/include/boost/spirit/home/lex/qi/plain_tokenid_mask.hpp
@@ -26,6 +26,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/lexical_cast.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit
 {
@@ -84,7 +85,7 @@ namespace boost { namespace spirit { namespace qi
                 // been initialized with
 
                 typedef typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 token_type;
                 typedef typename token_type::id_type id_type;
 

--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -15,7 +15,6 @@
 #pragma once
 #endif
 
-#include <boost/detail/iterator.hpp>
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/qi/detail/attributes.hpp>
 #include <boost/spirit/home/support/char_encoding/ascii.hpp>
@@ -32,6 +31,7 @@
 #include <boost/mpl/and.hpp>
 #include <boost/limits.hpp>
 #include <boost/integer_traits.hpp>
+#include <iterator> // for std::iterator_traits
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
@@ -318,9 +318,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         {
             typedef radix_traits<Radix> radix_check;
             typedef int_extractor<Radix, Accumulator, MaxDigits, Accumulate> extractor;
-            typedef typename
-                boost::detail::iterator_traits<Iterator>::value_type
-            char_type;
+            typedef typename std::iterator_traits<Iterator>::value_type char_type;
 
             Iterator it = first;
             std::size_t leading_zeros = 0;
@@ -423,9 +421,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         {
             typedef radix_traits<Radix> radix_check;
             typedef int_extractor<Radix, Accumulator, -1, Accumulate> extractor;
-            typedef typename
-                boost::detail::iterator_traits<Iterator>::value_type
-            char_type;
+            typedef typename std::iterator_traits<Iterator>::value_type char_type;
 
             Iterator it = first;
             std::size_t count = 0;

--- a/include/boost/spirit/home/qi/stream/detail/iterator_source.hpp
+++ b/include/boost/spirit/home/qi/stream/detail/iterator_source.hpp
@@ -12,7 +12,7 @@
 #endif
 
 #include <boost/iostreams/stream.hpp>
-#include <boost/detail/iterator.hpp>
+#include <iterator> // for std::iterator_traits, std::distance
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace qi { namespace detail
@@ -21,9 +21,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     template <typename Iterator>
     struct base_iterator_source
     {
-        typedef typename
-            boost::detail::iterator_traits<Iterator>::value_type
-        char_type;
+        typedef typename std::iterator_traits<Iterator>::value_type char_type;
         typedef boost::iostreams::seekable_device_tag category;
 
         base_iterator_source (Iterator const& first_, Iterator const& last_)
@@ -90,7 +88,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     struct iterator_source<
             Iterator, 
             typename boost::enable_if_c<boost::is_convertible<
-                typename boost::detail::iterator_traits<Iterator>::iterator_category, std::random_access_iterator_tag>::value>::type
+                typename std::iterator_traits<Iterator>::iterator_category, std::random_access_iterator_tag>::value>::type
         > : base_iterator_source<Iterator>
     {
         typedef base_iterator_source<Iterator> base_type;

--- a/include/boost/spirit/home/qi/string/detail/tst.hpp
+++ b/include/boost/spirit/home/qi/string/detail/tst.hpp
@@ -12,7 +12,7 @@
 #endif
 
 #include <boost/call_traits.hpp>
-#include <boost/detail/iterator.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace qi { namespace detail
 {
@@ -74,7 +74,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             while (p && i != last)
             {
                 typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 c = filter(*i); // filter only the input
 
                 if (c == p->id)
@@ -118,7 +118,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             for(;;)
             {
                 typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 c = *first;
 
                 if (*pp == 0)
@@ -154,7 +154,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
                 return;
 
             typename
-                boost::detail::iterator_traits<Iterator>::value_type
+                std::iterator_traits<Iterator>::value_type
             c = *first;
 
             if (c == p->id)

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -45,6 +45,7 @@
 #include <boost/variant.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/config.hpp>
+#include <iterator> // for std::iterator_traits, std::distance
 #include <vector>
 #include <utility>
 #include <ios>
@@ -559,12 +560,12 @@ namespace boost { namespace spirit { namespace traits
     template <typename Iterator>
     struct attribute_size<iterator_range<Iterator> >
     {
-        typedef typename boost::detail::iterator_traits<Iterator>::
+        typedef typename std::iterator_traits<Iterator>::
             difference_type type;
 
         static type call(iterator_range<Iterator> const& r)
         {
-            return boost::detail::distance(r.begin(), r.end());
+            return std::distance(r.begin(), r.end());
         }
     };
 

--- a/include/boost/spirit/home/support/container.hpp
+++ b/include/boost/spirit/home/support/container.hpp
@@ -15,7 +15,6 @@
 
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/support/attributes_fwd.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/optional.hpp>
@@ -23,6 +22,7 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/repeat.hpp>
 #include <boost/range/iterator_range.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace traits
 {
@@ -465,7 +465,7 @@ namespace boost { namespace spirit { namespace traits
     template <typename Iterator, typename Enable/* = void*/>
     struct deref_iterator
     {
-        typedef typename boost::detail::iterator_traits<Iterator>::reference type;
+        typedef typename std::iterator_traits<Iterator>::reference type;
         static type call(Iterator& it)
         {
             return *it;

--- a/include/boost/spirit/home/support/detail/lexer/generate_cpp.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/generate_cpp.hpp
@@ -10,7 +10,6 @@
 #include "consts.hpp"
 #include "internals.hpp"
 #include <iostream>
-#include <boost/detail/iterator.hpp>
 #include "runtime_error.hpp"
 #include "size_t.hpp"
 #include "state_machine.hpp"

--- a/include/boost/spirit/home/support/detail/lexer/input.hpp
+++ b/include/boost/spirit/home/support/detail/lexer/input.hpp
@@ -7,16 +7,16 @@
 #define BOOST_LEXER_INPUT
 
 #include "char_traits.hpp"
-#include <boost/detail/iterator.hpp>
 #include "size_t.hpp"
 #include "state_machine.hpp"
+#include <iterator> // for std::iterator_traits
 
 namespace boost
 {
 namespace lexer
 {
 template<typename FwdIter, typename Traits =
-    char_traits<typename boost::detail::iterator_traits<FwdIter>::value_type> >
+    char_traits<typename std::iterator_traits<FwdIter>::value_type> >
 class basic_input
 {
 public:

--- a/include/boost/spirit/home/support/iterators/detail/buffering_input_iterator_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/buffering_input_iterator_policy.hpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
 #include <boost/spirit/home/support/iterators/detail/input_iterator_policy.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 #include <boost/assert.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace iterator_policies
 {
@@ -35,18 +35,18 @@ namespace boost { namespace spirit { namespace iterator_policies
         {
         private:
             typedef
-                typename boost::detail::iterator_traits<T>::value_type
+                typename std::iterator_traits<T>::value_type
             result_type;
 
         public:
             typedef
-                typename boost::detail::iterator_traits<T>::difference_type
+                typename std::iterator_traits<T>::difference_type
             difference_type;
             typedef
-                typename boost::detail::iterator_traits<T>::difference_type
+                typename std::iterator_traits<T>::difference_type
             distance_type;
             typedef
-                typename boost::detail::iterator_traits<T>::pointer
+                typename std::iterator_traits<T>::pointer
             pointer;
             typedef result_type& reference;
             typedef result_type value_type;
@@ -96,7 +96,7 @@ namespace boost { namespace spirit { namespace iterator_policies
         struct shared
         {
             typedef
-                typename boost::detail::iterator_traits<T>::value_type
+                typename std::iterator_traits<T>::value_type
             result_type;
 
             explicit shared(T const& input) 

--- a/include/boost/spirit/home/support/iterators/detail/input_iterator_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/input_iterator_policy.hpp
@@ -9,8 +9,8 @@
 
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
-#include <boost/detail/iterator.hpp> // for boost::detail::iterator_traits
 #include <boost/assert.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace iterator_policies
 {
@@ -38,21 +38,21 @@ namespace boost { namespace spirit { namespace iterator_policies
         {
         private:
             typedef
-                typename boost::detail::iterator_traits<T>::value_type
+                typename std::iterator_traits<T>::value_type
             result_type;
 
         public:
             typedef
-                typename boost::detail::iterator_traits<T>::difference_type
+                typename std::iterator_traits<T>::difference_type
             difference_type;
             typedef
-                typename boost::detail::iterator_traits<T>::difference_type
+                typename std::iterator_traits<T>::difference_type
             distance_type;
             typedef
-                typename boost::detail::iterator_traits<T>::pointer
+                typename std::iterator_traits<T>::pointer
             pointer;
             typedef
-                typename boost::detail::iterator_traits<T>::reference
+                typename std::iterator_traits<T>::reference
             reference;
             typedef result_type value_type;
 

--- a/include/boost/spirit/home/x3/string/detail/tst.hpp
+++ b/include/boost/spirit/home/x3/string/detail/tst.hpp
@@ -8,8 +8,8 @@
 #define BOOST_SPIRIT_X3_TST_MARCH_09_2007_0905AM
 
 #include <boost/call_traits.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/assert.hpp>
+#include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace x3 { namespace detail
 {
@@ -112,7 +112,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             for (;;)
             {
                 typename
-                    boost::detail::iterator_traits<Iterator>::value_type
+                    std::iterator_traits<Iterator>::value_type
                 c = *first;
 
                 if (*pp == 0)
@@ -148,7 +148,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
                 return;
 
             typename
-                boost::detail::iterator_traits<Iterator>::value_type
+                std::iterator_traits<Iterator>::value_type
             c = *first;
 
             if (c == p->id)

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -23,7 +23,6 @@
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/seq/elem.hpp>
 
-#include <boost/detail/iterator.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/type_traits/is_integral.hpp>
@@ -33,6 +32,8 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/limits.hpp>
+
+#include <iterator> // for std::iterator_traits
 
 #if !defined(SPIRIT_NUMERICS_LOOP_UNROLL)
 # define SPIRIT_NUMERICS_LOOP_UNROLL 3
@@ -296,7 +297,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             typedef radix_traits<Radix> radix_check;
             typedef int_extractor<Radix, Accumulator, MaxDigits> extractor;
             typedef typename
-                boost::detail::iterator_traits<Iterator>::value_type
+                std::iterator_traits<Iterator>::value_type
             char_type;
 
             Iterator it = first;
@@ -394,7 +395,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             typedef radix_traits<Radix> radix_check;
             typedef int_extractor<Radix, Accumulator, -1> extractor;
             typedef typename
-                boost::detail::iterator_traits<Iterator>::value_type
+                std::iterator_traits<Iterator>::value_type
             char_type;
 
             Iterator it = first;

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -11,7 +11,6 @@
 
 #include <boost/fusion/support/category_of.hpp>
 #include <boost/spirit/home/x3/support/unused.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/fusion/include/deque.hpp>
 #include <boost/tti/has_type.hpp>
 #include <boost/mpl/identity.hpp>
@@ -277,7 +276,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename Iterator, typename Enable = void>
     struct deref_iterator
     {
-        typedef typename boost::detail::iterator_traits<Iterator>::reference type;
+        typedef typename std::iterator_traits<Iterator>::reference type;
         static type call(Iterator& it)
         {
             return *it;


### PR DESCRIPTION
Both `iterator_traits` and `distance` in `boost::detail` namespace are just
aliases from `std` namespace.