### PR TITLE
extract_uint: Fixed IgnoreOverflowDigits=true problem at overflow

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -154,14 +154,14 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             if (n > val)
                 return false;
 
-            n *= Radix;
+            T tmp = n * Radix;
 
             // Ensure n += digit will not overflow
             const int digit = radix_traits<Radix>::digit(ch);
-            if (n > max - digit)
+            if (tmp > max - digit)
                 return false;
 
-            n += static_cast<T>(digit);
+            n = tmp + static_cast<T>(digit);
             return true;
         }
     };
@@ -186,14 +186,14 @@ namespace boost { namespace spirit { namespace qi { namespace detail
             if (n < val)
                 return false;
 
-            n *= Radix;
+            T tmp = n * Radix;
 
             // Ensure n -= digit will not underflow
             int const digit = radix_traits<Radix>::digit(ch);
-            if (n < min + digit)
+            if (tmp < min + digit)
                 return false;
 
-            n -= static_cast<T>(digit);
+            n = tmp - static_cast<T>(digit);
             return true;
         }
     };

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -152,14 +152,14 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             if (n > val)
                 return false;
 
-            n *= Radix;
+            T tmp = n * Radix;
 
             // Ensure n += digit will not overflow
             const int digit = radix_traits<Radix>::digit(ch);
-            if (n > max - digit)
+            if (tmp > max - digit)
                 return false;
 
-            n += static_cast<T>(digit);
+            n = tmp + static_cast<T>(digit);
             return true;
         }
     };
@@ -183,14 +183,14 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             if (n < val)
                 return false;
 
-            n *= Radix;
+            T tmp = n * Radix;
 
             // Ensure n -= digit will not underflow
             int const digit = radix_traits<Radix>::digit(ch);
-            if (n < min + digit)
+            if (tmp < min + digit)
                 return false;
 
-            n -= static_cast<T>(digit);
+            n = tmp - static_cast<T>(digit);
             return true;
         }
     };


### PR DESCRIPTION
The IgnoreOverflowDigits=true parser always succeeds and because of that it
expects from the digits parser that a number passed as inout argument will be
changed only on success.

Changed negative_accumulator and X3 for consistency.

Fixes #428