### PR TITLE
unused_type tweaks

### DIFF
--- a/include/boost/spirit/home/support/unused.hpp
+++ b/include/boost/spirit/home/support/unused.hpp
@@ -15,11 +15,6 @@
 #include <boost/config.hpp>
 #include <boost/mpl/bool.hpp>
 
-#if defined(BOOST_MSVC)
-# pragma warning(push)
-# pragma warning(disable: 4522) // multiple assignment operators specified warning
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit
 {
@@ -31,60 +26,46 @@ namespace boost { namespace spirit
     ///////////////////////////////////////////////////////////////////////////
     struct unused_type
     {
-        unused_type()
+        BOOST_DEFAULTED_FUNCTION(unused_type() BOOST_NOEXCEPT, {})
+
+        template <typename T>
+        BOOST_CONSTEXPR unused_type(T const&) BOOST_NOEXCEPT
         {
         }
 
         template <typename T>
-        unused_type(T const&)
-        {
-        }
-
-        template <typename T>
-        unused_type const&
-        operator=(T const&) const
+        BOOST_CONSTEXPR unused_type const&
+        operator=(T const&) const BOOST_NOEXCEPT
         {
             return *this;
         }
 
         template <typename T>
-        unused_type&
-        operator=(T const&)
-        {
-            return *this;
-        }
-
-        unused_type const&
-        operator=(unused_type const&) const
-        {
-            return *this;
-        }
-
-        unused_type&
-        operator=(unused_type const&)
+        BOOST_CXX14_CONSTEXPR unused_type&
+        operator=(T const&) BOOST_NOEXCEPT
         {
             return *this;
         }
     };
 
-    unused_type const unused = unused_type();
+    BOOST_CONSTEXPR unused_type const unused = unused_type();
 
     namespace detail
     {
         struct unused_only
         {
-            unused_only(unused_type const&) {}
+            BOOST_CONSTEXPR unused_only(unused_type const&) BOOST_NOEXCEPT {}
         };
     }
 
     template <typename Out>
-    inline Out& operator<<(Out& out, detail::unused_only const&)
+    BOOST_CONSTEXPR inline Out& operator<<(Out& out, detail::unused_only const&)
     {
         return out;
     }
 
     template <typename In>
-    inline In& operator>>(In& in, unused_type&)
+    BOOST_CONSTEXPR inline In& operator>>(In& in, unused_type&)
     {
         return in;
     }
@@ -97,9 +78,5 @@ namespace boost { namespace spirit
         template <> struct not_is_unused<unused_type> : mpl::false_ {};
     }
 }}
-
-#if defined(BOOST_MSVC)
-# pragma warning(pop)
-#endif
 
 #endif

--- a/include/boost/spirit/home/x3/support/unused.hpp
+++ b/include/boost/spirit/home/x3/support/unused.hpp
@@ -8,9 +8,8 @@
 #if !defined(BOOST_SPIRIT_X3_UNUSED_APRIL_16_2006_0616PM)
 #define BOOST_SPIRIT_X3_UNUSED_APRIL_16_2006_0616PM
 
-#include <ostream>
-#include <istream>
 #include <boost/mpl/identity.hpp>
+#include <iosfwd>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace x3

--- a/include/boost/spirit/home/x3/support/unused.hpp
+++ b/include/boost/spirit/home/x3/support/unused.hpp
@@ -12,47 +12,28 @@
 #include <istream>
 #include <boost/mpl/identity.hpp>
 
