### PR TITLE
Hexencode extended ASCII

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ before_install:
     toolset.flags clang-linux.compile OPTIONS <known-warnings>suppress :
         -Wno-unused-command-line-argument # Sometimes it barks on -I and -stdlib
         -Wno-nested-anon-types # Boost.Random
-        -Wno-uninitialized -Wno-invalid-source-encoding : unchecked ;
+        -Wno-uninitialized : unchecked ;
 
   - |
     # Determining the root branch

--- a/test/karma/case_handling1.cpp
+++ b/test/karma/case_handling1.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/detail/workaround.hpp>

--- a/test/karma/case_handling2.cpp
+++ b/test/karma/case_handling2.cpp
@@ -102,11 +102,11 @@ main()
     {
         using namespace boost::spirit::iso8859_1;
 
-        BOOST_TEST(test("ää", lower["Ää"]));
-        BOOST_TEST(test("ää", lower["Ää"]));
+        BOOST_TEST(test("\xE4\xE4", lower["\xC4\xE4"]));
+        BOOST_TEST(test("\xE4\xE4", lower["\xC4\xE4"]));
 
-        BOOST_TEST(test("ÄÄ", upper["Ää"]));
-        BOOST_TEST(test("ÄÄ", upper["Ää"]));
+        BOOST_TEST(test("\xC4\xC4", upper["\xC4\xE4"]));
+        BOOST_TEST(test("\xC4\xC4", upper["\xC4\xE4"]));
     }
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/karma/case_handling2.cpp
+++ b/test/karma/case_handling2.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/detail/workaround.hpp>
@@ -95,11 +92,7 @@ main()
         BOOST_TEST(test(L"\t", upper[upper[space]], L'\t'));
     }
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
-    {
+    { // test extended ASCII characters
         using namespace boost::spirit::iso8859_1;
 
         BOOST_TEST(test("\xE4\xE4", lower["\xC4\xE4"]));
@@ -108,9 +101,6 @@ main()
         BOOST_TEST(test("\xC4\xC4", upper["\xC4\xE4"]));
         BOOST_TEST(test("\xC4\xC4", upper["\xC4\xE4"]));
     }
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     {
         using namespace boost::spirit::ascii;

--- a/test/karma/case_handling3.cpp
+++ b/test/karma/case_handling3.cpp
@@ -32,11 +32,11 @@ main()
     {
         using namespace boost::spirit::iso8859_1;
 
-        BOOST_TEST(test("ä", lower['Ä']));
-        BOOST_TEST(test("ä", lower['ä']));
+        BOOST_TEST(test("\xE4", lower['\xC4']));
+        BOOST_TEST(test("\xE4", lower['\xE4']));
 
-        BOOST_TEST(test("Ä", upper['Ä']));
-        BOOST_TEST(test("Ä", upper['ä']));
+        BOOST_TEST(test("\xC4", upper['\xC4']));
+        BOOST_TEST(test("\xC4", upper['\xE4']));
     }
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/karma/case_handling3.cpp
+++ b/test/karma/case_handling3.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/detail/workaround.hpp>
@@ -25,11 +22,7 @@ main()
 {
     using namespace boost::spirit;
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
-    {
+    { // test extended ASCII characters
         using namespace boost::spirit::iso8859_1;
 
         BOOST_TEST(test("\xE4", lower['\xC4']));
@@ -38,9 +31,6 @@ main()
         BOOST_TEST(test("\xC4", upper['\xC4']));
         BOOST_TEST(test("\xC4", upper['\xE4']));
     }
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     {
         using namespace boost::spirit::ascii;

--- a/test/karma/char_class.cpp
+++ b/test/karma/char_class.cpp
@@ -144,9 +144,9 @@ int main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha, 'é'));
-        BOOST_TEST(test("é", lower, 'é'));
-        BOOST_TEST(!test("", upper, 'é'));
+        BOOST_TEST(test("\xE9", alpha, '\xE9'));
+        BOOST_TEST(test("\xE9", lower, '\xE9'));
+        BOOST_TEST(!test("", upper, '\xE9'));
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")
 #endif

--- a/test/karma/char_class.cpp
+++ b/test/karma/char_class.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -140,16 +137,10 @@ int main()
         BOOST_TEST(!test("", xdigit, 'g'));
 
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
+        // test extended ASCII characters
         BOOST_TEST(test("\xE9", alpha, '\xE9'));
         BOOST_TEST(test("\xE9", lower, '\xE9'));
         BOOST_TEST(!test("", upper, '\xE9'));
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
     }
 
     {

--- a/test/karma/encoding.cpp
+++ b/test/karma/encoding.cpp
@@ -35,22 +35,22 @@ main()
 #endif
 
     {
-        BOOST_TEST(test("á", iso8859_1[lower['á']]));
-        BOOST_TEST(test("Á", iso8859_1[upper['á']]));
-        BOOST_TEST(test("á", iso8859_1[lower[char_('á')]]));
-        BOOST_TEST(test("Á", iso8859_1[upper[char_('á')]]));
-        BOOST_TEST(test("á", iso8859_1[lower[lit('á')]]));
-        BOOST_TEST(test("Á", iso8859_1[upper[lit('á')]]));
-        BOOST_TEST(test("á", iso8859_1[lower[char_]], 'á'));
-        BOOST_TEST(test("Á", iso8859_1[upper[char_]], 'á'));
-        BOOST_TEST(test("á", iso8859_1[lower['Á']]));
-        BOOST_TEST(test("Á", iso8859_1[upper['Á']]));
-        BOOST_TEST(test("á", iso8859_1[lower[char_('Á')]]));
-        BOOST_TEST(test("Á", iso8859_1[upper[char_('Á')]]));
-        BOOST_TEST(test("á", iso8859_1[lower[lit('Á')]]));
-        BOOST_TEST(test("Á", iso8859_1[upper[lit('Á')]]));
-        BOOST_TEST(test("á", iso8859_1[lower[char_]], 'Á'));
-        BOOST_TEST(test("Á", iso8859_1[upper[char_]], 'Á'));
+        BOOST_TEST(test("\xE1", iso8859_1[lower['\xE1']]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper['\xE1']]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[char_('\xE1')]]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[char_('\xE1')]]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[lit('\xE1')]]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[lit('\xE1')]]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[char_]], '\xE1'));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[char_]], '\xE1'));
+        BOOST_TEST(test("\xE1", iso8859_1[lower['\xC1']]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper['\xC1']]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[char_('\xC1')]]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[char_('\xC1')]]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[lit('\xC1')]]));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[lit('\xC1')]]));
+        BOOST_TEST(test("\xE1", iso8859_1[lower[char_]], '\xC1'));
+        BOOST_TEST(test("\xC1", iso8859_1[upper[char_]], '\xC1'));
     }
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
@@ -62,11 +62,11 @@ main()
 #pragma setlocale("german")
 #endif
     {
-        BOOST_TEST(test("ää", iso8859_1[lower["Ää"]]));
-        BOOST_TEST(test("ää", iso8859_1[lower[lit("Ää")]]));
+        BOOST_TEST(test("\xE4\xE4", iso8859_1[lower["\xC4\xE4"]]));
+        BOOST_TEST(test("\xE4\xE4", iso8859_1[lower[lit("\xC4\xE4")]]));
 
-        BOOST_TEST(test("ÄÄ", iso8859_1[upper["Ää"]]));
-        BOOST_TEST(test("ÄÄ", iso8859_1[upper[lit("Ää")]]));
+        BOOST_TEST(test("\xC4\xC4", iso8859_1[upper["\xC4\xE4"]]));
+        BOOST_TEST(test("\xC4\xC4", iso8859_1[upper[lit("\xC4\xE4")]]));
     }
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/karma/encoding.cpp
+++ b/test/karma/encoding.cpp
@@ -4,9 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_string.hpp>
@@ -29,12 +26,7 @@ main()
 
     encoding<char_encoding::iso8859_1> iso8859_1;
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
-
-    {
+    { // test extended ASCII characters
         BOOST_TEST(test("\xE1", iso8859_1[lower['\xE1']]));
         BOOST_TEST(test("\xC1", iso8859_1[upper['\xE1']]));
         BOOST_TEST(test("\xE1", iso8859_1[lower[char_('\xE1')]]));
@@ -51,26 +43,13 @@ main()
         BOOST_TEST(test("\xC1", iso8859_1[upper[lit('\xC1')]]));
         BOOST_TEST(test("\xE1", iso8859_1[lower[char_]], '\xC1'));
         BOOST_TEST(test("\xC1", iso8859_1[upper[char_]], '\xC1'));
-    }
 
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
-
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
-    {
         BOOST_TEST(test("\xE4\xE4", iso8859_1[lower["\xC4\xE4"]]));
         BOOST_TEST(test("\xE4\xE4", iso8859_1[lower[lit("\xC4\xE4")]]));
 
         BOOST_TEST(test("\xC4\xC4", iso8859_1[upper["\xC4\xE4"]]));
         BOOST_TEST(test("\xC4\xC4", iso8859_1[upper[lit("\xC4\xE4")]]));
     }
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     return boost::report_errors();
 }

