### PR TITLE
V2: Merge make_attribute into transform_attribute

### DIFF
--- a/include/boost/spirit/home/karma/action/action.hpp
+++ b/include/boost/spirit/home/karma/action/action.hpp
@@ -22,6 +22,7 @@
 #include <boost/spirit/home/karma/meta_compiler.hpp>
 #include <boost/spirit/home/karma/generator.hpp>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -53,16 +54,17 @@ namespace boost { namespace spirit { namespace karma
           , Attribute const& attr_) const
         {
             typedef typename attribute<Context, unused_type>::type attr_type;
-            typedef traits::make_attribute<attr_type, Attribute> make_attribute;
 
             // create a attribute if none is supplied
             // this creates a _copy_ of the attribute because the semantic
             // action will likely change parts of this
             typedef traits::transform_attribute<
-                typename make_attribute::type, attr_type, domain> transform;
+                Attribute const, attr_type, domain> transform;
 
-            typename transform::type attr = 
-                traits::pre_transform<domain, attr_type>(make_attribute::call(attr_));
+            boost::ignore_unused<transform>();
+
+            attr_type attr = 
+                traits::pre_transform<domain, attr_type>(attr_);
 
             // call the function, passing the attribute, the context and a bool 
             // flag that the client can set to false to fail generating.

--- a/include/boost/spirit/home/karma/detail/attributes.hpp
+++ b/include/boost/spirit/home/karma/detail/attributes.hpp
@@ -74,16 +74,6 @@ namespace boost { namespace spirit { namespace karma
     {};
 
     template <typename Attribute>
-    struct transform_attribute<unused_type, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type const, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
     struct transform_attribute<Attribute, unused_type>
       : transform_attribute<unused_type, unused_type>
     {};

--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -286,15 +286,12 @@ namespace boost { namespace spirit { namespace karma
             if (f)
             {
                 // Create an attribute if none is supplied.
-                typedef traits::make_attribute<attr_type, Attribute>
-                    make_attribute;
                 typedef traits::transform_attribute<
-                    typename make_attribute::type, attr_type, domain>
+                    Attribute const, attr_type, domain>
                 transform;
 
                 typename transform::type attr_ =
-                    traits::pre_transform<domain, attr_type>(
-                        make_attribute::call(attr));
+                    traits::pre_transform<domain, attr_type>(attr);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited
@@ -326,15 +323,12 @@ namespace boost { namespace spirit { namespace karma
             if (f)
             {
                 // Create an attribute if none is supplied.
-                typedef traits::make_attribute<attr_type, Attribute>
-                    make_attribute;
                 typedef traits::transform_attribute<
-                    typename make_attribute::type, attr_type, domain>
+                    Attribute const, attr_type, domain>
                 transform;
 
                 typename transform::type attr_ =
-                    traits::pre_transform<domain, attr_type>(
-                        make_attribute::call(attr));
+                    traits::pre_transform<domain, attr_type>(attr);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited

--- a/include/boost/spirit/home/qi/action/action.hpp
+++ b/include/boost/spirit/home/qi/action/action.hpp
@@ -52,14 +52,12 @@ namespace boost { namespace spirit { namespace qi
           , Attribute& attr_) const
         {
             typedef typename attribute<Context, Iterator>::type attr_type;
-            typedef traits::make_attribute<attr_type, Attribute> make_attribute;
 
             // create an attribute if one is not supplied
             typedef traits::transform_attribute<
-                typename make_attribute::type, attr_type, domain> transform;
+                Attribute, attr_type, domain> transform;
 
-            typename make_attribute::type made_attr = make_attribute::call(attr_);
-            typename transform::type attr = transform::pre(made_attr);
+            typename transform::type attr = transform::pre(attr_);
 
             Iterator save = first;
             if (subject.parse(first, last, context, skipper, attr))
@@ -109,14 +107,9 @@ namespace boost { namespace spirit { namespace qi
           , unused_type) const
         {
             typedef typename attribute<Context, Iterator>::type attr_type;
-            typedef traits::make_attribute<attr_type, unused_type> make_attribute;
 
             // synthesize the attribute since one is not supplied
-            typedef traits::transform_attribute<
-                typename make_attribute::type, attr_type, domain> transform;
-
-            typename make_attribute::type made_attr = make_attribute::call(unused_type());
-            typename transform::type attr = transform::pre(made_attr);
+            attr_type attr = attr_type();
 
             Iterator save = first;
             if (subject.parse(first, last, context, skipper, attr))

--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -120,16 +120,6 @@ namespace boost { namespace spirit { namespace qi
     {};
 
     template <typename Attribute>
-    struct transform_attribute<unused_type, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<unused_type const, Attribute>
-      : transform_attribute<unused_type, unused_type>
-    {};
-
-    template <typename Attribute>
     struct transform_attribute<Attribute, unused_type>
       : transform_attribute<unused_type, unused_type>
     {};

--- a/include/boost/spirit/home/qi/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/qi/nonterminal/rule.hpp
@@ -291,16 +291,13 @@ namespace boost { namespace spirit { namespace qi
                 if (is_same<skipper_type, unused_type>::value)
                     qi::skip_over(first, last, skipper);
 
-                typedef traits::make_attribute<attr_type, Attribute> make_attribute;
-
                 // do down-stream transformation, provides attribute for
                 // rhs parser
                 typedef traits::transform_attribute<
-                    typename make_attribute::type, attr_type, domain>
+                    Attribute, attr_type, domain>
                 transform;
 
-                typename make_attribute::type made_attr = make_attribute::call(attr_param);
-                typename transform::type attr_ = transform::pre(made_attr);
+                typename transform::type attr_ = transform::pre(attr_param);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited
@@ -345,16 +342,13 @@ namespace boost { namespace spirit { namespace qi
                 if (is_same<skipper_type, unused_type>::value)
                     qi::skip_over(first, last, skipper);
 
-                typedef traits::make_attribute<attr_type, Attribute> make_attribute;
-
                 // do down-stream transformation, provides attribute for
                 // rhs parser
                 typedef traits::transform_attribute<
-                    typename make_attribute::type, attr_type, domain>
+                    Attribute, attr_type, domain>
                 transform;
 
-                typename make_attribute::type made_attr = make_attribute::call(attr_param);
-                typename transform::type attr_ = transform::pre(made_attr);
+                typename transform::type attr_ = transform::pre(attr_param);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited

--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -168,16 +168,12 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 >
             context_type;
 
-            // Create an attribute if none is supplied.
-            typedef traits::make_attribute<subrule_attr_type, Attribute> 
-                make_attribute;
-
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,
             // without passing values for them.
             context_type context(*this
               , traits::pre_transform<spirit::karma::domain, subrule_attr_type>(
-                      make_attribute::call(attr)));
+                      attr));
 
             return def.binder(sink, context, delimiter);
         }
@@ -203,16 +199,12 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 >
             context_type;
 
-            // Create an attribute if none is supplied.
-            typedef traits::make_attribute<subrule_attr_type, Attribute> 
-                make_attribute;
-
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,
             // passing values of incompatible types for them.
             context_type context(*this
               , traits::pre_transform<spirit::karma::domain, subrule_attr_type>(
-                        make_attribute::call(attr)), params, caller_context);
+                        attr), params, caller_context);
 
             return def.binder(sink, context, delimiter);
         }

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -171,18 +171,13 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 >
             context_type;
 
-            // prepare attribute
-            typedef traits::make_attribute<
-                subrule_attr_type, Attribute> make_attribute;
-
             // do down-stream transformation, provides attribute for 
             // rhs parser
             typedef traits::transform_attribute<
-                typename make_attribute::type, subrule_attr_type, spirit::qi::domain> 
+                Attribute, subrule_attr_type, spirit::qi::domain> 
             transform;
 
-            typename make_attribute::type made_attr = make_attribute::call(attr);
-            typename transform::type attr_ = transform::pre(made_attr);
+            typename transform::type attr_ = transform::pre(attr);
 
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,
@@ -225,18 +220,13 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                 >
             context_type;
 
-            // prepare attribute
-            typedef traits::make_attribute<
-                subrule_attr_type, Attribute> make_attribute;
-
             // do down-stream transformation, provides attribute for 
             // rhs parser
             typedef traits::transform_attribute<
-                typename make_attribute::type, subrule_attr_type, spirit::qi::domain> 
+                Attribute, subrule_attr_type, spirit::qi::domain> 
             transform;
 
-            typename make_attribute::type made_attr = make_attribute::call(attr);
-            typename transform::type attr_ = transform::pre(made_attr);
+            typename transform::type attr_ = transform::pre(attr);
 
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,


### PR DESCRIPTION
This will allow to simplify transform_attribute (e.g. no need to handle
references anymore) and to ensure the pre/post/fail calls are made to the
same transformation.

That's what I mentioned in https://github.com/boostorg/spirit/pull/460#issuecomment-462967855