### PR TITLE
Classic: file_iterator_tests: Fixed temp file race

### DIFF
--- a/classic/test/file_iterator_tests.cpp
+++ b/classic/test/file_iterator_tests.cpp
@@ -24,7 +24,7 @@ using namespace BOOST_SPIRIT_CLASSIC_NS;
 
 namespace {
 
-static const char* TMP_FILE = "file_iter.tmp";
+static char TMP_FILE[L_tmpnam];
 
 bool CreateTempFile(void)
 {
@@ -149,9 +149,15 @@ BOOST_CLASS_REQUIRE(iter, boost, RandomAccessIteratorConcept);
 
 int main(void)
 {
+    if (!std::tmpnam(TMP_FILE))
+    {
+        std::cerr << "ERROR: Cannot create unique file name\n";
+        return 3;
+    }
+
     if (!CreateTempFile())
     {
-        cerr << "ERROR: Cannot create temporary file file_iter.tmp" << endl;
+        std::cerr << "ERROR: Cannot create temporary file " << TMP_FILE << '\n';
         return 2;
     }
 


### PR DESCRIPTION
We have multiple runs of the test and sometimes it fails because of a race.