### PR TITLE
Tests: Added precompiled headers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ before_build:
       # Creating %USERPROFILE%/user-config.jam file
       @'
       
-      import feature os regex toolset ;
+      import feature os regex toolset pch ;
       
       # clcache
       local toolset = [ regex.split [ os.environ TOOLSET ] "-" ] ;
@@ -52,6 +52,9 @@ before_build:
           -wd4127  # conditional expression is constant
           -wd4459  # declaration of 'varname' hides global declaration
         : unchecked ;
+      
+      # A subfeature that tells Spirit tests to use PCH
+      feature.subfeature pch on : version : spirit : optional propagated incidental ;
       
       '@ | sc "$env:USERPROFILE/user-config.jam"
 
@@ -107,6 +110,6 @@ build_script:
 test_script:
   - set B2_ARGS=%B2_ARGS% warnings=on known-warnings=suppress warnings-as-errors=on
   - echo B2 argumets %B2_ARGS%
-  - b2 %B2_ARGS% %PROJECT%\classic\test
-  - b2 %B2_ARGS% %PROJECT%\repository\test
-  - b2 %B2_ARGS% %PROJECT%\test
+  - b2 %B2_ARGS% pch=on-spirit %PROJECT%\classic\test
+  - b2 %B2_ARGS% pch=on-spirit %PROJECT%\repository\test
+  - b2 %B2_ARGS% pch=on-spirit %PROJECT%\test

--- a/classic/test/Jamfile
+++ b/classic/test/Jamfile
@@ -1,6 +1,7 @@
 #==============================================================================
 #   Copyright (c) 2002 Joel de Guzman
 #   Copyright (c) 2003-2004 Martin Wille
+#   Copyright (c) 2019 Nikita Kniazev
 #   http://spirit.sourceforge.net/
 #
 #   Use, modification and distribution is subject to the Boost Software
@@ -12,22 +13,30 @@
 #  Joel de Guzman [Sept 27, 2002]
 #
 
+project spirit-classic
+    : requirements
+        <include>.
+    ;
 
+###############################################################################
 
