### PR TITLE
X3: Fixed static assert on parse_rule instantiation

### DIFF
--- a/test/x3/rule_separate_tu.cpp
+++ b/test/x3/rule_separate_tu.cpp
@@ -10,13 +10,28 @@
 
 #include <boost/core/lightweight_test.hpp>
 
+#include "test.hpp"
+
 int main()
 {
-    char const* const s = "*", * const end = s + std::strlen(s);
+    using spirit_test::test;
+    using spirit_test::test_attr;
 
-    BOOST_TEST(parse(s, end, unused_attr::skipper));
-    BOOST_TEST(parse(s, end, unused_attr::grammar));
-    BOOST_TEST(phrase_parse(s, end, unused_attr::grammar, unused_attr::skipper));
+    {
+        BOOST_TEST(test("*", unused_attr::skipper));
+        BOOST_TEST(test("#", unused_attr::skipper2));
+        BOOST_TEST(test("==", unused_attr::grammar));
+        BOOST_TEST(test("*=*=", unused_attr::grammar, unused_attr::skipper));
+        BOOST_TEST(test("#=#=", unused_attr::grammar, unused_attr::skipper2));
+    }
+
+    {
+        int i;
+        BOOST_TEST(test_attr("123", used_attr::grammar, i));
+        BOOST_TEST_EQ(i, 123);
+        BOOST_TEST(test_attr(" 42", used_attr::grammar, i, used_attr::skipper));
+        BOOST_TEST_EQ(i, 42);
+    }
 
     return boost::report_errors();
 }

--- a/test/x3/rule_separate_tu_grammar.cpp
+++ b/test/x3/rule_separate_tu_grammar.cpp
@@ -17,8 +17,29 @@ const auto skipper_def = x3::lit('*');
 BOOST_SPIRIT_DEFINE(skipper)
 BOOST_SPIRIT_INSTANTIATE(skipper_type, char const*, x3::unused_type)
 
+const skipper2_type skipper2 = "skipper2";
+const auto skipper2_def = x3::lit('#');
+BOOST_SPIRIT_DEFINE(skipper2)
+BOOST_SPIRIT_INSTANTIATE(skipper2_type, char const*, x3::unused_type)
+
 const grammar_type grammar = "grammar";
 const auto grammar_def = *x3::lit('=');
+BOOST_SPIRIT_DEFINE(grammar)
+BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::unused_type)
+BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::phrase_parse_context<skipper_type>::type)
+BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::phrase_parse_context<skipper2_type>::type)
+
+}
+
+namespace used_attr {
+
+const skipper_type skipper = "skipper";
+const auto skipper_def = x3::space;
+BOOST_SPIRIT_DEFINE(skipper)
+BOOST_SPIRIT_INSTANTIATE(skipper_type, char const*, x3::unused_type)
+
+const grammar_type grammar = "grammar";
+const auto grammar_def = x3::int_;
 BOOST_SPIRIT_DEFINE(grammar)
 BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::unused_type)
 BOOST_SPIRIT_INSTANTIATE(grammar_type, char const*, x3::phrase_parse_context<skipper_type>::type)

--- a/test/x3/rule_separate_tu_grammar.hpp
+++ b/test/x3/rule_separate_tu_grammar.hpp
@@ -20,8 +20,29 @@ using skipper_type = x3::rule<class skipper_r>;
 extern const skipper_type skipper;
 BOOST_SPIRIT_DECLARE(skipper_type)
 
+// the `unused_type const` must have the same effect as no attribute
+using skipper2_type = x3::rule<class skipper2_r, x3::unused_type const>;
+extern const skipper2_type skipper2;
+BOOST_SPIRIT_DECLARE(skipper2_type)
+
 // grammar must has no attribute, checks `parse` and `phrase_parse`
 using grammar_type = x3::rule<class grammar_r>;
+extern const grammar_type grammar;
+BOOST_SPIRIT_DECLARE(grammar_type)
+
+}
+
+// Check instantiation when rule has an attribute.
+
+namespace used_attr {
+
+namespace x3 = boost::spirit::x3;
+
+using skipper_type = x3::rule<class skipper_r>;
+extern const skipper_type skipper;
+BOOST_SPIRIT_DECLARE(skipper_type)
+
+using grammar_type = x3::rule<class grammar_r, int>;
 extern const grammar_type grammar;
 BOOST_SPIRIT_DECLARE(grammar_type)
 


### PR DESCRIPTION
During overload resolution disallowed signature can be instantiated leading to firing the static assertation and overload resolution failure. I could just remove it, but do not want to leave unbounded by value overloads; replacing to not deducing Attribute with specifying a default parameter will not work because we want to allow `BOOST_SPIRIT_DECLARE` without prior `BOOST_SPIRIT_DEFINE` - this requires having default parameters in both declaration and definition and the standard seems to forbid it (GCC - fine, MSVC - warning, Clang - error).

Reverts #437, fixes #453.