### PR TITLE
X3: Fixed wrong parse_rule signature instantiation

### DIFF
--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -125,3 +125,6 @@ run error_handler.cpp /boost//filesystem ;
 run iterator_check.cpp ;
 
 run to_utf8.cpp ;
+
+obj rule_separate_tu_grammar : rule_separate_tu_grammar.cpp ;
+run rule_separate_tu.cpp rule_separate_tu_grammar ;

--- a/test/x3/rule1.cpp
+++ b/test/x3/rule1.cpp
@@ -25,9 +25,18 @@ main()
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::rule;
     using boost::spirit::x3::lit;
+    using boost::spirit::x3::int_;
     using boost::spirit::x3::unused_type;
     using boost::spirit::x3::phrase_parse;
     using boost::spirit::x3::skip_flag;
+    using boost::spirit::x3::traits::has_attribute;
+
+    // check attribute advertising
+    static_assert( has_attribute<rule<class r, int>, /*Context=*/unused_type>::value, "");
+    static_assert(!has_attribute<rule<class r     >, /*Context=*/unused_type>::value, "");
+    static_assert( has_attribute<decltype(rule<class r, int>{} = int_), /*Context=*/unused_type>::value, "");
+    static_assert(!has_attribute<decltype(rule<class r     >{} = int_), /*Context=*/unused_type>::value, "");
+
 
     { // basic tests
 

--- a/test/x3/rule_separate_tu.cpp
+++ b/test/x3/rule_separate_tu.cpp
@@ -1,0 +1,22 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "rule_separate_tu_grammar.hpp"
+
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    char const* const s = "*", * const end = s + std::strlen(s);
+
+    BOOST_TEST(parse(s, end, unused_attr::skipper));
+    BOOST_TEST(parse(s, end, unused_attr::grammar));
+    BOOST_TEST(phrase_parse(s, end, unused_attr::grammar, unused_attr::skipper));
+
+    return boost::report_errors();
+}

--- a/test/x3/rule_separate_tu_grammar.cpp
+++ b/test/x3/rule_separate_tu_grammar.cpp
@@ -1,0 +1,26 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "rule_separate_tu_grammar.hpp"
+
+#include <boost/spirit/home/x3.hpp>
+
+namespace unused_attr {
+
+const skipper_type skipper = "skipper";
+const auto skipper_def = x3::lit('*');
+BOOST_SPIRIT_DEFINE(skipper)
+BOOST_SPIRIT_INSTANTIATE(skipper_type, char const*, x3::unused_type)
+
+const grammar_type grammar = "grammar";
+const auto grammar_def = *x3::lit('=');
+BOOST_SPIRIT_DEFINE(grammar)
+BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::unused_type)
+BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::phrase_parse_context<skipper_type>::type)
+
+}

--- a/test/x3/rule_separate_tu_grammar.hpp
+++ b/test/x3/rule_separate_tu_grammar.hpp
@@ -1,0 +1,28 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/home/x3.hpp>
+
+// Check that `BOOST_SPIRIT_INSTANTIATE` instantiates `parse_rule` with proper
+// types when a rule has no attribute.
+
+namespace unused_attr {
+
+namespace x3 = boost::spirit::x3;
+
+// skipper must has no attribute, checks `parse` and `skip_over`
+using skipper_type = x3::rule<class skipper_r>;
+extern const skipper_type skipper;
+BOOST_SPIRIT_DECLARE(skipper_type)
+
+// grammar must has no attribute, checks `parse` and `phrase_parse`
+using grammar_type = x3::rule<class grammar_r>;
+extern const grammar_type grammar;
+BOOST_SPIRIT_DECLARE(grammar_type)
+
+}


### PR DESCRIPTION
When a rule has no attribute (leaves `Attribute` template parameter as default)
the `BOOST_SPIRIT_INSTANTIATE` macro instantiates a `parse_rule` helper function
with a wrong signature because `parse`, `phrase_parse`, and `skip_over` pass as
the attribute `unused` variable which deduces to `unused_type const&` type, but
`BOOST_SPIRIT_INSTANTIATE` instantiates `parse_rule` with `unused_type&` type.

Used a trick to change `parse_rule` signature to take unsued_type by value when rule has no attribute (the signature `parse_rule(..., unsued_type)`).