-# VP, 2005/04/14: Inside boost, we inherit proper <include>
-# from Jamroot.
-# Not sure about standalone Spirit.
-# SPIRIT_HEADER_INCLUDE ?= ../../.. ;
-# spirit-header-include = <include>$(SPIRIT_HEADER_INCLUDE) ;
+cpp-pch pch : pch.hpp : : : <include>. <toolset>msvc:<cxxflags>"/FIpch.hpp" ;
+cpp-pch pch-dbg : pch.hpp : <define>BOOST_SPIRIT_DEBUG :
+                          : <include>. <toolset>msvc:<cxxflags>"/FIpch.hpp" ;
+
+explicit pch pch-dbg ;
+
+###############################################################################
 
 rule spirit-run ( sources + : args * : input-files * : requirements * : name ? : default-build * )
 {
     name ?= $(sources[1]:D=:S=) ;
     return  
-       [ run $(sources) : $(args) : $(input-files) : $(requirements) : $(name)
+       [ run $(sources) : $(args) : $(input-files) : $(requirements)
+          <pch>on-spirit:<source>pch : $(name)
         : $(default-build) ]
        [ run $(sources) : $(args) : $(input-files) : $(requirements)
-          <define>BOOST_SPIRIT_DEBUG=1 : $(name)_debug
+          <pch>on-spirit:<source>pch-dbg <define>BOOST_SPIRIT_DEBUG : $(name)_debug
         : $(default-build) ]
         ;
 }
@@ -44,7 +53,7 @@ local opt-metrowerks = <toolset>cw:<optimization>speed ;
 # VP, 2005/04/14: MT is not available with Como, but this is
 # not handled yet.
 local multi-threading = <library>/boost/thread//boost_thread 
-                        <threading>multi <define>BOOST_ALL_NO_LIB=1 ;
+                        <threading>multi <define>BOOST_ALL_NO_LIB ;
 
     test-suite "spirit.classic.core.kernel"
         : [ spirit-run match_tests.cpp ]
@@ -53,7 +62,7 @@ local multi-threading = <library>/boost/thread//boost_thread
 
     test-suite "spirit.classic.core.scanner"
         : [ spirit-run scanner_tests.cpp ]
-          [ spirit-run scanner_value_type_tests.cpp ]
+          [ spirit-run scanner_value_type_tests.cpp : : : <pch>off ]
         ;
 
     test-suite "spirit.classic.core.primitive"
@@ -73,9 +82,9 @@ local multi-threading = <library>/boost/thread//boost_thread
         ;
 
     test-suite "spirit.classic.core.non_terminal"
-        : [ spirit-run rule_tests.cpp ]
-          [ spirit-run owi_st_tests.cpp ]
-          [ spirit-run grammar_tests.cpp : : : $(opt-metrowerks) ]
+        : [ spirit-run rule_tests.cpp : : : <pch>off ]
+          [ spirit-run owi_st_tests.cpp : : : <undef>BOOST_SPIRIT_THREADSAFE ]
+          [ spirit-run grammar_tests.cpp : : : <pch>off $(opt-metrowerks) ]
           [ spirit-run grammar_multi_instance_tst.cpp : : : $(opt-metrowerks) ]
           [ spirit-run subrule_tests.cpp ]
           [        run owi_mt_tests.cpp : : : $(multi-threading) ]
@@ -87,7 +96,7 @@ local multi-threading = <library>/boost/thread//boost_thread
     test-suite "spirit.classic.meta"
         : [ spirit-run fundamental_tests.cpp ]
           [ spirit-run parser_traits_tests.cpp ]
-          [ spirit-run traverse_tests.cpp : : : <toolset>intel:<debug-symbols>off ]
+          [ spirit-run traverse_tests.cpp : : : <pch>off <toolset>intel:<debug-symbols>off ]
         ;
 
     test-suite "spirit.classic.attribute"
@@ -120,12 +129,12 @@ local multi-threading = <library>/boost/thread//boost_thread
           [ spirit-run for_tests.cpp ]
           [ spirit-run while_tests.cpp ]
           [ spirit-run lazy_tests.cpp ]
-          [ spirit-run switch_tests_eps_default.cpp ]
-          [ spirit-run switch_tests_general_def.cpp ]
-          [ spirit-run switch_tests_wo_default.cpp ]
-          [ spirit-run switch_tests_single.cpp ]
+          [ spirit-run switch_tests_eps_default.cpp : : : <pch>off ]
+          [ spirit-run switch_tests_general_def.cpp : : : <pch>off ]
+          [ spirit-run switch_tests_wo_default.cpp : : : <pch>off ]
+          [ spirit-run switch_tests_single.cpp : : : <pch>off ]
           [ spirit-run switch_problem.cpp ]
-          [ spirit-run select_p_with_rule.cpp ]
+          [ spirit-run select_p_with_rule.cpp : : : <pch>off ]
         ;
 
     test-suite "spirit.classic.utility.parsers"
@@ -133,7 +142,7 @@ local multi-threading = <library>/boost/thread//boost_thread
           [ spirit-run confix_tests.cpp ]
           [ spirit-run loops_tests.cpp ]
           [ spirit-run symbols_tests.cpp ]
-          [ spirit-run symbols_add_null.cpp ]
+          [ spirit-run symbols_add_null.cpp : : : <pch>off ]
           [ spirit-run symbols_find_null.cpp ]
           [ spirit-run escape_char_parser_tests.cpp : : : $(opt) ]
           [ spirit-run distinct_tests.cpp ]
@@ -151,7 +160,7 @@ local multi-threading = <library>/boost/thread//boost_thread
           [ compile-fail fixed_size_queue_fail_tests.cpp ]
           [ spirit-run file_iterator_tests.cpp : : : <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS ]
           [ spirit-run multi_pass_tests.cpp : : : $(opt-metrowerks) ]
-          [ spirit-run sf_bug_720917.cpp : : : $(opt-metrowerks) ]
+          [ spirit-run sf_bug_720917.cpp : : : <pch>off $(opt-metrowerks) ]
           [ spirit-run position_iterator_tests.cpp : : : $(opt-metrowerks) ]
           [ compile multi_pass_compile_tests.cpp ]
         ;

--- a/classic/test/for_tests.cpp
+++ b/classic/test/for_tests.cpp
@@ -10,12 +10,8 @@
 // Tests for spirit::for_p
 // [13-Jan-2003]
 ////////////////////////////////////////////////////////////////////////////////
-#define qDebug 0
 #include <iostream>
 #include <cstring>
-#if qDebug
-#define SPIRIT_DEBUG
-#endif
 #include <string>
 #include <boost/spirit/include/classic_core.hpp>
 #include <boost/spirit/include/classic_assign_actor.hpp>

--- a/classic/test/if_tests.cpp
+++ b/classic/test/if_tests.cpp
@@ -11,12 +11,8 @@
 // Tests for BOOST_SPIRIT_CLASSIC_NS::if_p
 // [28-Dec-2002]
 ////////////////////////////////////////////////////////////////////////////////
-#define qDebug 0
 #include <iostream>
 #include <cstring>
-#if qDebug
-#define BOOST_SPIRIT_DEBUG
-#endif
 #include <boost/spirit/include/classic_core.hpp>
 #include <boost/spirit/include/classic_if.hpp>
 #include <boost/spirit/include/classic_assign_actor.hpp>

--- a/classic/test/loops_tests.cpp
+++ b/classic/test/loops_tests.cpp
@@ -9,8 +9,6 @@
 #include <iostream>
 #include <boost/detail/lightweight_test.hpp>
 
-
-//#define BOOST_SPIRIT_DEBUG
 #include <boost/spirit/include/classic_core.hpp>
 #include <boost/spirit/include/classic_loops.hpp>
 using namespace BOOST_SPIRIT_CLASSIC_NS;

--- a/classic/test/operators_tests.cpp
+++ b/classic/test/operators_tests.cpp
@@ -11,7 +11,6 @@
 
 using namespace std;
 
-//#define BOOST_SPIRIT_DEBUG
 #include <boost/spirit/include/classic_core.hpp>
 using namespace BOOST_SPIRIT_CLASSIC_NS;
 

--- a/classic/test/owi_st_tests.cpp
+++ b/classic/test/owi_st_tests.cpp
@@ -8,6 +8,9 @@
 =============================================================================*/
 // vim:ts=4:sw=4:et
 
+#if defined(BOOST_BUILD_PCH_ENABLED) && defined(BOOST_SPIRIT_THREADSAFE)
+# error BOOST_SPIRIT_THREADSAFE has to be undefined for this test
+#endif
 #undef BOOST_SPIRIT_THREADSAFE
 #include <boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp>
 #include <boost/detail/lightweight_test.hpp>

--- a/classic/test/pch.hpp
+++ b/classic/test/pch.hpp
@@ -1,0 +1,15 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#ifdef BOOST_BUILD_PCH_ENABLED
+
+#include <boost/spirit/include/classic.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <vector>
+#include <string>
+#include <iostream>
+
+#endif

--- a/classic/test/while_tests.cpp
+++ b/classic/test/while_tests.cpp
@@ -10,12 +10,8 @@
 // Tests for BOOST_SPIRIT_CLASSIC_NS::while_p
 // [28-Dec-2002]
 ////////////////////////////////////////////////////////////////////////////////
-#define qDebug 0
 #include <iostream>
 #include <cstring>
-#if qDebug
-#define BOOST_SPIRIT_DEBUG
-#endif
 
 #include "impl/string_length.hpp"
 #include <boost/spirit/include/classic_core.hpp>

--- a/repository/test/Jamfile
+++ b/repository/test/Jamfile
@@ -1,6 +1,7 @@
 #==============================================================================
 #   Copyright (c) 2001-2009 Joel de Guzman
 #   Copyright (c) 2001-2009 Hartmut Kaiser
+#   Copyright (c) 2017-2019 Nikita Kniazev
 #
 #   Use, modification and distribution is subject to the Boost Software
 #   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -13,6 +14,14 @@ project spirit_v2_repository/test
     :
     :
     ;
+
+###############################################################################
+
+alias qi-pch : : <pch>on-spirit:<source>../../test/qi//pch ;
+alias ka-pch : : <pch>on-spirit:<source>../../test/karma//pch ;
+explicit qi-pch ka-pch ;
+
+###############################################################################
 
 import os ;
 
@@ -31,16 +40,16 @@ import testing ;
     test-suite spirit_v2_repository :
 
     # run Qi repository tests
-    [ run qi/advance.cpp                    : : : : qi_repo_advance ]
-    [ run qi/confix.cpp                     : : : : qi_repo_confix ]
-    [ run qi/distinct.cpp                   : : : : qi_repo_distinct ]
-    [ run qi/subrule.cpp                    : : : : qi_repo_subrule ]
-    [ run qi/keywords.cpp                   : : : $(keywords_reqs) : qi_repo_keywords ]
-    [ run qi/seek.cpp                       : : : : qi_repo_seek ]
+    [ run qi-pch qi/advance.cpp             : : : : qi_repo_advance ]
+    [ run qi-pch qi/confix.cpp              : : : : qi_repo_confix ]
+    [ run qi-pch qi/distinct.cpp            : : : : qi_repo_distinct ]
+    [ run qi-pch qi/subrule.cpp             : : : : qi_repo_subrule ]
+    [ run qi-pch qi/keywords.cpp            : : : $(keywords_reqs) : qi_repo_keywords ]
+    [ run qi-pch qi/seek.cpp                : : : : qi_repo_seek ]
 
     # run Karma repository tests
-    [ run karma/confix.cpp                  : : : : karma_repo_confix ]
-    [ run karma/subrule.cpp                 : : : : karma_repo_subrule ]
+    [ run ka-pch karma/confix.cpp           : : : : karma_repo_confix ]
+    [ run ka-pch karma/subrule.cpp          : : : : karma_repo_subrule ]
 
     ;
 }

