### PR TITLE
Remove broken 1.0#INF parser

### DIFF
--- a/doc/qi/numeric.qbk
+++ b/doc/qi/numeric.qbk
@@ -682,10 +682,6 @@ imposed by custom policies.
                                             [Negate `n` if `b` is `true`. Default implementation
                                             is provided for `float`, `double` and `long double`.]]
 
-    [[`boost::spirit::traits::is_equal_to_one(n)`]
-                                            [Return `true` if `n` is equal to `1.0`. Default implementation
-                                            is provided for `float`, `double` and `long double`.]]
-
 ]
 
 [note The additional spirit real number traits above are provided to
@@ -716,7 +712,7 @@ corresponds to the following grammar:
         ;
 
     nan
-        =   -lit("1.0#") >> no_case["nan"]
+        =   no_case["nan"]
             >> -('(' >> *(char_ - ')') >> ')')
         ;
 
@@ -791,20 +787,9 @@ For models of `RealPolicies` the following expressions must be valid:
                                             If successful, place the result into `n`.]]
 ]
 
-The `parse_nan` and `parse_inf` functions get called whenever:
-
-[:a number to parse does not start with a digit (after having
-successfully parsed an optional sign)]
-
-or
-
-[:after a real number of the value 1 (having no exponential
-part and a fractional part value of 0) has been parsed.]
-
-The first call recognizes representations of NaN or Inf starting with a
-non-digit character (such as NaN, Inf, QNaN etc.). The second call
-recognizes representation formats starting with a `1.0` (such as
-`"1.0#NAN"` or `"1.0#INF"` etc.).
+The `parse_nan` and `parse_inf` functions get called whenever
+a number to parse does not start with a digit (after having
+successfully parsed an optional sign).
 
 The functions should return true if a Nan or Inf has been found. In this
 case the attribute `n` should be set to the matched value (NaN or Inf).

