### PR TITLE
transform_attribute: Disallow references as template parameters

### DIFF
--- a/include/boost/spirit/home/karma/detail/attributes.hpp
+++ b/include/boost/spirit/home/karma/detail/attributes.hpp
@@ -44,22 +44,6 @@ namespace boost { namespace spirit { namespace karma
         // Karma only, no post() and no fail() required
     };
 
-    // reference types need special handling
-    template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed&, Transformed>
-      : transform_attribute<Exposed, Transformed>
-    {};
-
-    template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed const&, Transformed>
-      : transform_attribute<Exposed const, Transformed>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute const&, Attribute>
-      : transform_attribute<Attribute const, Attribute>
-    {};
-
     // unused_type needs some special handling as well
     template <>
     struct transform_attribute<unused_type, unused_type>

--- a/include/boost/spirit/home/qi/detail/attributes.hpp
+++ b/include/boost/spirit/home/qi/detail/attributes.hpp
@@ -94,16 +94,6 @@ namespace boost { namespace spirit { namespace qi
         }
     };
 
-    // reference types need special handling
-    template <typename Attribute>
-    struct transform_attribute<Attribute&, Attribute>
-    {
-        typedef Attribute& type;
-        static Attribute& pre(Attribute& val) { return val; }
-        static void post(Attribute&, Attribute const&) {}
-        static void fail(Attribute&) {}
-    };
-
     // unused_type needs some special handling as well
     template <>
     struct transform_attribute<unused_type, unused_type>
@@ -139,16 +129,6 @@ namespace boost { namespace spirit { namespace traits
           : qi::transform_attribute<Exposed, Transformed>
         {};
     }
-
-    template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed&, Transformed, qi::domain>
-      : transform_attribute<Exposed, Transformed, qi::domain>
-    {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute&, Attribute, qi::domain>
-      : qi::transform_attribute<Attribute&, Attribute>
-    {};
 }}}
 
 #endif

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -30,6 +30,7 @@
 #include <boost/fusion/include/mpl.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_reference.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/end.hpp>
 #include <boost/mpl/find_if.hpp>
@@ -956,7 +957,12 @@ namespace boost { namespace spirit { namespace traits
       , typename Enable/* = void*/>
     struct transform_attribute
       : detail::transform_attribute_base<Exposed, Transformed, Domain>
-    {};
+    {
+        BOOST_STATIC_ASSERT_MSG(!is_reference<Exposed>::value,
+            "Exposed cannot be a reference type");
+        BOOST_STATIC_ASSERT_MSG(!is_reference<Transformed>::value,
+            "Transformed cannot be a reference type");
+    };
 
     template <typename Transformed, typename Domain>
     struct transform_attribute<unused_type, Transformed, Domain>

--- a/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/spirit/home/x3/support/traits/transform_attribute.hpp>
 #include <boost/spirit/home/x3/support/traits/move_to.hpp>
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -43,15 +44,6 @@ namespace boost { namespace spirit { namespace x3
     template <typename Exposed, typename Transformed, typename Enable = void>
     struct transform_attribute
       : default_transform_attribute<Exposed, Transformed> {};
-
-    // reference types need special handling
-    template <typename Attribute>
-    struct transform_attribute<Attribute&, Attribute>
-    {
-        typedef Attribute& type;
-        static Attribute& pre(Attribute& val) { return val; }
-        static void post(Attribute&, Attribute const&) {}
-    };
 
     // unused_type needs some special handling as well
     template <>
@@ -88,15 +80,13 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 {
     template <typename Exposed, typename Transformed>
     struct transform_attribute<Exposed, Transformed, x3::parser_id>
-      : x3::transform_attribute<Exposed, Transformed> {};
-
-    template <typename Exposed, typename Transformed>
-    struct transform_attribute<Exposed&, Transformed, x3::parser_id>
-      : transform_attribute<Exposed, Transformed, x3::parser_id> {};
-
-    template <typename Attribute>
-    struct transform_attribute<Attribute&, Attribute, x3::parser_id>
-      : x3::transform_attribute<Attribute&, Attribute> {};
+      : x3::transform_attribute<Exposed, Transformed>
+    {
+        static_assert(!std::is_reference<Exposed>::value,
+            "Exposed cannot be a reference type");
+        static_assert(!std::is_reference<Transformed>::value,
+            "Transformed cannot be a reference type");
+    };
 }}}}
 
 #endif


### PR DESCRIPTION
The special handling was used instead of removing references from the `make_attribute<T,U>::type`. Since `make_attribute` is gone the workaround is no longer needed.

Closes #450