### PR TITLE
X3: Perform attribute transformation before calling parse_rule

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -114,7 +114,17 @@ namespace boost { namespace spirit { namespace x3
             static_assert(has_attribute,
                 "The rule does not have an attribute. Check your parser.");
 
-            return parse_rule(*this, first, last, context, attr);
+            using transform = traits::transform_attribute<
+                Attribute_, attribute_type, parser_id>;
+
+            using transform_attr = typename transform::type;
+            transform_attr attr_ = transform::pre(attr);
+
+            if (parse_rule(*this, first, last, context, attr_)) {
+                transform::post(attr, std::forward<transform_attr>(attr_));
+                return true;
+            }
+            return false;
         }
 
         template <typename Iterator, typename Context>

--- a/test/x3/rule3.cpp
+++ b/test/x3/rule3.cpp
@@ -38,6 +38,19 @@ struct stationary : boost::noncopyable
 };
 
 
+namespace check_stationary {
+
+boost::spirit::x3::rule<class a_r, stationary> const a;
+boost::spirit::x3::rule<class b_r, stationary> const b;
+
+auto const a_def = '{' >> boost::spirit::x3::int_ >> '}';
+auto const b_def = a;
+
+BOOST_SPIRIT_DEFINE(a, b)
+
+}
+
+
 int main()
 {
     using spirit_test::test_attr;
@@ -46,7 +59,6 @@ int main()
     using namespace boost::spirit::x3::ascii;
     using boost::spirit::x3::rule;
     using boost::spirit::x3::lit;
-    using boost::spirit::x3::int_;
     using boost::spirit::x3::eps;
     using boost::spirit::x3::unused_type;
 
@@ -91,11 +103,8 @@ int main()
     }
 
     { // ensure no unneded synthesization, copying and moving occured
-        auto a = rule<class a_r, stationary>{} = '{' >> int_ >> '}';
-        auto b = rule<class b_r, stationary>{} = a;
-
         stationary st { 0 };
-        BOOST_TEST(test_attr("{42}", b, st));
+        BOOST_TEST(test_attr("{42}", check_stationary::b, st));
         BOOST_TEST_EQ(st.val, 42);
     }
 

--- a/test/x3/rule_separate_tu.cpp
+++ b/test/x3/rule_separate_tu.cpp
@@ -26,7 +26,9 @@ int main()
     }
 
     {
-        int i;
+        long i;
+        static_assert(!std::is_same<decltype(i), used_attr::grammar_type::attribute_type>::value,
+            "ensure we have instantiated the rule with a different attribute type");
         BOOST_TEST(test_attr("123", used_attr::grammar, i));
         BOOST_TEST_EQ(i, 123);
         BOOST_TEST(test_attr(" 42", used_attr::grammar, i, used_attr::skipper));


### PR DESCRIPTION
This will deal with linking problems when rule attribute type is not the same
as the actual attribute type. It will not harm anyone as the transformation
after parse_rule will just pass-through the attribute because it will be the
same there. It will also do not alter rule_definition parsing so other usages
are still valid.

Refs #454, supersedes #347.