--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -151,20 +151,6 @@ namespace boost { namespace spirit { namespace traits
     }
 
     template <typename T>
-    inline bool
-    is_equal_to_one(T const& value)
-    {
-        return value == 1.0;
-    }
-
-    inline bool
-    is_equal_to_one(unused_type)
-    {
-        // no-op for unused_type
-        return false;
-    }
-
-    template <typename T>
     struct real_accumulator : mpl::identity<T> {};
 
     template <>
@@ -296,22 +282,6 @@ namespace boost { namespace spirit { namespace qi  { namespace detail
                 // No exponent found. Scale the number by -frac_digits.
                 bool r = traits::scale(-frac_digits, n, acc_n);
                 BOOST_VERIFY(r);
-            }
-            else if (traits::is_equal_to_one(acc_n))
-            {
-                // There is a chance of having to parse one of the 1.0#...
-                // styles some implementations use for representing NaN or Inf.
-
-                // Check whether the number to parse is a NaN or Inf
-                if (p.parse_nan(first, last, n) ||
-                    p.parse_inf(first, last, n))
-                {
-                    // If we got a negative sign, negate the number
-                    traits::assign_to(traits::negate(neg, n), attr);
-                    return true;    // got a NaN or Inf, return immediately
-                }
-
-                n = static_cast<T>(acc_n);
             }
             else
             {

--- a/include/boost/spirit/home/qi/numeric/real_policies.hpp
+++ b/include/boost/spirit/home/qi/numeric/real_policies.hpp
@@ -89,22 +89,9 @@ namespace boost { namespace spirit { namespace qi
         }
 
         ///////////////////////////////////////////////////////////////////////
-        //  The parse_nan() and parse_inf() functions get called whenever:
-        //
-        //    - a number to parse does not start with a digit (after having
-        //      successfully parsed an optional sign)
-        //
-        //  or
-        //
-        //    - after a floating point number of the value 1 (having no
-        //      exponential part and a fractional part value of 0) has been
-        //      parsed.
-        //
-        //  The first call allows to recognize representations of NaN or Inf
-        //  starting with a non-digit character (such as NaN, Inf, QNaN etc.).
-        //
-        //  The second call allows to recognize representation formats starting
-        //  with a 1.0 (such as 1.0#NAN or 1.0#INF etc.).
+        //  The parse_nan() and parse_inf() functions get called whenever
+        //  a number to parse does not start with a digit (after having
+        //  successfully parsed an optional sign).
         //
         //  The functions should return true if a Nan or Inf has been found. In
         //  this case the attr should be set to the matched value (NaN or

--- a/include/boost/spirit/home/x3/numeric/real_policies.hpp
+++ b/include/boost/spirit/home/x3/numeric/real_policies.hpp
@@ -73,22 +73,9 @@ namespace boost { namespace spirit { namespace x3
         }
 
         ///////////////////////////////////////////////////////////////////////
-        //  The parse_nan() and parse_inf() functions get called whenever:
-        //
-        //    - a number to parse does not start with a digit (after having
-        //      successfully parsed an optional sign)
-        //
-        //  or
-        //
-        //    - after a floating point number of the value 1 (having no
-        //      exponential part and a fractional part value of 0) has been
-        //      parsed.
-        //
-        //  The first call allows to recognize representations of NaN or Inf
-        //  starting with a non-digit character (such as NaN, Inf, QNaN etc.).
-        //
-        //  The second call allows to recognize representation formats starting
-        //  with a 1.0 (such as 1.0#NAN or 1.0#INF etc.).
+        //  The parse_nan() and parse_inf() functions get called whenever
+        //  a number to parse does not start with a digit (after having
+        //  successfully parsed an optional sign).
         //
         //  The functions should return true if a Nan or Inf has been found. In
         //  this case the attr should be set to the matched value (NaN or

--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -103,20 +103,6 @@ namespace boost { namespace spirit { namespace x3 { namespace extension
         // no-op for unused_type
         return n;
     }
-
-    template <typename T>
-    inline bool
-    is_equal_to_one(T const& value)
-    {
-        return value == 1.0;
-    }
-
-    inline bool
-    is_equal_to_one(unused_type)
-    {
-        // no-op for unused_type
-        return false;
-    }
 }}}}
 
 namespace boost { namespace spirit { namespace x3
@@ -235,20 +221,6 @@ namespace boost { namespace spirit { namespace x3
             {
                 // No exponent found. Scale the number by -frac_digits.
                 extension::scale(-frac_digits, n);
-            }
-            else if (extension::is_equal_to_one(n))
-            {
-                // There is a chance of having to parse one of the 1.0#...
-                // styles some implementations use for representing NaN or Inf.
-
-                // Check whether the number to parse is a NaN or Inf
-                if (p.parse_nan(first, last, n) ||
-                    p.parse_inf(first, last, n))
-                {
-                    // If we got a negative sign, negate the number
-                    traits::move_to(extension::negate(neg, n), attr);
-                    return true;    // got a NaN or Inf, return immediately
-                }
             }
 
             // If we got a negative sign, negate the number

--- a/test/qi/real.hpp
+++ b/test/qi/real.hpp
@@ -114,8 +114,6 @@ struct custom_real
     custom_real(double n_) : n(n_) {}
     friend bool operator==(custom_real a, custom_real b) 
         { return a.n == b.n; }
-    friend bool operator==(custom_real a, double b) 
-        { return a.n == b; }
     friend custom_real operator*(custom_real a, custom_real b) 
         { return custom_real(a.n * b.n); }
     friend custom_real operator+(custom_real a, custom_real b) 

--- a/test/x3/real.hpp
+++ b/test/x3/real.hpp
@@ -111,8 +111,6 @@ struct custom_real
     custom_real(double n_) : n(n_) {}
     friend bool operator==(custom_real a, custom_real b)
         { return a.n == b.n; }
-    friend bool operator==(custom_real a, double b)
-        { return a.n == b; }
     friend custom_real operator*(custom_real a, custom_real b)
         { return custom_real(a.n * b.n); }
     friend custom_real operator+(custom_real a, custom_real b)


### PR DESCRIPTION
It was poorly documented and never worked correctly. None of atof, strtof, and
input streams are accepting such values. Fixing it would be a bigger breaking
change than removing it.

Fixes #415, addresses #163 and https://svn.boost.org/trac10/ticket/8699