-#if defined(BOOST_MSVC)
-# pragma warning(push)
-# pragma warning(disable: 4522) // multiple assignment operators specified warning
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost { namespace spirit { namespace x3
 {
     struct unused_type
     {
-        unused_type()
+        unused_type() = default;
+
+        template <typename T>
+        constexpr unused_type(T const&) noexcept
         {
         }
 
         template <typename T>
-        unused_type(T const&)
-        {
-        }
-
-        template <typename T>
-        unused_type const&
-        operator=(T const&) const
+        constexpr unused_type const&
+        operator=(T const&) const noexcept
         {
             return *this;
         }
 
         template <typename T>
-        unused_type&
-        operator=(T const&)
-        {
-            return *this;
-        }
-
-        unused_type const&
-        operator=(unused_type const&) const
-        {
-            return *this;
-        }
-
-        unused_type&
-        operator=(unused_type const&)
+        constexpr unused_type&
+        operator=(T const&) noexcept
         {
             return *this;
         }
@@ -60,27 +41,23 @@ namespace boost { namespace spirit { namespace x3
         // unused_type can also masquerade as an empty context (see context.hpp)
 
         template <typename ID>
-        unused_type get(ID) const
+        constexpr unused_type get(ID) const noexcept
         {
             return {};
         }
     };
 
-    auto const unused = unused_type{};
+    constexpr auto const unused = unused_type{};
 
-    inline std::ostream& operator<<(std::ostream& out, unused_type const&)
+    constexpr std::ostream& operator<<(std::ostream& out, unused_type const&)
     {
         return out;
     }
 
-    inline std::istream& operator>>(std::istream& in, unused_type&)
+    constexpr std::istream& operator>>(std::istream& in, unused_type&)
     {
         return in;
     }
 }}}
-
-#if defined(BOOST_MSVC)
-# pragma warning(pop)
-#endif
 
 #endif

--- a/test/support/Jamfile
+++ b/test/support/Jamfile
@@ -47,6 +47,7 @@ rule compile-fail ( sources + : requirements * : target-name ? )
 ###############################################################################
 
 run istream_iterator_basic.cpp ;
+run unused_type.cpp ;
 run utree.cpp ;
 run utree_debug.cpp ;
 

--- a/test/support/unused_type.cpp
+++ b/test/support/unused_type.cpp
@@ -1,0 +1,33 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/home/support/unused.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+template <typename Expected, typename T>
+void test(T&)
+{
+    BOOST_STATIC_ASSERT((boost::is_same<T&, Expected>::value));
+}
+
+int main()
+{
+    using boost::spirit::unused;
+    using boost::spirit::unused_type;
+
+    unused_type unused_mut;
+    test<unused_type const&>(unused);
+    test<unused_type&>(unused_mut);
+    test<unused_type const&>(unused = 123);
+    test<unused_type const&>(unused = unused);
+    test<unused_type const&>(unused = unused_mut);
+    test<unused_type&>(unused_mut = 123);
+    test<unused_type&>(unused_mut = unused);
+    test<unused_type&>(unused_mut = unused_mut);
+}

--- a/test/support/unused_type.cpp
+++ b/test/support/unused_type.cpp
@@ -10,10 +10,16 @@
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || \
+    !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#include <type_traits>
+static_assert(std::is_trivial<boost::spirit::unused_type>::value, "");
+#endif
+
 template <typename Expected, typename T>
 void test(T&)
 {
-    BOOST_STATIC_ASSERT((boost::is_same<T&, Expected>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<T, Expected>::value));
 }
 
 int main()
@@ -22,12 +28,12 @@ int main()
     using boost::spirit::unused_type;
 
     unused_type unused_mut;
-    test<unused_type const&>(unused);
-    test<unused_type&>(unused_mut);
-    test<unused_type const&>(unused = 123);
-    test<unused_type const&>(unused = unused);
-    test<unused_type const&>(unused = unused_mut);
-    test<unused_type&>(unused_mut = 123);
-    test<unused_type&>(unused_mut = unused);
-    test<unused_type&>(unused_mut = unused_mut);
+    test<unused_type const>(unused);
+    test<unused_type>(unused_mut);
+    test<unused_type const>(unused = 123);
+    test<unused_type const>(unused = unused);
+    test<unused_type const>(unused = unused_mut);
+    test<unused_type>(unused_mut = 123);
+    test<unused_type>(unused_mut = unused);
+    test<unused_type>(unused_mut = unused_mut);
 }

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -118,6 +118,7 @@ run confix.cpp ;
 run repeat.cpp ;
 run seek.cpp ;
 
+run unused_type.cpp ;
 run attribute_type_check.cpp ;
 run fusion_map.cpp ;
 run x3_variant.cpp ;

--- a/test/x3/unused_type.cpp
+++ b/test/x3/unused_type.cpp
@@ -14,6 +14,8 @@ int main()
     using boost::spirit::x3::unused;
     using boost::spirit::x3::unused_type;
 
+    static_assert(std::is_trivial<unused_type>::value, "");
+
     unused_type unused_mut;
     static_assert(std::is_same<decltype((unused)), unused_type const&>::value, "");
     static_assert(std::is_same<decltype((unused_mut)), unused_type&>::value, "");

--- a/test/x3/unused_type.cpp
+++ b/test/x3/unused_type.cpp
@@ -1,0 +1,26 @@
+/*=============================================================================
+    Copyright (c) 2019 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/home/x3/support/unused.hpp>
+#include <type_traits>
+
+int main()
+{
+    using boost::spirit::x3::unused;
+    using boost::spirit::x3::unused_type;
+
+    unused_type unused_mut;
+    static_assert(std::is_same<decltype((unused)), unused_type const&>::value, "");
+    static_assert(std::is_same<decltype((unused_mut)), unused_type&>::value, "");
+    static_assert(std::is_same<decltype(unused = 123), unused_type const&>::value, "");
+    static_assert(std::is_same<decltype(unused = unused), unused_type const&>::value, "");
+    static_assert(std::is_same<decltype(unused = unused_mut), unused_type const&>::value, "");
+    static_assert(std::is_same<decltype(unused_mut = 123), unused_type&>::value, "");
+    static_assert(std::is_same<decltype(unused_mut = unused), unused_type&>::value, "");
+    static_assert(std::is_same<decltype(unused_mut = unused_mut), unused_type&>::value, "");
+}


### PR DESCRIPTION
Added basic tests and on C++11 made the type trivial and all operations with it constexpr.