### PR TITLE
Removed wrong and redundant transform_attribute specializations

### DIFF
--- a/include/boost/spirit/home/karma/detail/attributes.hpp
+++ b/include/boost/spirit/home/karma/detail/attributes.hpp
@@ -14,8 +14,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace karma
 {
-    template <typename Exposed, typename Transformed, typename Enable = void>
-    struct transform_attribute
+    template <typename Exposed, typename Transformed>
+    struct default_transform_attribute
     {
         typedef Transformed type;
         static Transformed pre(Exposed& val) 
@@ -24,6 +24,12 @@ namespace boost { namespace spirit { namespace karma
         }
         // Karma only, no post() and no fail() required
     };
+
+    // main specialization for Karma
+    template <typename Exposed, typename Transformed, typename Enable = void>
+    struct transform_attribute
+      : default_transform_attribute<Exposed, Transformed>
+    {};
 
     template <typename Exposed, typename Transformed>
     struct transform_attribute<boost::optional<Exposed> const, Transformed
@@ -37,7 +43,7 @@ namespace boost { namespace spirit { namespace karma
     };
 
     template <typename Attribute>
-    struct transform_attribute<Attribute const, Attribute>
+    struct default_transform_attribute<Attribute const, Attribute>
     {
         typedef Attribute const& type;
         static Attribute const& pre(Attribute const& val) { return val; }
@@ -61,37 +67,12 @@ namespace boost { namespace spirit { namespace karma
     {};
 
     // unused_type needs some special handling as well
-    template <>
-    struct transform_attribute<unused_type, unused_type>
+    template <typename Attribute>
+    struct transform_attribute<Attribute, unused_type>
     {
         typedef unused_type type;
         static unused_type pre(unused_type) { return unused; }
     };
-
-    template <>
-    struct transform_attribute<unused_type const, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type const, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute const, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -105,39 +105,14 @@ namespace boost { namespace spirit { namespace qi
     };
 
     // unused_type needs some special handling as well
-    template <>
-    struct transform_attribute<unused_type, unused_type>
+    template <typename Attribute>
+    struct transform_attribute<Attribute, unused_type>
     {
         typedef unused_type type;
         static unused_type pre(unused_type) { return unused; }
         static void post(unused_type, unused_type) {}
         static void fail(unused_type) {}
     };
-
-    template <>
-    struct transform_attribute<unused_type const, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type const, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute const, unused_type>
-      : transform_attribute<unused_type, unused_type>
-    {};
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
@@ -54,33 +54,13 @@ namespace boost { namespace spirit { namespace x3
     };
 
     // unused_type needs some special handling as well
-    template <>
-    struct transform_attribute<unused_type, unused_type>
+    template <typename Attribute>
+    struct transform_attribute<Attribute, unused_type>
     {
         typedef unused_type type;
         static unused_type pre(unused_type) { return unused; }
         static void post(unused_type, unused_type) {}
     };
-
-    template <>
-    struct transform_attribute<unused_type const, unused_type>
-      : transform_attribute<unused_type, unused_type> {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type, Attribute>
-      : transform_attribute<unused_type, unused_type> {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type const, Attribute>
-      : transform_attribute<unused_type, unused_type> {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute, unused_type>
-      : transform_attribute<unused_type, unused_type> {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute const, unused_type>
-      : transform_attribute<unused_type, unused_type> {};
 }}}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/x3/rule4.cpp
+++ b/test/x3/rule4.cpp
@@ -108,7 +108,7 @@ main()
 
     { // error handling
 
-        auto r = rule<my_rule_class, char const*>()
+        auto r = rule<my_rule_class>()
             = '(' > int_ > ',' > int_ > ')';
 
         BOOST_TEST(test("(123,456)", r));

--- a/test/x3/with.cpp
+++ b/test/x3/with.cpp
@@ -43,7 +43,7 @@ main()
     { // injecting data into the context in the grammar
 
         int val = 0;
-        auto r = rule<my_rule_class, char const*>() =
+        auto r = rule<my_rule_class>() =
             '(' > int_ > ',' > int_ > ')'
             ;
 


### PR DESCRIPTION
The wrong specializations were allowing to assign a parse to a rule with
incompatible attribute types.