--- a/test/karma/pattern4.cpp
+++ b/test/karma/pattern4.cpp
@@ -119,27 +119,27 @@ int main()
         typedef boost::spirit::char_encoding::iso8859_1 iso8859_1;
         karma::rule<outiter_type, iso8859_1> r;
 
-        r = lower['·'];
-        BOOST_TEST(test("·", r));
-        r = lower[char_('¡')];
-        BOOST_TEST(test("·", r));
-        r = upper['·'];
-        BOOST_TEST(test("¡", r));
-        r = upper[char_('¡')];
-        BOOST_TEST(test("¡", r));
+        r = lower['\xE1'];
+        BOOST_TEST(test("\xE1", r));
+        r = lower[char_('\xC1')];
+        BOOST_TEST(test("\xE1", r));
+        r = upper['\xE1'];
+        BOOST_TEST(test("\xC1", r));
+        r = upper[char_('\xC1')];
+        BOOST_TEST(test("\xC1", r));
 
-        r = lower["·¡"];
-        BOOST_TEST(test("··", r));
-        r = lower[lit("·¡")];
-        BOOST_TEST(test("··", r));
-        r = lower[string("·¡")];
-        BOOST_TEST(test("··", r));
-        r = upper["·¡"];
-        BOOST_TEST(test("¡¡", r));
-        r = upper[lit("·¡")];
-        BOOST_TEST(test("¡¡", r));
-        r = upper[string("·¡")];
-        BOOST_TEST(test("¡¡", r));
+        r = lower["\xE1\xC1"];
+        BOOST_TEST(test("\xE1\xE1", r));
+        r = lower[lit("\xE1\xC1")];
+        BOOST_TEST(test("\xE1\xE1", r));
+        r = lower[string("\xE1\xC1")];
+        BOOST_TEST(test("\xE1\xE1", r));
+        r = upper["\xE1\xC1"];
+        BOOST_TEST(test("\xC1\xC1", r));
+        r = upper[lit("\xE1\xC1")];
+        BOOST_TEST(test("\xC1\xC1", r));
+        r = upper[string("\xE1\xC1")];
+        BOOST_TEST(test("\xC1\xC1", r));
     }
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))

