### PR TITLE
Lex: Remove variadic `tokenize_and_phrase_parse`

### DIFF
--- a/doc/lex/lexer_api.qbk
+++ b/doc/lex/lexer_api.qbk
@@ -139,7 +139,7 @@ sequence has been successfully matched by the given grammar).
       , BOOST_SCOPED_ENUM(skip_flag) post_skip = skip_flag::postskip);
 
     template <typename Iterator, typename Lexer, typename ParserExpr
-      , typename Skipper, typename Attr1, typename Attr2, ..., typename AttrN>
+      , typename Skipper, typename Attribute>
     inline bool
     tokenize_and_phrase_parse(
         Iterator& first
@@ -147,10 +147,10 @@ sequence has been successfully matched by the given grammar).
       , Lexer const& lex
       , ParserExpr const& expr
       , Skipper const& skipper
-      , Attr1 const& attr1, Attr2 const& attr2, ..., AttrN const& attrN);
+      , Attribute& attr);
 
     template <typename Iterator, typename Lexer, typename ParserExpr
-      , typename Skipper, typename Attr1, typename Attr2, ..., typename AttrN>
+      , typename Skipper, typename Attribute>
     inline bool
     tokenize_and_phrase_parse(
         Iterator& first
@@ -158,8 +158,7 @@ sequence has been successfully matched by the given grammar).
       , Lexer const& lex
       , ParserExpr const& expr
       , Skipper const& skipper
-      , BOOST_SCOPED_ENUM(skip_flag) post_skip
-      , Attr1 const& attr1, Attr2 const& attr2, ..., AttrN const& attrN);
+      , BOOST_SCOPED_ENUM(skip_flag) post_skip, Attribute& attr);
 
 The maximum number of supported arguments is limited by the preprocessor 
 constant `SPIRIT_ARGUMENTS_LIMIT`. This constant defaults to the value defined

--- a/include/boost/spirit/home/lex/tokenize_and_parse_attr.hpp
+++ b/include/boost/spirit/home/lex/tokenize_and_parse_attr.hpp
@@ -57,54 +57,6 @@ namespace boost { namespace spirit { namespace lex
         return compile<qi::domain>(expr).parse(
             iter, lex.end(), unused, unused, attr);
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator, typename Lexer, typename ParserExpr
-      , typename Skipper, BOOST_PP_ENUM_PARAMS(N, typename A)>
-    inline bool
-    tokenize_and_phrase_parse(Iterator& first, Iterator last, Lexer const& lex
-      , ParserExpr const& expr, Skipper const& skipper
-      , BOOST_SCOPED_ENUM(skip_flag) post_skip
-      , BOOST_PP_ENUM_BINARY_PARAMS(N, A, & attr))
-    {
-        // Report invalid expression error as early as possible.
-        // If you got an error_invalid_expression error message here,
-        // then either the expression (expr) or skipper is not a valid
-        // spirit qi expression.
-        BOOST_SPIRIT_ASSERT_MATCH(qi::domain, ParserExpr);
-        BOOST_SPIRIT_ASSERT_MATCH(qi::domain, Skipper);
-
-        typedef
-            typename spirit::result_of::compile<qi::domain, Skipper>::type
-        skipper_type;
-        skipper_type const skipper_ = compile<qi::domain>(skipper);
-
-        typedef fusion::vector<
-            BOOST_PP_ENUM(N, BOOST_SPIRIT_QI_ATTRIBUTE_REFERENCE, A)
-        > vector_type;
-
-        vector_type attr (BOOST_PP_ENUM_PARAMS(N, attr));
-        typename Lexer::iterator_type iter = lex.begin(first, last);
-        if (!compile<qi::domain>(expr).parse(
-                iter, lex.end(), unused, skipper_, attr))
-            return false;
-
-        if (post_skip == skip_flag::postskip)
-            qi::skip_over(first, last, skipper_);
-        return true;
-    }
-
-    template <typename Iterator, typename Lexer, typename ParserExpr
-      , typename Skipper, BOOST_PP_ENUM_PARAMS(N, typename A)>
-    inline bool
-    tokenize_and_phrase_parse(Iterator& first, Iterator last, Lexer const& lex
-      , ParserExpr const& expr, Skipper const& skipper
-      , BOOST_PP_ENUM_BINARY_PARAMS(N, A, & attr))
-    {
-        return tokenize_and_phrase_parse(first, last, expr, skipper
-          , skip_flag::postskip, BOOST_PP_ENUM_PARAMS(N, attr));
-    }
-
 }}}
 
 #undef BOOST_SPIRIT_QI_ATTRIBUTE_REFERENCE


### PR DESCRIPTION
They were added 10 years ago and did not compile all the time due to bugs spotted during warning elimination work, but the main reason to remove them is that there was not a single report about the issues.

Closes #490