### PR TITLE
Replace mpl::find_if+is_same with find

### DIFF
--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -30,9 +30,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename
-            mpl::find_if<types, is_same<mpl::_1, Expected> >::type
-        iter_1;
+        typedef typename mpl::find<types, Expected>::type iter_1;
 
         typedef typename
             mpl::eval_if<

--- a/include/boost/spirit/home/x3/support/traits/variant_find_substitute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/variant_find_substitute.hpp
@@ -9,6 +9,7 @@
 #define BOOST_SPIRIT_X3_VARIANT_FIND_SUBSTITUTE_APR_18_2014_930AM
 
 #include <boost/spirit/home/x3/support/traits/is_substitute.hpp>
+#include <boost/mpl/find.hpp>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
@@ -22,9 +23,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename
-            mpl::find_if<types, is_same<mpl::_1, Attribute> >::type
-        iter_1;
+        typedef typename mpl::find<types, Attribute>::type iter_1;
 
         typedef typename
             mpl::eval_if<

--- a/include/boost/spirit/home/x3/support/traits/variant_has_substitute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/variant_has_substitute.hpp
@@ -9,6 +9,7 @@
 #define BOOST_SPIRIT_X3_VARIANT_HAS_SUBSTITUTE_APR_18_2014_925AM
 
 #include <boost/spirit/home/x3/support/traits/is_substitute.hpp>
+#include <boost/mpl/find.hpp>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
@@ -22,9 +23,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename
-            mpl::find_if<types, is_same<mpl::_1, Attribute>>::type
-        iter_1;
+        typedef typename mpl::find<types, Attribute>::type iter_1;
 
         typedef typename
             mpl::eval_if<


### PR DESCRIPTION
From `mpl::find` docs:
> `typedef find<s,t>::type i;`
> Semantics: Equivalent to `typedef find_if<s, is_same<_,t> >::type i;`