--- a/test/karma/pattern4.cpp
+++ b/test/karma/pattern4.cpp
@@ -3,9 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/config/warning_disable.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -108,9 +105,6 @@ int main()
         BOOST_TEST(test_delimited("a 10 12.4 ", start, space));
     }
 
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
     { // specifying the encoding
         using karma::lower;
         using karma::upper;
@@ -141,10 +135,6 @@ int main()
         r = upper[string("\xE1\xC1")];
         BOOST_TEST(test("\xC1\xC1", r));
     }
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     return boost::report_errors();
 }

--- a/test/qi/char_class.cpp
+++ b/test/qi/char_class.cpp
@@ -116,9 +116,9 @@ main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        BOOST_TEST(test("\xE9", alpha));
+        BOOST_TEST(test("\xE9", lower));
+        BOOST_TEST(!test("\xE9", upper));
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")
 #endif
@@ -205,9 +205,9 @@ main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        BOOST_TEST(test("\xE9", alpha));
+        BOOST_TEST(test("\xE9", lower));
+        BOOST_TEST(!test("\xE9", upper));
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/qi/char_class.cpp
+++ b/test/qi/char_class.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #define BOOST_SPIRIT_UNICODE
 
 #include <boost/detail/lightweight_test.hpp>
@@ -112,16 +109,10 @@ main()
         BOOST_TEST(test("f", xdigit));
         BOOST_TEST(!test("g", xdigit));
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
+        // test extended ASCII characters
         BOOST_TEST(test("\xE9", alpha));
         BOOST_TEST(test("\xE9", lower));
         BOOST_TEST(!test("\xE9", upper));
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
     }
 
     {
@@ -201,17 +192,10 @@ main()
         BOOST_TEST(test(L"f", xdigit));
         BOOST_TEST(!test(L"g", xdigit));
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
+        // TODO: these tests are suspicious, they do not test unicode
         BOOST_TEST(test("\xE9", alpha));
         BOOST_TEST(test("\xE9", lower));
         BOOST_TEST(!test("\xE9", upper));
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
     }
 
     {   // test attribute extraction

--- a/test/qi/encoding.cpp
+++ b/test/qi/encoding.cpp
@@ -39,18 +39,18 @@ main()
 #endif
 
     {
-        BOOST_TEST(test("¡", iso8859_1[no_case['·']]));
-        BOOST_TEST(test("¡", iso8859_1[no_case[char_('·')]]));
+        BOOST_TEST(test("\xC1", iso8859_1[no_case['\xE1']]));
+        BOOST_TEST(test("\xC1", iso8859_1[no_case[char_('\xE1')]]));
     }
 
     {
-        BOOST_TEST(test("…", iso8859_1[no_case[char_("Â-Ô")]]));
-        BOOST_TEST(!test("ˇ", iso8859_1[no_case[char_("Â-Ô")]]));
+        BOOST_TEST(test("\xC9", iso8859_1[no_case[char_("\xE5-\xEF")]]));
+        BOOST_TEST(!test("\xFF", iso8859_1[no_case[char_("\xE5-\xEF")]]));
     }
 
     {
-        BOOST_TEST(test("¡·", iso8859_1[no_case["·¡"]]));
-        BOOST_TEST(test("¡·", iso8859_1[no_case[lit("·¡")]]));
+        BOOST_TEST(test("\xC1\xE1", iso8859_1[no_case["\xE1\xC1"]]));
+        BOOST_TEST(test("\xC1\xE1", iso8859_1[no_case[lit("\xE1\xC1")]]));
     }
 
 

--- a/test/qi/encoding.cpp
+++ b/test/qi/encoding.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_string.hpp>
@@ -33,30 +30,16 @@ main()
 
     encoding<char_encoding::iso8859_1> iso8859_1;
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
-
-    {
+    { // test extended ASCII characters
         BOOST_TEST(test("\xC1", iso8859_1[no_case['\xE1']]));
         BOOST_TEST(test("\xC1", iso8859_1[no_case[char_('\xE1')]]));
-    }
 
-    {
         BOOST_TEST(test("\xC9", iso8859_1[no_case[char_("\xE5-\xEF")]]));
         BOOST_TEST(!test("\xFF", iso8859_1[no_case[char_("\xE5-\xEF")]]));
-    }
 
-    {
         BOOST_TEST(test("\xC1\xE1", iso8859_1[no_case["\xE1\xC1"]]));
         BOOST_TEST(test("\xC1\xE1", iso8859_1[no_case[lit("\xE1\xC1")]]));
     }
-
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     return boost::report_errors();
 }

--- a/test/qi/no_case.cpp
+++ b/test/qi/no_case.cpp
@@ -58,7 +58,7 @@ main()
 #endif
     {
         using namespace boost::spirit::iso8859_1;
-        BOOST_TEST(test("¡", no_case[char_('·')]));
+        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
     }
 
     {
@@ -66,8 +66,8 @@ main()
         BOOST_TEST(test("X", no_case[char_("a-z")]));
         BOOST_TEST(!test("1", no_case[char_("a-z")]));
 
-        BOOST_TEST(test("…", no_case[char_("Â-Ô")]));
-        BOOST_TEST(!test("ˇ", no_case[char_("Â-Ô")]));
+        BOOST_TEST(test("\xC9", no_case[char_("\xE5-\xEF")]));
+        BOOST_TEST(!test("\xFF", no_case[char_("\xE5-\xEF")]));
     }
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")
@@ -85,8 +85,8 @@ main()
 #endif
     {
         using namespace boost::spirit::iso8859_1;
-        BOOST_TEST(test("¡·", no_case[lit("·¡")]));
-        BOOST_TEST(test("··", no_case[no_case[lit("·¡")]]));
+        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
+        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
     }
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/qi/no_case.cpp
+++ b/test/qi/no_case.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_string.hpp>
@@ -52,26 +49,22 @@ main()
         BOOST_TEST(!test("z", no_case['x']));
     }
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
-    {
-        using namespace boost::spirit::iso8859_1;
-        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
-    }
-
     {
         using namespace boost::spirit::iso8859_1;
         BOOST_TEST(test("X", no_case[char_("a-z")]));
         BOOST_TEST(!test("1", no_case[char_("a-z")]));
+    }
+
+    { // test extended ASCII characters
+        using namespace boost::spirit::iso8859_1;
+        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
 
         BOOST_TEST(test("\xC9", no_case[char_("\xE5-\xEF")]));
         BOOST_TEST(!test("\xFF", no_case[char_("\xE5-\xEF")]));
+
+        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
+        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
     }
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     {
         using namespace boost::spirit::ascii;
@@ -79,18 +72,6 @@ main()
         BOOST_TEST(test("BOCHI BOCHI", no_case[lit("bochi bochi")]));
         BOOST_TEST(!test("Vavoo", no_case[lit("bochi bochi")]));
     }
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
-    {
-        using namespace boost::spirit::iso8859_1;
-        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
-        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
-    }
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     {
         // should work!

--- a/test/qi/rule1.cpp
+++ b/test/qi/rule1.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>

--- a/test/qi/rule2.cpp
+++ b/test/qi/rule2.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>

--- a/test/qi/rule3.cpp
+++ b/test/qi/rule3.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>

--- a/test/qi/rule4.cpp
+++ b/test/qi/rule4.cpp
@@ -115,19 +115,19 @@ main()
         typedef boost::spirit::char_encoding::iso8859_1 iso8859_1;
         rule<char const*, iso8859_1> r;
 
-        r = no_case['·'];
-        BOOST_TEST(test("¡", r));
-        r = no_case[char_('·')];
-        BOOST_TEST(test("¡", r));
+        r = no_case['\xE1'];
+        BOOST_TEST(test("\xC1", r));
+        r = no_case[char_('\xE1')];
+        BOOST_TEST(test("\xC1", r));
 
-        r = no_case[char_("Â-Ô")];
-        BOOST_TEST(test("…", r));
-        BOOST_TEST(!test("ˇ", r));
+        r = no_case[char_("\xE5-\xEF")];
+        BOOST_TEST(test("\xC9", r));
+        BOOST_TEST(!test("\xFF", r));
 
-        r = no_case["·¡"];
-        BOOST_TEST(test("¡·", r));
-        r = no_case[lit("·¡")];
-        BOOST_TEST(test("¡·", r));
+        r = no_case["\xE1\xC1"];
+        BOOST_TEST(test("\xC1\xE1", r));
+        r = no_case[lit("\xE1\xC1")];
+        BOOST_TEST(test("\xC1\xE1", r));
     }
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))

