### PR TITLE
Fix gcc 9 -Wdeprecated-copy warning.

### DIFF
--- a/include/boost/spirit/home/support/unused.hpp
+++ b/include/boost/spirit/home/support/unused.hpp
@@ -53,18 +53,6 @@ namespace boost { namespace spirit
         {
             return *this;
         }
-
-        unused_type const&
-        operator=(unused_type const&) const
-        {
-            return *this;
-        }
-
-        unused_type&
-        operator=(unused_type const&)
-        {
-            return *this;
-        }
     };
 
     unused_type const unused = unused_type();


### PR DESCRIPTION
Hi,

This fixes an -Wdeprecated-copy warning when using gcc 9, as many other cases were fixed already.

Cheers,
Romain