--- a/repository/test/qi/test.hpp
+++ b/repository/test/qi/test.hpp
@@ -15,7 +15,7 @@
 namespace spirit_test
 {
     template <typename Char, typename Parser>
-    bool test(Char const* in, Parser const& p, bool full_match = true)
+    inline bool test(Char const* in, Parser const& p, bool full_match = true)
     {
         // we don't care about the result of the "what" function.
         // we only care that all parsers have it:
@@ -29,7 +29,7 @@ namespace spirit_test
     }
 
     template <typename Char, typename Parser, typename Skipper>
-    bool test(Char const* in, Parser const& p
+    inline bool test(Char const* in, Parser const& p
         , Skipper const& s, bool full_match = true)
     {
         // we don't care about the result of the "what" function.
@@ -44,7 +44,7 @@ namespace spirit_test
     }
 
     template <typename Char, typename Parser, typename Attr>
-    bool test_attr(Char const* in, Parser const& p
+    inline bool test_attr(Char const* in, Parser const& p
         , Attr& attr, bool full_match = true)
     {
         // we don't care about the result of the "what" function.
@@ -59,7 +59,7 @@ namespace spirit_test
     }
 
     template <typename Char, typename Parser, typename Attr, typename Skipper>
-    bool test_attr(Char const* in, Parser const& p
+    inline bool test_attr(Char const* in, Parser const& p
         , Attr& attr, Skipper const& s, bool full_match = true)
     {
         // we don't care about the result of the "what" function.
@@ -89,7 +89,7 @@ namespace spirit_test
         }
     };
 
-    void print_info(boost::spirit::info const& what)
+    inline void print_info(boost::spirit::info const& what)
     {
         using boost::spirit::basic_info_walker;
 

--- a/test/karma/Jamfile
+++ b/test/karma/Jamfile
@@ -2,6 +2,7 @@
 #   Copyright (c) 2001-2011 Joel de Guzman
 #   Copyright (c) 2001-2012 Hartmut Kaiser
 #   Copyright (c)      2011 Bryce Lelbach
+#   Copyright (c) 2016-2019 Nikita Kniazev
 #
 #   Use, modification and distribution is subject to the Boost Software
 #   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -20,6 +21,12 @@ project spirit-karma
 
 ###############################################################################
 
+cpp-pch pch : pch.hpp : : : <include>. <toolset>msvc:<cxxflags>"/FIpch.hpp" ;
+
+explicit pch ;
+
+###############################################################################
+
 local subproject-name = karma ;
 
 rule run ( sources + : args * : input-files *
@@ -27,21 +34,21 @@ rule run ( sources + : args * : input-files *
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.run $(sources) : $(args) : $(input-files)
-           : $(requirements) : $(target-name) : $(default-build) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) : $(default-build) ] ;
 }
 
 rule compile ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 rule compile-fail ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile-fail $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 ###############################################################################
@@ -70,7 +77,7 @@ run char2.cpp ;
 run char3.cpp ;
 run char_class.cpp ;
 run columns.cpp ;
-run debug.cpp ;
+run debug.cpp : : : <pch>off ;
 run delimiter.cpp ;
 run duplicate.cpp ;
 run encoding.cpp ;
@@ -127,4 +134,4 @@ run regression_real_0.cpp ;
 run regression_real_policy_sign.cpp ;
 run regression_real_scientific.cpp ;
 run regression_semantic_action_attribute.cpp ;
-run regression_unicode_char.cpp ;
+run regression_unicode_char.cpp : : : <pch>off ;

--- a/test/karma/alternative1.cpp
+++ b/test/karma/alternative1.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define KARMA_TEST_COMPILE_FAIL
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/alternative2.cpp
+++ b/test/karma/alternative2.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define KARMA_TEST_COMPILE_FAIL
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/char1.cpp
+++ b/test/karma/char1.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/char2.cpp
+++ b/test/karma/char2.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/char3.cpp
+++ b/test/karma/char3.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/delimiter.cpp
+++ b/test/karma/delimiter.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/format_manip_attr.cpp
+++ b/test/karma/format_manip_attr.cpp
@@ -3,10 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
-#define SPIRIT_ARGUMENTS_LIMIT 10
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -19,6 +15,10 @@
 #include <boost/spirit/include/karma_format_attr.hpp>
 
 #include "test_manip_attr.hpp"
+
+#if SPIRIT_ARGUMENTS_LIMIT < 10
+# error SPIRIT_ARGUMENTS_LIMIT must be at least 10 to run the test
+#endif
 
 using spirit_test::test;
 using spirit_test::test_delimited;

--- a/test/karma/generate_attr.cpp
+++ b/test/karma/generate_attr.cpp
@@ -3,10 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
-#define SPIRIT_ARGUMENTS_LIMIT 10
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -15,6 +11,10 @@
 #include <boost/spirit/include/karma_generate_attr.hpp>
 
 #include "test_attr.hpp"
+
+#if SPIRIT_ARGUMENTS_LIMIT < 10
+# error SPIRIT_ARGUMENTS_LIMIT must be at least 10 to run the test
+#endif
 
 using namespace spirit_test;
 

--- a/test/karma/int1.cpp
+++ b/test/karma/int1.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/mpl/vector.hpp>

--- a/test/karma/int2.cpp
+++ b/test/karma/int2.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/mpl/vector.hpp>

--- a/test/karma/int3.cpp
+++ b/test/karma/int3.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/lexical_cast.hpp>

--- a/test/karma/pch.hpp
+++ b/test/karma/pch.hpp
@@ -1,0 +1,21 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#ifdef BOOST_BUILD_PCH_ENABLED
+
+#include <boost/spirit/include/karma.hpp>
+#include <boost/spirit/include/support_argument.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/optional.hpp>
+#include <boost/variant.hpp>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#endif

--- a/test/karma/real1.cpp
+++ b/test/karma/real1.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include "real.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/karma/real2.cpp
+++ b/test/karma/real2.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include "real.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/karma/real3.cpp
+++ b/test/karma/real3.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-//#define KARMA_FAIL_COMPILATION
-
 #include <boost/spirit/include/version.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>

--- a/test/karma/sequence1.cpp
+++ b/test/karma/sequence1.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define KARMA_TEST_COMPILE_FAIL
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/karma/sequence2.cpp
+++ b/test/karma/sequence2.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define KARMA_TEST_COMPILE_FAIL
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/Jamfile
+++ b/test/lex/Jamfile
@@ -2,6 +2,7 @@
 #   Copyright (c) 2001-2011 Joel de Guzman
 #   Copyright (c) 2001-2012 Hartmut Kaiser
 #   Copyright (c)      2011 Bryce Lelbach
+#   Copyright (c) 2016-2019 Nikita Kniazev
 #
 #   Use, modification and distribution is subject to the Boost Software
 #   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -22,6 +23,12 @@ project spirit-lex
 
 ###############################################################################
 
+cpp-pch pch : pch.hpp : : : <include>. <toolset>msvc:<cxxflags>"/FIpch.hpp" ;
+
+explicit pch ;
+
+###############################################################################
+
 local subproject-name = lex ;
 
 rule run ( sources + : args * : input-files *
@@ -29,21 +36,21 @@ rule run ( sources + : args * : input-files *
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.run $(sources) : $(args) : $(input-files)
-           : $(requirements) : $(target-name) : $(default-build) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) : $(default-build) ] ;
 }
 
 rule compile ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 rule compile-fail ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile-fail $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 ###############################################################################
@@ -79,16 +86,22 @@ run plain_token.cpp ;
 
 run regression_basic_lexer.cpp ;
 run regression_matlib_dynamic.cpp ;
+# matlib_static needs a generated header from matlib_generate target but
+# with PCH enabled <dependency> does something strange that leads to having
+# two matlib_generate targets with different requirements. I tried to replace
+# it with <use> but it does not make a dependency between targets (the docs
+# says that <use> is extended version of <dependency> that applies usage
+# requirements). So I ended with using check-target-builds.
 run regression_matlib_generate.cpp         : [ location matlib_static.h ] ;
-run regression_matlib_static.cpp           : : : <dependency>lex_regression_matlib_generate ;
+run regression_matlib_static.cpp           : : : [ check-target-builds lex_regression_matlib_generate ] ;
 run regression_matlib_generate_switch.cpp  : [ location matlib_static_switch.h ] ;
-run regression_matlib_switch.cpp           : : : <dependency>lex_regression_matlib_generate_switch ;
+run regression_matlib_switch.cpp           : : : [ check-target-builds lex_regression_matlib_generate_switch ] ;
 run regression_word_count.cpp ;
 run regression_syntax_error.cpp ;
 run regression_wide.cpp ;
 run regression_file_iterator1.cpp ;
 run regression_file_iterator2.cpp ;
-run regression_file_iterator3.cpp ;
+run regression_file_iterator3.cpp : : : <pch>off ;
 run regression_file_iterator4.cpp ;
 run regression_static_wide_6253.cpp ;
 run regression_less_8563.cpp ;

--- a/test/lex/auto_switch_lexerstate.cpp
+++ b/test/lex/auto_switch_lexerstate.cpp
@@ -10,8 +10,6 @@
 // Additionally this test makes sure the syntax 'self("state", "targetstate")'
 // works properly.
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG 1
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/pch.hpp
+++ b/test/lex/pch.hpp
@@ -1,0 +1,17 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#ifdef BOOST_BUILD_PCH_ENABLED
+
+#include <boost/spirit/include/lex.hpp>
+#include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <string>
+#include <iostream>
+
+#endif

--- a/test/lex/plain_token.cpp
+++ b/test/lex/plain_token.cpp
@@ -3,14 +3,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-#define BOOST_VARIANT_MINIMIZE_SIZE
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/config/warning_disable.hpp>
 
-#include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
 
 #include <string>
 

--- a/test/lex/regression_file_iterator1.cpp
+++ b/test/lex/regression_file_iterator1.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/regression_file_iterator2.cpp
+++ b/test/lex/regression_file_iterator2.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG 1
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/regression_file_iterator4.cpp
+++ b/test/lex/regression_file_iterator4.cpp
@@ -8,8 +8,6 @@
 // if a token matched at the beginning of a line is discarded using 
 // lex::pass_fail.
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG 1
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/regression_syntax_error.cpp
+++ b/test/lex/regression_syntax_error.cpp
@@ -8,7 +8,11 @@
 #include <boost/config/warning_disable.hpp>
 
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
+#include <boost/spirit/include/qi_char.hpp>
+#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/spirit/include/qi_eoi.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/lex/regression_word_count.cpp
+++ b/test/lex/regression_word_count.cpp
@@ -4,15 +4,15 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-#define BOOST_VARIANT_MINIMIZE_SIZE
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/config/warning_disable.hpp>
 
-#include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
+#include <boost/spirit/include/qi_action.hpp>
+#include <boost/spirit/include/qi_char.hpp>
+#include <boost/spirit/include/qi_grammar.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 
 #include <iostream>

--- a/test/lex/set_token_value.cpp
+++ b/test/lex/set_token_value.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/phoenix_object.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>

--- a/test/lex/state_switcher.cpp
+++ b/test/lex/state_switcher.cpp
@@ -4,8 +4,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/detail/lightweight_test.hpp>
-#include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
 #include "test_parser.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/lex/string_token_id.cpp
+++ b/test/lex/string_token_id.cpp
@@ -3,14 +3,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-#define BOOST_VARIANT_MINIMIZE_SIZE
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/config/warning_disable.hpp>
 
-#include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_operator.hpp>
+#include <boost/spirit/include/qi_action.hpp>
+#include <boost/spirit/include/qi_grammar.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 
 #include <iostream>

--- a/test/lex/test_parser.hpp
+++ b/test/lex/test_parser.hpp
@@ -13,7 +13,7 @@
 namespace spirit_test
 {
     template <typename Char, typename Parser, typename Lexer>
-    bool test_parser(Char const* in, Parser const& p, Lexer& lex, 
+    inline bool test_parser(Char const* in, Parser const& p, Lexer& lex, 
         bool full_match = true)
     {
         // we don't care about the result of the "what" function.
@@ -34,7 +34,7 @@ namespace spirit_test
     }
 
     template <typename Char, typename Parser, typename Lexer, typename Skipper>
-    bool test_parser(Char const* in, Parser const& p, Lexer& lex,
+    inline bool test_parser(Char const* in, Parser const& p, Lexer& lex,
           Skipper const& s, bool full_match = true)
     {
         // we don't care about the result of the "what" function.

--- a/test/lex/token_iterpair.cpp
+++ b/test/lex/token_iterpair.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/token_moretypes.cpp
+++ b/test/lex/token_moretypes.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/token_omit.cpp
+++ b/test/lex/token_omit.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/lex/token_onetype.cpp
+++ b/test/lex/token_onetype.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #define BOOST_SPIRIT_LEXERTL_DEBUG
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 

--- a/test/qi/Jamfile
+++ b/test/qi/Jamfile
@@ -2,6 +2,7 @@
 #   Copyright (c) 2001-2011 Joel de Guzman
 #   Copyright (c) 2001-2012 Hartmut Kaiser
 #   Copyright (c)      2011 Bryce Lelbach
+#   Copyright (c) 2016-2019 Nikita Kniazev
 #
 #   Use, modification and distribution is subject to the Boost Software
 #   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -20,6 +21,12 @@ project spirit-qi
 
 ###############################################################################
 
+cpp-pch pch : pch.hpp : : : <include>. <toolset>msvc:<cxxflags>"/FIpch.hpp" ;
+
+explicit pch ;
+
+###############################################################################
+
 local subproject-name = qi ;
 
 rule run ( sources + : args * : input-files *
@@ -27,29 +34,29 @@ rule run ( sources + : args * : input-files *
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.run $(sources) : $(args) : $(input-files)
-           : $(requirements) : $(target-name) : $(default-build) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) : $(default-build) ] ;
 }
 
 rule compile ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 rule compile-fail ( sources + : requirements * : target-name ? )
 {
     target-name ?= $(subproject-name)_$(sources[1]:D=:S=) ;
     return [ testing.compile-fail $(sources)
-           : $(requirements) : $(target-name) ] ;
+           : $(requirements) <pch>on-spirit:<source>pch : $(target-name) ] ;
 }
 
 ###############################################################################
 
 compile-fail grammar_fail.cpp ;
 compile-fail rule_fail.cpp ;
-run actions.cpp ;
-run actions2.cpp ;
+run actions.cpp : : : <pch>off ; # Enable PCH when boostorg/proto#13 is merged.
+run actions2.cpp : : : <pch>off ;
 run alternative.cpp ;
 run attr.cpp ;
 run attribute1.cpp ;
@@ -59,10 +66,10 @@ run auto.cpp ;
 run binary.cpp ;
 run bool1.cpp ;
 run bool2.cpp ;
-run char1.cpp ;
+run char1.cpp : : : <pch>off ; # Enable PCH after fixing interference from including auto.
 run char2.cpp ;
-run char_class.cpp ;
-run debug.cpp ;
+run char_class.cpp : : : <pch>off ;
+run debug.cpp : : : <pch>off ;
 run difference.cpp ;
 run encoding.cpp ;
 run end.cpp ;
@@ -129,7 +136,7 @@ run iterator_check.cpp ;
 compile pass_container3.cpp ;
 compile regression_attr_with_action.cpp ;
 compile regression_container_attribute.cpp ;
-compile regression_debug_optional.cpp ;
+compile regression_debug_optional.cpp : <pch>off ;
 compile regression_fusion_proto_spirit.cpp ;
 compile regression_one_element_fusion_sequence.cpp ;
 compile regression_one_element_sequence_attribute.cpp ;
@@ -145,4 +152,4 @@ run regression_transform_assignment.cpp ;
 run regression_binary_action.cpp ;
 run regression_stream_eof.cpp ;
 
-run to_utf8.cpp ;
+run to_utf8.cpp : : : <pch>off ;

--- a/test/qi/match_manip_attr.cpp
+++ b/test/qi/match_manip_attr.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#define SPIRIT_ARGUMENTS_LIMIT 10
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -13,6 +11,10 @@
 #include <boost/spirit/include/qi_parse.hpp>
 
 #include "test_manip_attr.hpp"
+
+#if SPIRIT_ARGUMENTS_LIMIT < 10
+# error SPIRIT_ARGUMENTS_LIMIT must be at least 10 to run the test
+#endif
 
 using namespace spirit_test;
 

--- a/test/qi/parse_attr.cpp
+++ b/test/qi/parse_attr.cpp
@@ -3,8 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#define SPIRIT_ARGUMENTS_LIMIT 10
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -13,6 +11,10 @@
 #include <boost/spirit/include/qi_parse_attr.hpp>
 
 #include "test_attr.hpp"
+
+#if SPIRIT_ARGUMENTS_LIMIT < 10
+# error SPIRIT_ARGUMENTS_LIMIT must be at least 10 to run the test
+#endif
 
 using namespace spirit_test;
 

--- a/test/qi/pch.hpp
+++ b/test/qi/pch.hpp
@@ -1,0 +1,23 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#ifdef BOOST_BUILD_PCH_ENABLED
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/support_argument.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/optional.hpp>
+#include <boost/variant.hpp>
+#include <map>
+#include <set>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#endif


### PR DESCRIPTION
Not intrusive. Significantly speeds up tests on MSVC (for about 3 times). Finally solves exceeding build time limits on CI with MSVC compilers.

Did not set up PCH for X3, it is fast as-is (tooks only about 2 minutes). Repository tests reuse PCH from Qi/Karma tests.