--- a/test/qi/rule4.cpp
+++ b/test/qi/rule4.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>
@@ -107,9 +104,6 @@ main()
         BOOST_TEST(!test("[123,456]", r));
     }
 
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("french")
-#endif
     { // specifying the encoding
 
         typedef boost::spirit::char_encoding::iso8859_1 iso8859_1;
@@ -129,10 +123,6 @@ main()
         r = no_case[lit("\xE1\xC1")];
         BOOST_TEST(test("\xC1\xE1", r));
     }
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
 
     {
         typedef boost::variant<double, int> v_type;

--- a/test/x3/any_parser.cpp
+++ b/test/x3/any_parser.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -107,9 +107,9 @@ main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        BOOST_TEST(test("\xE9", alpha));
+        BOOST_TEST(test("\xE9", lower));
+        BOOST_TEST(!test("\xE9", upper));
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")
 #endif
@@ -203,9 +203,9 @@ main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        BOOST_TEST(test("\xE9", alpha));
+        BOOST_TEST(test("\xE9", lower));
+        BOOST_TEST(!test("\xE9", upper));
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #define BOOST_SPIRIT_X3_UNICODE
 
 #include <boost/detail/lightweight_test.hpp>
@@ -103,16 +100,10 @@ main()
         BOOST_TEST(test("f", xdigit));
         BOOST_TEST(!test("g", xdigit));
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
+        // test extended ASCII characters
         BOOST_TEST(test("\xE9", alpha));
         BOOST_TEST(test("\xE9", lower));
         BOOST_TEST(!test("\xE9", upper));
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
     }
 
     {
@@ -199,17 +190,10 @@ main()
         BOOST_TEST(test(L" ", ~braille));
         // $$$ TODO $$$ Add more unicode tests
 
-// needed for VC7.1 only
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("german")
-#endif
+        // TODO: these tests are suspicious, they do not test unicode
         BOOST_TEST(test("\xE9", alpha));
         BOOST_TEST(test("\xE9", lower));
         BOOST_TEST(!test("\xE9", upper));
-
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-#pragma setlocale("")
-#endif
     }
 
     {   // test attribute extraction

--- a/test/x3/no_case.cpp
+++ b/test/x3/no_case.cpp
@@ -48,7 +48,7 @@ main()
 
     {
         using namespace boost::spirit::x3::iso8859_1;
-        BOOST_TEST(test("¡", no_case[char_('·')]));
+        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
     }
 
     {
@@ -56,8 +56,8 @@ main()
         BOOST_TEST(test("X", no_case[char_("a-z")]));
         BOOST_TEST(!test("1", no_case[char_("a-z")]));
 
-        BOOST_TEST(test("…", no_case[char_("Â-Ô")]));
-        BOOST_TEST(!test("ˇ", no_case[char_("Â-Ô")]));
+        BOOST_TEST(test("\xC9", no_case[char_("\xE5-\xEF")]));
+        BOOST_TEST(!test("\xFF", no_case[char_("\xE5-\xEF")]));
     }
 
     {
@@ -69,8 +69,8 @@ main()
 
     {
         using namespace boost::spirit::x3::iso8859_1;
-        BOOST_TEST(test("¡·", no_case[lit("·¡")]));
-        BOOST_TEST(test("··", no_case[no_case[lit("·¡")]]));
+        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
+        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
     }
 
     {

--- a/test/x3/no_case.cpp
+++ b/test/x3/no_case.cpp
@@ -6,9 +6,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file intentionally contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 
@@ -48,16 +45,19 @@ main()
 
     {
         using namespace boost::spirit::x3::iso8859_1;
-        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
-    }
-
-    {
-        using namespace boost::spirit::x3::iso8859_1;
         BOOST_TEST(test("X", no_case[char_("a-z")]));
         BOOST_TEST(!test("1", no_case[char_("a-z")]));
+    }
+
+    { // test extended ASCII characters
+        using namespace boost::spirit::x3::iso8859_1;
+        BOOST_TEST(test("\xC1", no_case[char_('\xE1')]));
 
         BOOST_TEST(test("\xC9", no_case[char_("\xE5-\xEF")]));
         BOOST_TEST(!test("\xFF", no_case[char_("\xE5-\xEF")]));
+
+        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
+        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
     }
 
     {
@@ -65,12 +65,6 @@ main()
         BOOST_TEST(test("Bochi Bochi", no_case[lit("bochi bochi")]));
         BOOST_TEST(test("BOCHI BOCHI", no_case[lit("bochi bochi")]));
         BOOST_TEST(!test("Vavoo", no_case[lit("bochi bochi")]));
-    }
-
-    {
-        using namespace boost::spirit::x3::iso8859_1;
-        BOOST_TEST(test("\xC1\xE1", no_case[lit("\xE1\xC1")]));
-        BOOST_TEST(test("\xE1\xE1", no_case[no_case[lit("\xE1\xC1")]]));
     }
 
     {

--- a/test/x3/rule1.cpp
+++ b/test/x3/rule1.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 

--- a/test/x3/rule2.cpp
+++ b/test/x3/rule2.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 

--- a/test/x3/rule3.cpp
+++ b/test/x3/rule3.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <boost/fusion/include/std_pair.hpp>

--- a/test/x3/rule4.cpp
+++ b/test/x3/rule4.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-// this file deliberately contains non-ascii characters
-// boostinspect:noascii
-
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <boost/fusion/include/vector.hpp>


### PR DESCRIPTION
Mostly to please Clang, but also makes sources UTF-8 valid.