### PR TITLE
Explicitly delete all non implemented assignment operators.

### DIFF
--- a/include/boost/spirit/home/karma/auto/auto.hpp
+++ b/include/boost/spirit/home/karma/auto/auto.hpp
@@ -146,9 +146,8 @@ namespace boost { namespace spirit { namespace karma
         T t_;
         generator_impl_type generator_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        lit_auto_generator& operator= (lit_auto_generator const&);
+        BOOST_DELETED_FUNCTION(lit_auto_generator& operator= (lit_auto_generator const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/karma/auxiliary/lazy.hpp
+++ b/include/boost/spirit/home/karma/auxiliary/lazy.hpp
@@ -139,9 +139,8 @@ namespace boost { namespace spirit { namespace karma
         Function func;
         Modifiers modifiers;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        lazy_generator& operator= (lazy_generator const&);
+        BOOST_DELETED_FUNCTION(lazy_generator& operator= (lazy_generator const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/karma/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/karma/detail/alternative_function.hpp
@@ -191,9 +191,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         Delimiter const& delim;
         Attribute const& attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        alternative_generate_function& operator= (alternative_generate_function const&);
+        BOOST_DELETED_FUNCTION(alternative_generate_function& operator= (alternative_generate_function const&));
     };
 
     // specialization for strict alternatives
@@ -241,9 +240,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         Attribute const& attr;
         bool failed;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        alternative_generate_function& operator= (alternative_generate_function const&);
+        BOOST_DELETED_FUNCTION(alternative_generate_function& operator= (alternative_generate_function const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/karma/detail/fail_function.hpp
+++ b/include/boost/spirit/home/karma/detail/fail_function.hpp
@@ -50,9 +50,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         Context& ctx;
         Delimiter const& delim;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        fail_function& operator= (fail_function const&);
+        BOOST_DELETED_FUNCTION(fail_function& operator= (fail_function const&));
     };
 
 }}}}

--- a/include/boost/spirit/home/karma/detail/pass_container.hpp
+++ b/include/boost/spirit/home/karma/detail/pass_container.hpp
@@ -383,9 +383,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
 
         F f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        pass_container& operator= (pass_container const&);
+        BOOST_DELETED_FUNCTION(pass_container& operator= (pass_container const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/karma/detail/unused_delimiter.hpp
+++ b/include/boost/spirit/home/karma/detail/unused_delimiter.hpp
@@ -21,9 +21,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
           : delimiter(delim) {}
         Delimiter const& delimiter;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        unused_delimiter& operator= (unused_delimiter const&);
+        BOOST_DELETED_FUNCTION(unused_delimiter& operator= (unused_delimiter const&));
     };
 
     // If a surrounding verbatim[] directive was specified, the current

--- a/include/boost/spirit/home/karma/directive/columns.hpp
+++ b/include/boost/spirit/home/karma/directive/columns.hpp
@@ -109,9 +109,8 @@ namespace boost { namespace spirit { namespace karma
             unsigned int const numcolumns;
             mutable unsigned int count;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            columns_delimiter& operator= (columns_delimiter const&);
+            BOOST_DELETED_FUNCTION(columns_delimiter& operator= (columns_delimiter const&));
         };
     }
 

--- a/include/boost/spirit/home/karma/directive/repeat.hpp
+++ b/include/boost/spirit/home/karma/directive/repeat.hpp
@@ -91,9 +91,8 @@ namespace boost { namespace spirit { namespace karma
 
         T const exact;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        exact_iterator& operator= (exact_iterator const&);
+        BOOST_DELETED_FUNCTION(exact_iterator& operator= (exact_iterator const&));
     };
 
     // handles repeat(min, max)[p]
@@ -112,9 +111,8 @@ namespace boost { namespace spirit { namespace karma
         T const min;
         T const max;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        finite_iterator& operator= (finite_iterator const&);
+        BOOST_DELETED_FUNCTION(finite_iterator& operator= (finite_iterator const&));
     };
 
     // handles repeat(min, inf)[p]
@@ -131,9 +129,8 @@ namespace boost { namespace spirit { namespace karma
 
         T const min;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        infinite_iterator& operator= (infinite_iterator const&);
+        BOOST_DELETED_FUNCTION(infinite_iterator& operator= (infinite_iterator const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/karma/stream/detail/format_manip.hpp
+++ b/include/boost/spirit/home/karma/stream/detail/format_manip.hpp
@@ -43,9 +43,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         BOOST_SCOPED_ENUM(delimit_flag) const pre;
         Attribute const& attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        format_manip& operator= (format_manip const&);
+        BOOST_DELETED_FUNCTION(format_manip& operator= (format_manip const&));
     };
 
     template <typename Expr, typename Delimiter, typename Attribute>
@@ -63,9 +62,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         BOOST_SCOPED_ENUM(delimit_flag) const pre;
         Attribute attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        format_manip& operator= (format_manip const&);
+        BOOST_DELETED_FUNCTION(format_manip& operator= (format_manip const&));
     };
 
     template <typename Expr, typename Delimiter, typename Attribute>
@@ -83,9 +81,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
         BOOST_SCOPED_ENUM(delimit_flag) const pre;
         Attribute const& attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        format_manip& operator= (format_manip const&);
+        BOOST_DELETED_FUNCTION(format_manip& operator= (format_manip const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/karma/stream/detail/iterator_sink.hpp
+++ b/include/boost/spirit/home/karma/stream/detail/iterator_sink.hpp
@@ -45,9 +45,8 @@ namespace boost { namespace spirit { namespace karma { namespace detail
 
         OutputIterator& sink;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        iterator_sink& operator= (iterator_sink const&);
+        BOOST_DELETED_FUNCTION(iterator_sink& operator= (iterator_sink const&));
     };
 
 }}}}

--- a/include/boost/spirit/home/karma/stream/stream.hpp
+++ b/include/boost/spirit/home/karma/stream/stream.hpp
@@ -285,9 +285,8 @@ namespace boost { namespace spirit { namespace karma
 
         T t_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        lit_stream_generator& operator= (lit_stream_generator const&);
+        BOOST_DELETED_FUNCTION(lit_stream_generator& operator= (lit_stream_generator const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/karma/string/symbols.hpp
+++ b/include/boost/spirit/home/karma/string/symbols.hpp
@@ -411,9 +411,8 @@ namespace boost { namespace spirit { namespace karma
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            adder& operator= (adder const&);
+            BOOST_DELETED_FUNCTION(adder& operator= (adder const&));
         };
 
         struct remover
@@ -444,9 +443,8 @@ namespace boost { namespace spirit { namespace karma
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            remover& operator= (remover const&);
+            BOOST_DELETED_FUNCTION(remover& operator= (remover const&));
         };
 
         adder add;
@@ -670,9 +668,8 @@ namespace boost { namespace spirit { namespace karma
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            adder& operator= (adder const&);
+            BOOST_DELETED_FUNCTION(adder& operator= (adder const&));
         };
 
         struct remover
@@ -703,9 +700,8 @@ namespace boost { namespace spirit { namespace karma
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            remover& operator= (remover const&);
+            BOOST_DELETED_FUNCTION(remover& operator= (remover const&));
         };
 
         adder add;

--- a/include/boost/spirit/home/lex/detail/sequence_function.hpp
+++ b/include/boost/spirit/home/lex/detail/sequence_function.hpp
@@ -33,9 +33,8 @@ namespace boost { namespace spirit { namespace lex { namespace detail
         String const& state;
         String const& targetstate;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        sequence_collect_function& operator= (sequence_collect_function const&);
+        BOOST_DELETED_FUNCTION(sequence_collect_function& operator= (sequence_collect_function const&));
     };
 
     template <typename LexerDef>
@@ -53,9 +52,8 @@ namespace boost { namespace spirit { namespace lex { namespace detail
 
         LexerDef& def;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        sequence_add_actions_function& operator= (sequence_add_actions_function const&);
+        BOOST_DELETED_FUNCTION(sequence_add_actions_function& operator= (sequence_add_actions_function const&));
     };
 
 }}}}

--- a/include/boost/spirit/home/lex/lexer/action.hpp
+++ b/include/boost/spirit/home/lex/lexer/action.hpp
@@ -51,9 +51,8 @@ namespace boost { namespace spirit { namespace lex
         Subject subject;
         Action f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        action& operator= (action const&);
+        BOOST_DELETED_FUNCTION(action& operator= (action const&));
     };
 
 }}}

--- a/include/boost/spirit/home/lex/lexer/lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexer.hpp
@@ -181,9 +181,8 @@ namespace boost { namespace spirit { namespace lex
 
                 lexer_def_& def;
 
-            private:
                 // silence MSVC warning C4512: assignment operator could not be generated
-                adder& operator= (adder const&);
+                BOOST_DELETED_FUNCTION(adder& operator= (adder const&));
             };
             friend struct adder;
 
@@ -203,9 +202,8 @@ namespace boost { namespace spirit { namespace lex
 
                 lexer_def_& def;
 
-            private:
                 // silence MSVC warning C4512: assignment operator could not be generated
-                pattern_adder& operator= (pattern_adder const&);
+                BOOST_DELETED_FUNCTION(pattern_adder& operator= (pattern_adder const&));
             };
             friend struct pattern_adder;
 
@@ -280,9 +278,8 @@ namespace boost { namespace spirit { namespace lex
             string_type state;
             string_type targetstate;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            lexer_def_& operator= (lexer_def_ const&);
+            BOOST_DELETED_FUNCTION(lexer_def_& operator= (lexer_def_ const&));
         };
 
 #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)

--- a/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor.hpp
@@ -92,9 +92,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             T& dst_;
             T const& src_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            assign_on_exit& operator= (assign_on_exit const&);
+            BOOST_DELETED_FUNCTION(assign_on_exit& operator= (assign_on_exit const&));
         };
 
     public:

--- a/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/functor_data.hpp
@@ -193,9 +193,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
 
             bool bol_;      // helper storing whether last character was \n
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            data& operator= (data const&);
+            BOOST_DELETED_FUNCTION(data& operator= (data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -266,9 +265,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
         protected:
             std::size_t state_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            data& operator= (data const&);
+            BOOST_DELETED_FUNCTION(data& operator= (data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -402,9 +400,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             mutable bool has_value_;    // 'true' if value_ is valid
             bool has_hold_;     // 'true' if hold_ is valid
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            data& operator= (data const&);
+            BOOST_DELETED_FUNCTION(data& operator= (data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -542,9 +539,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             mutable bool has_value_;    // 'true' if value_ is valid
             bool has_hold_;     // 'true' if hold_ is valid
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            data& operator= (data const&);
+            BOOST_DELETED_FUNCTION(data& operator= (data const&));
         };
     }
 }}}}

--- a/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
@@ -188,9 +188,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             boost::lexer::basic_rules<char_type> const& rules_;
             semantic_actions_type const& actions_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            iterator_data_type& operator= (iterator_data_type const&);
+            BOOST_DELETED_FUNCTION(iterator_data_type& operator= (iterator_data_type const&));
         };
 
     public:

--- a/include/boost/spirit/home/lex/lexer/lexertl/static_functor_data.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/static_functor_data.hpp
@@ -209,9 +209,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
 
             bool bol_;      // helper storing whether last character was \n
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            static_data& operator= (static_data const&);
+            BOOST_DELETED_FUNCTION(static_data& operator= (static_data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -284,9 +283,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             std::size_t state_;
             std::size_t num_states_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            static_data& operator= (static_data const&);
+            BOOST_DELETED_FUNCTION(static_data& operator= (static_data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -423,9 +421,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             mutable bool has_value_;    // 'true' if value_ is valid
             bool has_hold_;     // 'true' if hold_ is valid
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            static_data& operator= (static_data const&);
+            BOOST_DELETED_FUNCTION(static_data& operator= (static_data const&));
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -563,9 +560,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             mutable bool has_value_;    // 'true' if value_ is valid
             bool has_hold_;     // 'true' if hold_ is valid
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            static_data& operator= (static_data const&);
+            BOOST_DELETED_FUNCTION(static_data& operator= (static_data const&));
         };
     }
 }}}}

--- a/include/boost/spirit/home/lex/lexer/lexertl/static_lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/static_lexer.hpp
@@ -151,9 +151,8 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             std::size_t num_states_;
             bool bol_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            iterator_data_type& operator= (iterator_data_type const&);
+            BOOST_DELETED_FUNCTION(iterator_data_type& operator= (iterator_data_type const&));
         };
 
         typedef LexerTables tables_type;

--- a/include/boost/spirit/home/lex/qi/state_switcher.hpp
+++ b/include/boost/spirit/home/lex/qi/state_switcher.hpp
@@ -154,9 +154,8 @@ namespace boost { namespace spirit { namespace qi
             Iterator& it;
             std::size_t state;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            reset_state_on_exit& operator= (reset_state_on_exit const&);
+            BOOST_DELETED_FUNCTION(reset_state_on_exit& operator= (reset_state_on_exit const&));
         };
     }
 
@@ -214,9 +213,8 @@ namespace boost { namespace spirit { namespace qi
         Subject subject;
         State state;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        state_switcher_context& operator= (state_switcher_context const&);
+        BOOST_DELETED_FUNCTION(state_switcher_context& operator= (state_switcher_context const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/action/action.hpp
+++ b/include/boost/spirit/home/qi/action/action.hpp
@@ -137,9 +137,8 @@ namespace boost { namespace spirit { namespace qi
         Subject subject;
         Action f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        action& operator= (action const&);
+        BOOST_DELETED_FUNCTION(action& operator= (action const&));
     };
 }}}
 

--- a/include/boost/spirit/home/qi/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/qi/auxiliary/attr.hpp
@@ -73,9 +73,8 @@ namespace boost { namespace spirit { namespace qi
 
         Value value_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        attr_parser& operator= (attr_parser const&);
+        BOOST_DELETED_FUNCTION(attr_parser& operator= (attr_parser const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
+++ b/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
@@ -114,9 +114,8 @@ namespace boost { namespace spirit { namespace qi
 
         Subject subject;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        attr_cast_parser& operator= (attr_cast_parser const&);
+        BOOST_DELETED_FUNCTION(attr_cast_parser& operator= (attr_cast_parser const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -174,9 +174,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Skipper const& skipper;
         Attribute& attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        alternative_function& operator= (alternative_function const&);
+        BOOST_DELETED_FUNCTION(alternative_function& operator= (alternative_function const&));
     };
 
     template <typename Iterator, typename Context, typename Skipper>
@@ -202,9 +201,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Context& context;
         Skipper const& skipper;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        alternative_function& operator= (alternative_function const&);
+        BOOST_DELETED_FUNCTION(alternative_function& operator= (alternative_function const&));
     };
 
 }}}}

--- a/include/boost/spirit/home/qi/detail/expect_function.hpp
+++ b/include/boost/spirit/home/qi/detail/expect_function.hpp
@@ -96,9 +96,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Skipper const& skipper;
         mutable bool is_first;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        expect_function& operator= (expect_function const&);
+        BOOST_DELETED_FUNCTION(expect_function& operator= (expect_function const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/fail_function.hpp
+++ b/include/boost/spirit/home/qi/detail/fail_function.hpp
@@ -50,9 +50,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Context& context;
         Skipper const& skipper;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        fail_function& operator= (fail_function const&);
+        BOOST_DELETED_FUNCTION(fail_function& operator= (fail_function const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/pass_container.hpp
+++ b/include/boost/spirit/home/qi/detail/pass_container.hpp
@@ -354,9 +354,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         F f;
         Attr& attr;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        pass_container& operator= (pass_container const&);
+        BOOST_DELETED_FUNCTION(pass_container& operator= (pass_container const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/detail/pass_function.hpp
+++ b/include/boost/spirit/home/qi/detail/pass_function.hpp
@@ -61,9 +61,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Context& context;
         Skipper const& skipper;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        pass_function& operator= (pass_function const&);
+        BOOST_DELETED_FUNCTION(pass_function& operator= (pass_function const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/permute_function.hpp
+++ b/include/boost/spirit/home/qi/detail/permute_function.hpp
@@ -63,9 +63,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Skipper const& skipper;
         bool* taken;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        permute_function& operator= (permute_function const&);
+        BOOST_DELETED_FUNCTION(permute_function& operator= (permute_function const&));
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/unused_skipper.hpp
+++ b/include/boost/spirit/home/qi/detail/unused_skipper.hpp
@@ -22,9 +22,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
           : skipper(skipper_) {}
         Skipper const& skipper;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        unused_skipper& operator= (unused_skipper const&);
+        BOOST_DELETED_FUNCTION(unused_skipper& operator= (unused_skipper const&));
     };
 
     template <typename Skipper>

--- a/include/boost/spirit/home/qi/directive/matches.hpp
+++ b/include/boost/spirit/home/qi/directive/matches.hpp
@@ -71,9 +71,8 @@ namespace boost { namespace spirit { namespace qi
 
         Subject subject;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        matches_directive& operator= (matches_directive const&);
+        BOOST_DELETED_FUNCTION(matches_directive& operator= (matches_directive const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/directive/omit.hpp
+++ b/include/boost/spirit/home/qi/directive/omit.hpp
@@ -70,9 +70,8 @@ namespace boost { namespace spirit { namespace qi
 
         Subject subject;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        omit_directive& operator= (omit_directive const&);
+        BOOST_DELETED_FUNCTION(omit_directive& operator= (omit_directive const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/directive/repeat.hpp
+++ b/include/boost/spirit/home/qi/directive/repeat.hpp
@@ -91,9 +91,8 @@ namespace boost { namespace spirit { namespace qi
 
         T const exact;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        exact_iterator& operator= (exact_iterator const&);
+        BOOST_DELETED_FUNCTION(exact_iterator& operator= (exact_iterator const&));
     };
 
     template <typename T>
@@ -111,9 +110,8 @@ namespace boost { namespace spirit { namespace qi
         T const min;
         T const max;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        finite_iterator& operator= (finite_iterator const&);
+        BOOST_DELETED_FUNCTION(finite_iterator& operator= (finite_iterator const&));
     };
 
     template <typename T>
@@ -129,9 +127,8 @@ namespace boost { namespace spirit { namespace qi
 
         T const min;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        infinite_iterator& operator= (infinite_iterator const&);
+        BOOST_DELETED_FUNCTION(infinite_iterator& operator= (infinite_iterator const&));
     };
 
     template <typename Subject, typename LoopIter>
@@ -209,9 +206,8 @@ namespace boost { namespace spirit { namespace qi
         Subject subject;
         LoopIter iter;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        repeat_parser& operator= (repeat_parser const&);
+        BOOST_DELETED_FUNCTION(repeat_parser& operator= (repeat_parser const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/stream/detail/iterator_source.hpp
+++ b/include/boost/spirit/home/qi/stream/detail/iterator_source.hpp
@@ -69,9 +69,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Iterator const& last;
         std::streamsize pos;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        base_iterator_source& operator= (base_iterator_source const&);
+        BOOST_DELETED_FUNCTION(base_iterator_source& operator= (base_iterator_source const&));
     };
 
     template <typename Iterator, typename Enable = void>

--- a/include/boost/spirit/home/qi/stream/detail/match_manip.hpp
+++ b/include/boost/spirit/home/qi/stream/detail/match_manip.hpp
@@ -46,9 +46,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Attribute& attr;
         BOOST_SCOPED_ENUM(skip_flag) const post_skip;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        match_manip& operator= (match_manip const&);
+        BOOST_DELETED_FUNCTION(match_manip& operator= (match_manip const&));
     };
 
     template <typename Expr, typename Skipper, typename Attribute>
@@ -66,9 +65,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Attribute attr;
         BOOST_SCOPED_ENUM(skip_flag) const post_skip;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        match_manip& operator= (match_manip const&);
+        BOOST_DELETED_FUNCTION(match_manip& operator= (match_manip const&));
     };
 
     template <typename Expr, typename Skipper, typename Attribute>
@@ -86,9 +84,8 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         Attribute& attr;
         BOOST_SCOPED_ENUM(skip_flag) const post_skip;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        match_manip& operator= (match_manip const&);
+        BOOST_DELETED_FUNCTION(match_manip& operator= (match_manip const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/string/lit.hpp
+++ b/include/boost/spirit/home/qi/string/lit.hpp
@@ -118,9 +118,8 @@ namespace boost { namespace spirit { namespace qi
 
         String str;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        literal_string& operator= (literal_string const&);
+        BOOST_DELETED_FUNCTION(literal_string& operator= (literal_string const&));
     };
 
     template <typename String, bool no_attribute>

--- a/include/boost/spirit/home/qi/string/symbols.hpp
+++ b/include/boost/spirit/home/qi/string/symbols.hpp
@@ -322,9 +322,8 @@ public:
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            adder& operator= (adder const&);
+            BOOST_DELETED_FUNCTION(adder& operator= (adder const&));
         };
 
         struct remover
@@ -365,9 +364,8 @@ public:
 
             symbols& sym;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            remover& operator= (remover const&);
+            BOOST_DELETED_FUNCTION(remover& operator= (remover const&));
         };
 
         adder add;

--- a/include/boost/spirit/home/support/detail/what_function.hpp
+++ b/include/boost/spirit/home/support/detail/what_function.hpp
@@ -39,9 +39,8 @@ namespace boost { namespace spirit { namespace detail
         info& what;
         Context& context;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        what_function& operator= (what_function const&);
+        BOOST_DELETED_FUNCTION(what_function& operator= (what_function const&));
     };
 }}}
 

--- a/include/boost/spirit/home/support/info.hpp
+++ b/include/boost/spirit/home/support/info.hpp
@@ -117,9 +117,8 @@ namespace boost { namespace spirit
         utf8_string const& tag;
         int depth;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        basic_info_walker& operator= (basic_info_walker const&);
+        BOOST_DELETED_FUNCTION(basic_info_walker& operator= (basic_info_walker const&));
     };
 
     // bare-bones print support
@@ -141,9 +140,8 @@ namespace boost { namespace spirit
 
         Out& out;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        simple_printer& operator= (simple_printer const&);
+        BOOST_DELETED_FUNCTION(simple_printer& operator= (simple_printer const&));
     };
 
     template <typename Out>

--- a/include/boost/spirit/home/support/iterators/detail/split_functor_input_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/split_functor_input_policy.hpp
@@ -190,9 +190,8 @@ namespace boost { namespace spirit { namespace iterator_policies
             mutable typename Functor::second_type ftor;
             result_type curtok;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            shared& operator= (shared const&);
+            BOOST_DELETED_FUNCTION(shared& operator= (shared const&));
         };
     };
 

--- a/include/boost/spirit/home/support/nonterminal/expand_arg.hpp
+++ b/include/boost/spirit/home/support/nonterminal/expand_arg.hpp
@@ -78,9 +78,8 @@ namespace boost { namespace spirit { namespace detail
 
         Context& context;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        expand_arg& operator= (expand_arg const&);
+        BOOST_DELETED_FUNCTION(expand_arg& operator= (expand_arg const&));
     };
 
 }}}

--- a/include/boost/spirit/home/support/terminal.hpp
+++ b/include/boost/spirit/home/support/terminal.hpp
@@ -485,9 +485,8 @@ namespace boost { namespace spirit
               , phoenix::as_actor<A2>::convert(_2_));
         }
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        terminal& operator= (terminal const&);
+        BOOST_DELETED_FUNCTION(terminal& operator= (terminal const&));
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -543,9 +542,8 @@ namespace boost { namespace spirit
 
             data_type data_;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            stateful_tag& operator= (stateful_tag const&);
+            BOOST_DELETED_FUNCTION(stateful_tag& operator= (stateful_tag const&));
         };
     }
 
@@ -562,9 +560,8 @@ namespace boost { namespace spirit
           : spirit::terminal<tag_type>(data) 
         {}
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        stateful_tag_type& operator= (stateful_tag_type const&);
+        BOOST_DELETED_FUNCTION(stateful_tag_type& operator= (stateful_tag_type const&));
     };
 
     namespace detail

--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -50,9 +50,8 @@ namespace boost { namespace spirit { namespace x3
 
         Value value_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        attr_parser& operator= (attr_parser const&);
+        attr_parser& operator= (attr_parser const&) = delete;
     };
     
     template <typename Value, std::size_t N>
@@ -86,9 +85,8 @@ namespace boost { namespace spirit { namespace x3
 
         Value value_[N];
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        attr_parser& operator= (attr_parser const&);
+        attr_parser& operator= (attr_parser const&) = delete;
     };
     
     template <typename Value>

--- a/include/boost/spirit/repository/home/qi/directive/kwd.hpp
+++ b/include/boost/spirit/repository/home/qi/directive/kwd.hpp
@@ -172,9 +172,8 @@ template <typename T>
         }
 
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        kwd_pass_iterator& operator= (kwd_pass_iterator const&);
+        BOOST_DELETED_FUNCTION(kwd_pass_iterator& operator= (kwd_pass_iterator const&));
     };
 
     template <typename T>
@@ -203,9 +202,8 @@ template <typename T>
         }
         T const exact;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        kwd_exact_iterator& operator= (kwd_exact_iterator const&);
+        BOOST_DELETED_FUNCTION(kwd_exact_iterator& operator= (kwd_exact_iterator const&));
     };
 
     template <typename T>
@@ -235,9 +233,8 @@ template <typename T>
         T const min;
         T const max;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        kwd_finite_iterator& operator= (kwd_finite_iterator const&);
+        BOOST_DELETED_FUNCTION(kwd_finite_iterator& operator= (kwd_finite_iterator const&));
     };
 
     template <typename T>
@@ -255,9 +252,8 @@ template <typename T>
         }
         T const min;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        kwd_infinite_iterator& operator= (kwd_infinite_iterator const&);
+        BOOST_DELETED_FUNCTION(kwd_infinite_iterator& operator= (kwd_infinite_iterator const&));
     };
 
     // This class enables the transportation of parameters needed to call
@@ -440,9 +436,8 @@ template <typename T>
                 spirit::qi::no_case_literal_string< KeywordType, true>,
                 spirit::qi::literal_string<KeywordType, true> >::type keyword_string_type;
        keyword_string_type keyword;
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        kwd_parser& operator= (kwd_parser const&);
+        BOOST_DELETED_FUNCTION(kwd_parser& operator= (kwd_parser const&));
 
         template <typename Iterator, typename Context, typename Skipper>
         static spirit::qi::detail::fail_function<Iterator, Context, Skipper>
@@ -585,9 +580,8 @@ template <typename Subject, typename KeywordType, typename LoopIter, typename Di
         LoopIter iter;
 
         KeywordType keyword;
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        complex_kwd_parser& operator= (complex_kwd_parser const&);
+        BOOST_DELETED_FUNCTION(complex_kwd_parser& operator= (complex_kwd_parser const&));
 
         template <typename Iterator, typename Context, typename Skipper>
         static spirit::qi::detail::fail_function<Iterator, Context, Skipper>

--- a/include/boost/spirit/repository/home/qi/operator/detail/keywords.hpp
+++ b/include/boost/spirit/repository/home/qi/operator/detail/keywords.hpp
@@ -689,9 +689,8 @@ namespace boost { namespace spirit { namespace repository { namespace qi { names
             Skipper const& skipper;
             ParseDispatcher const& dispatcher;
 
-            private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            complex_kwd_function& operator= (complex_kwd_function const&);
+            BOOST_DELETED_FUNCTION(complex_kwd_function& operator= (complex_kwd_function const&));
         };
 
 

--- a/test/lex/dedent_handling_phoenix.cpp
+++ b/test/lex/dedent_handling_phoenix.cpp
@@ -74,9 +74,8 @@ struct dumper
 
     std::stringstream& strm;
 
-private:
     // silence MSVC warning C4512: assignment operator could not be generated
-    dumper& operator= (dumper const&);
+    BOOST_DELETED_FUNCTION(dumper& operator= (dumper const&));
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/lex/matlib.h
+++ b/test/lex/matlib.h
@@ -36,9 +36,8 @@ struct store_double
         out.push_back(std::atof(work.c_str()));
     }
 
-private:
     // silence MSVC warning C4512: assignment operator could not be generated
-    store_double& operator= (store_double const&);
+    BOOST_DELETED_FUNCTION(store_double& operator= (store_double const&));
 };
 
 struct add_row
@@ -58,9 +57,8 @@ struct add_row
         ctx.set_state_name("A");
     }
 
-private:
     // silence MSVC warning C4512: assignment operator could not be generated
-    add_row& operator= (add_row const&);
+    BOOST_DELETED_FUNCTION(add_row& operator= (add_row const&));
 };
 
 template <class Lexer>

--- a/test/lex/set_token_value.cpp
+++ b/test/lex/set_token_value.cpp
@@ -78,9 +78,8 @@ struct handle_whitespace
 
     std::stack<unsigned int>& indents_;
 
-private:
     // silence MSVC warning C4512: assignment operator could not be generated
-    handle_whitespace& operator= (handle_whitespace const&);
+    BOOST_DELETED_FUNCTION(handle_whitespace& operator= (handle_whitespace const&));
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/qi/terminal_ex.cpp
+++ b/test/qi/terminal_ex.cpp
@@ -69,9 +69,8 @@ namespace testns
 
         const T1 t1;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        ops_1_parser& operator= (ops_1_parser const&);
+        BOOST_DELETED_FUNCTION(ops_1_parser& operator= (ops_1_parser const&));
     };
 
     template <typename T1, typename T2>
@@ -122,9 +121,8 @@ namespace testns
         const T1 t1;
         const T2 t2;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        ops_2_parser& operator= (ops_2_parser const&);
+        BOOST_DELETED_FUNCTION(ops_2_parser& operator= (ops_2_parser const&));
     };
 
     template <typename T1, typename T2, typename T3>
@@ -180,9 +178,8 @@ namespace testns
         const T2 t2;
         const T3 t3;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        ops_3_parser& operator= (ops_3_parser const&);
+        BOOST_DELETED_FUNCTION(ops_3_parser& operator= (ops_3_parser const&));
     };
 
 }


### PR DESCRIPTION
Commit (almost) automatically generated with the following sed command:
sed -i -ne '1h;1!H;${g;s|// silence MSVC warning C4512: assignment operator could not be generated\n\([[:blank:]]*\)\([^\n]\+\);\n|// silence MSVC warning C4512: assignment operator could not be generated\n\1BOOST_DELETED_FUNCTION(\2);\n|g;p}' $(git ls-files)

Then all files in the x3 subfolder were reverted to HEAD, and manually
updated to use " = delete" instead of BOOST_DELETED_FUNCTION.