### PR TITLE
X3: rule: Skip attribute synthesization on unused actual attribute

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -12,7 +12,6 @@
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/core/skip_over.hpp>
 #include <boost/spirit/home/x3/directive/expect.hpp>
-#include <boost/spirit/home/x3/support/traits/make_attribute.hpp>
 #include <boost/spirit/home/x3/support/utility/sfinae.hpp>
 #include <boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp>
 #include <boost/utility/addressof.hpp>
@@ -303,18 +302,14 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         {
             boost::ignore_unused(rule_name);
 
-            typedef traits::make_attribute<Attribute, ActualAttribute> make_attribute;
-
             // do down-stream transformation, provides attribute for
             // rhs parser
             typedef traits::transform_attribute<
-                typename make_attribute::type, Attribute, parser_id>
+                ActualAttribute, Attribute, parser_id>
             transform;
 
-            typedef typename make_attribute::value_type value_type;
             typedef typename transform::type transform_attr;
-            value_type made_attr = make_attribute::call(attr);
-            transform_attr attr_ = transform::pre(made_attr);
+            transform_attr attr_ = transform::pre(attr);
 
             bool ok_parse
               //Creates a place to hold the result of parse_rhs

--- a/test/x3/rule3.cpp
+++ b/test/x3/rule3.cpp
@@ -36,6 +36,8 @@ int main()
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::rule;
     using boost::spirit::x3::lit;
+    using boost::spirit::x3::eps;
+    using boost::spirit::x3::unused_type;
 
 
     { // synth attribute value-init
@@ -66,6 +68,15 @@ int main()
 
         BOOST_TEST(test_attr("abcdef", +rdef, s));
         BOOST_TEST(s == "abcdef");
+    }
+
+    {
+        auto r = rule<class r, int>{} = eps[([] (auto& ctx) {
+            using boost::spirit::x3::_val;
+            static_assert(std::is_same<std::decay_t<decltype(_val(ctx))>, unused_type>::value,
+                "Attribute must not be synthesized");
+        })];
+        BOOST_TEST(test("", r));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
There is a mistake in `make_attribute` trait that leads to synthesization and
immediately throwing out an attribue, so rule context always was unused_type
when actual attribute is unused_type (added test for this case). Instead of
fixing `make_attribute` trait I just completely removed synthesization in
rule by removing `make_attribute` trait usage (the traits could be removed
after a simple change in 'action' parser). I think the change is better
than fixing the trait because it removes excessive attribute default
construction in every rule and makes rule almost free to use.
