### PR TITLE
X3: parse_rule attribute must always be of rule::attribute_type&

### DIFF
--- a/doc/x3/tutorial/minimal.qbk
+++ b/doc/x3/tutorial/minimal.qbk
@@ -90,11 +90,11 @@ happening is that we are declaring a `parse_rule` function in the client
 namespace. For example, given a rule named `my_rule`,
 `BOOST_SPIRIT_DECLARE(my_rule)` expands to this code:
 
-    template <typename Iterator, typename Context, typename Attribute>
+    template <typename Iterator, typename Context>
     bool parse_rule(
         decltype(my_rule)
       , Iterator& first, Iterator const& last
-      , Context const& context, Attribute& attr);
+      , Context const& context, decltype(my_rule)::attribute_type& attr);
 
 If you went back and reviewed [link __tutorial_spirit_define__
 BOOST_SPIRIT_DEFINE], you'll see why it is exactly what we need to use for

--- a/doc/x3/tutorial/roman.qbk
+++ b/doc/x3/tutorial/roman.qbk
@@ -172,11 +172,11 @@ function in the client namespace that tells X3 how to invoke the rule. For examp
 given a rule named `my_rule` and a corresponding definition named `my_rule_def`,
 `BOOST_SPIRIT_DEFINE(my_rule)` expands to this code:
 
-    template <typename Iterator, typename Context, typename Attribute>
+    template <typename Iterator, typename Context>
     inline bool parse_rule(
         decltype(my_rule)
       , Iterator& first, Iterator const& last
-      , Context const& context, Attribute& attr)
+      , Context const& context, decltype(my_rule)::attribute_type& attr)
     {
         using boost::spirit::x3::unused;
         static auto const def_ = my_rule_def;

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -166,11 +166,11 @@ namespace boost { namespace spirit { namespace x3
     };
 
 #define BOOST_SPIRIT_DECLARE_(r, data, rule_type)                               \
-    template <typename Iterator, typename Context, typename Attribute>          \
+    template <typename Iterator, typename Context>                              \
     bool parse_rule(                                                            \
         rule_type rule_                                                         \
       , Iterator& first, Iterator const& last                                   \
-      , Context const& context, Attribute& attr);                               \
+      , Context const& context, rule_type::attribute_type& attr);               \
     /***/
 
 #define BOOST_SPIRIT_DECLARE(...) BOOST_PP_SEQ_FOR_EACH(                        \
@@ -180,11 +180,11 @@ namespace boost { namespace spirit { namespace x3
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
     using BOOST_PP_CAT(rule_name, _synonym) = decltype(rule_name);              \
-    template <typename Iterator, typename Context, typename Attribute>          \
+    template <typename Iterator, typename Context>                              \
     inline bool parse_rule(                                                     \
         BOOST_PP_CAT(rule_name, _synonym) /* rule_ */                           \
       , Iterator& first, Iterator const& last                                   \
-      , Context const& context, Attribute& attr)                                \
+      , Context const& context, BOOST_PP_CAT(rule_name, _synonym)::attribute_type& attr) \
     {                                                                           \
         using boost::spirit::x3::unused;                                        \
         static auto const def_ = (rule_name = BOOST_PP_CAT(rule_name, _def));   \
@@ -193,11 +193,11 @@ namespace boost { namespace spirit { namespace x3
     /***/
 #else
 #define BOOST_SPIRIT_DEFINE_(r, data, rule_name)                                \
-    template <typename Iterator, typename Context, typename Attribute>          \
+    template <typename Iterator, typename Context>                              \
     inline bool parse_rule(                                                     \
         decltype(rule_name) /* rule_ */                                         \
       , Iterator& first, Iterator const& last                                   \
-      , Context const& context, Attribute& attr)                                \
+      , Context const& context, decltype(rule_name)::attribute_type& attr)      \
     {                                                                           \
         using boost::spirit::x3::unused;                                        \
         static auto const def_ = (rule_name = BOOST_PP_CAT(rule_name, _def));   \
@@ -211,7 +211,7 @@ namespace boost { namespace spirit { namespace x3
     /***/
 
 #define BOOST_SPIRIT_INSTANTIATE(rule_type, Iterator, Context)                  \
-    template bool parse_rule<Iterator, Context, rule_type::attribute_type>(     \
+    template bool parse_rule<Iterator, Context>(                                \
         rule_type rule_                                                         \
       , Iterator& first, Iterator const& last                                   \
       , Context const& context, rule_type::attribute_type&);                    \


### PR DESCRIPTION
After #456 `parse_rule` is always called with value of `rule::attribute_type&`
type. By removing attribute type deduction we also will turn any possible bug
in `transform_attribute` from a linkage to compile error.

Fixes #454