### PR TITLE
V2: Use pre/post/fail functions directly from the transform

### DIFF
--- a/include/boost/spirit/home/karma/action/action.hpp
+++ b/include/boost/spirit/home/karma/action/action.hpp
@@ -22,7 +22,6 @@
 #include <boost/spirit/home/karma/meta_compiler.hpp>
 #include <boost/spirit/home/karma/generator.hpp>
 
-#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -61,10 +60,7 @@ namespace boost { namespace spirit { namespace karma
             typedef traits::transform_attribute<
                 Attribute const, attr_type, domain> transform;
 
-            boost::ignore_unused<transform>();
-
-            attr_type attr = 
-                traits::pre_transform<domain, attr_type>(attr_);
+            attr_type attr = transform::pre(attr_);
 
             // call the function, passing the attribute, the context and a bool 
             // flag that the client can set to false to fail generating.

--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -290,8 +290,7 @@ namespace boost { namespace spirit { namespace karma
                     Attribute const, attr_type, domain>
                 transform;
 
-                typename transform::type attr_ =
-                    traits::pre_transform<domain, attr_type>(attr);
+                typename transform::type attr_ = transform::pre(attr);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited
@@ -327,8 +326,7 @@ namespace boost { namespace spirit { namespace karma
                     Attribute const, attr_type, domain>
                 transform;
 
-                typename transform::type attr_ =
-                    traits::pre_transform<domain, attr_type>(attr);
+                typename transform::type attr_ = transform::pre(attr);
 
                 // If you are seeing a compilation error here, you are probably
                 // trying to use a rule or a grammar which has inherited

--- a/include/boost/spirit/home/qi/action/action.hpp
+++ b/include/boost/spirit/home/qi/action/action.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace spirit { namespace qi
                 {
                     // Do up-stream transformation, this integrates the results
                     // back into the original attribute value, if appropriate.
-                    traits::post_transform(attr_, attr);
+                    transform::post(attr_, attr);
                     return true;
                 }
 

--- a/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
+++ b/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
@@ -101,7 +101,7 @@ namespace boost { namespace spirit { namespace qi
 
             // do up-stream transformation, this mainly integrates the results
             // back into the original attribute value, if appropriate
-            traits::post_transform(attr_param, attr_);
+            transform::post(attr_param, attr_);
             return true;
         }
 

--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -149,20 +149,6 @@ namespace boost { namespace spirit { namespace traits
     struct transform_attribute<Attribute&, Attribute, qi::domain>
       : qi::transform_attribute<Attribute&, Attribute>
     {};
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Exposed, typename Transformed>
-    void post_transform(Exposed& dest, Transformed const& attr)
-    {
-        return transform_attribute<Exposed, Transformed, qi::domain>::post(dest, attr);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Exposed, typename Transformed>
-    void fail_transform(Exposed& dest, Transformed const&)
-    {
-        return transform_attribute<Exposed, Transformed, qi::domain>::fail(dest);
-    }
 }}}
 
 #endif

--- a/include/boost/spirit/home/qi/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/qi/nonterminal/rule.hpp
@@ -312,12 +312,12 @@ namespace boost { namespace spirit { namespace qi
                 {
                     // do up-stream transformation, this integrates the results
                     // back into the original attribute value, if appropriate
-                    traits::post_transform(attr_param, attr_);
+                    transform::post(attr_param, attr_);
                     return true;
                 }
 
                 // inform attribute transformation of failed rhs
-                traits::fail_transform(attr_param, attr_);
+                transform::fail(attr_param);
             }
             return false;
         }
@@ -363,12 +363,12 @@ namespace boost { namespace spirit { namespace qi
                 {
                     // do up-stream transformation, this integrates the results
                     // back into the original attribute value, if appropriate
-                    traits::post_transform(attr_param, attr_);
+                    transform::post(attr_param, attr_);
                     return true;
                 }
 
                 // inform attribute transformation of failed rhs
-                traits::fail_transform(attr_param, attr_);
+                transform::fail(attr_param);
             }
             return false;
         }

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -969,21 +969,6 @@ namespace boost { namespace spirit { namespace traits
     {};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Domain, typename Transformed, typename Exposed>
-    typename spirit::result_of::pre_transform<Exposed, Transformed, Domain>::type
-    pre_transform(Exposed& attr BOOST_PROTO_DISABLE_IF_IS_CONST(Exposed))
-    {
-        return transform_attribute<Exposed, Transformed, Domain>::pre(attr);
-    }
-
-    template <typename Domain, typename Transformed, typename Exposed>
-    typename spirit::result_of::pre_transform<Exposed const, Transformed, Domain>::type
-    pre_transform(Exposed const& attr)
-    {
-        return transform_attribute<Exposed const, Transformed, Domain>::pre(attr);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // swap_impl
     //
     // Swap (with proper handling of unused_types)
@@ -1348,15 +1333,5 @@ namespace boost { namespace spirit { namespace traits
         token_printer_debug<T>::print(out, val);
     }
 }}}
-
-///////////////////////////////////////////////////////////////////////////////
-namespace boost { namespace spirit { namespace result_of
-{
-    template <typename Exposed, typename Transformed, typename Domain>
-    struct pre_transform
-      : traits::transform_attribute<Exposed, Transformed, Domain>
-    {};
-}}}
-
 
 #endif

--- a/include/boost/spirit/home/support/attributes_fwd.hpp
+++ b/include/boost/spirit/home/support/attributes_fwd.hpp
@@ -30,9 +30,6 @@ namespace boost { namespace spirit { namespace result_of
     template <typename T, typename Attribute>
     struct attribute_as;
 
-    template <typename Exposed, typename Transformed, typename Domain>
-    struct pre_transform;
-
     template <typename T>
     struct optional_value;
 

--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -168,12 +168,13 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 >
             context_type;
 
+            typedef traits::transform_attribute<Attribute const
+              , subrule_attr_type, spirit::karma::domain> transform;
+
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,
             // without passing values for them.
-            context_type context(*this
-              , traits::pre_transform<spirit::karma::domain, subrule_attr_type>(
-                      attr));
+            context_type context(*this, transform::pre(attr));
 
             return def.binder(sink, context, delimiter);
         }
@@ -199,12 +200,14 @@ namespace boost { namespace spirit { namespace repository { namespace karma
                 >
             context_type;
 
+            typedef traits::transform_attribute<Attribute const
+              , subrule_attr_type, spirit::karma::domain> transform;
+
             // If you are seeing a compilation error here, you are probably
             // trying to use a subrule which has inherited attributes,
             // passing values of incompatible types for them.
             context_type context(*this
-              , traits::pre_transform<spirit::karma::domain, subrule_attr_type>(
-                        attr), params, caller_context);
+              , transform::pre(attr), params, caller_context);
 
             return def.binder(sink, context, delimiter);
         }

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -188,12 +188,12 @@ namespace boost { namespace spirit { namespace repository { namespace qi
             {
                 // do up-stream transformation, this integrates the results 
                 // back into the original attribute value, if appropriate
-                traits::post_transform(attr, attr_);
+                transform::post(attr, attr_);
                 return true;
             }
 
             // inform attribute transformation of failed rhs
-            traits::fail_transform(attr, attr_);
+            transform::fail(attr);
             return false;
         }
 
@@ -237,12 +237,12 @@ namespace boost { namespace spirit { namespace repository { namespace qi
             {
                 // do up-stream transformation, this integrates the results 
                 // back into the original attribute value, if appropriate
-                traits::post_transform(attr, attr_);
+                transform::post(attr, attr_);
                 return true;
             }
 
             // inform attribute transformation of failed rhs
-            traits::fail_transform(attr, attr_);
+            transform::fail(attr);
             return false;
         }
 


### PR DESCRIPTION
This will ensure that the same transformation is used for all operations.

Followup to #464