### PR TITLE
simplify value_initialize trait

### DIFF
--- a/include/boost/spirit/home/x3/support/traits/value_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/value_traits.hpp
@@ -9,8 +9,6 @@
 #if !defined(BOOST_SPIRIT_X3_VALUE_TRAITS_MAY_07_2013_0203PM)
 #define BOOST_SPIRIT_X3_VALUE_TRAITS_MAY_07_2013_0203PM
 
-#include <boost/utility/value_init.hpp>
-
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
     template <typename T, typename Enable = void>
@@ -18,7 +16,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         static T call()
         {
-            return boost::value_initialized<T>();
+            return {};
         }
     };
 }}}}


### PR DESCRIPTION
removed use of boost::value_initialized which is obsolete post C++11