### PR TITLE
Replace a couple of dead links.

### DIFF
--- a/classic/doc/functional.html
+++ b/classic/doc/functional.html
@@ -66,7 +66,7 @@
   </tr>
 </table>
 <p> This STL-style FP can be seen everywhere these days. The following example 
-  is taken from <a href="http://www.sgi.com/tech/stl/">SGI's Standard Template 
+  is taken from <a href="https://www.boost.org/sgi/stl/">SGI's Standard Template 
   Library Programmer's Guide</a>:</p>
 <pre>
     <code><span class=comment>//  Computes sin(x)/(x + DBL_MIN) for each element of a range.
@@ -187,7 +187,7 @@
 <p> There's a library, authored by yours truly, named <a href="../phoenix/index.html">Phoenix</a>. 
   While this is not officially part of the Spirit distribution, this library has 
   been used extensively to experiment on advanced FP techniques in C++. This library 
-  is highly influenced by <a href="http://www.cc.gatech.edu/%7Eyannis/fc%2B%2B/">FC++</a> 
+  is highly influenced by <a href="https://people.cs.umass.edu/~yannis/fc++/">FC++</a> 
   and boost Lambda (<a href="http://www.boost.org/libs/lambda/index.html">BLL</a>).</p>
 <table width="80%" border="0" align="center">
   <tr> 

--- a/classic/doc/preface.html
+++ b/classic/doc/preface.html
@@ -118,7 +118,7 @@
       The version that we have now is a complete rewrite of the original Spirit
       parser using expression templates and static polymorphism, inspired by
       the works of Todd Veldhuizen (" <a href=
-      "http://www.extreme.indiana.edu/%7Etveldhui/papers/Expression-Templates/exprtmpl.html">
+      "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.43.248">
       Expression Templates</a>", C++ Report, June 1995). Initially, the
       <i><b>static-Spirit</b></i> version was meant only to replace the core of
       the original <i><b>dynamic-Spirit</b></i>. Dynamic-spirit needed a parser

--- a/classic/doc/references.html
+++ b/classic/doc/references.html
@@ -32,7 +32,7 @@
     <td width="236" class="table_cells"> <a name="expression_templates"></a>Todd 
       Veldhuizen</td>
     <td width="520" class="table_cells"> "<a 
-href="http://www.extreme.indiana.edu/%7Etveldhui/papers/Expression-Templates/exprtmpl.html">Expression 
+href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.43.248">Expression 
       Templates</a>". <br>
       C++ Report, June 1995.</td>
   </tr>
@@ -82,7 +82,7 @@ href="http://www.coldewey.com/europlop2000/papers/geraud%2Bduret.zip">Generic
   <tr> 
     <td width="36" class="table_cells">7.</td>
     <td width="236" class="table_cells">Geoffrey Furnish</td>
-    <td width="520" height="53" class="table_cells"><a href="http://www.adtmag.com/joop/crarticle.asp?ID=627">&quot;Disambiguated 
+    <td width="520" height="53" class="table_cells"><a href="https://adtmag.com/articles/2000/04/25/disambiguated-glommable-expression-templates-reintroduced.aspx">&quot;Disambiguated 
       Glommable Expression Templates Reintroduced&quot;</a><br>
       C++ Report, May 2000</td>
   </tr>
@@ -119,7 +119,7 @@ href="http://www.cs.vu.nl/%7Edick/PTAPG.html">Parsing Techniques: A Practical
     <td width="236" class="table_cells"> T. J. Parr, H. G. Dietz, and<br>
       W. E. Cohen</td>
     <td width="520" class="table_cells"> <a 
-href="http://www.antlr.org/papers/pcctsbk.pdf">PCCTS Reference Manual (Version 
+href="https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.51.7097">PCCTS Reference Manual (Version 
       1.00)</a>. <br>
       School of Electrical Engineering, Purdue University, West Lafayette, August 
       1991.</td>
@@ -138,7 +138,7 @@ href="ftp://ftp.cs.rhul.ac.uk/pub/rdp">RDP, A Recursive Descent Compiler Compile
     <td width="236" class="table_cells"> <a name="back_tracking_parsers"></a>Adrian 
       Johnstone</td>
     <td width="520" class="table_cells"> <a 
-href="http://www.cs.rhul.ac.uk/research/languages/projects/lookahead_backtrack.shtml">Languages 
+href="https://www.cs.rhul.ac.uk/research/languages/csle/lookahead_backtrack.html">Languages 
       and Architectures, <br>
       Parser generators with backtrack or extended lookahead capability</a><br>
       Department of Computer Science, Royal Holloway, University of London, Egham, 
@@ -198,7 +198,7 @@ href="http://www.research.att.com/%7Ebs/whitespace98.pdf">Generalizing Overloadi
     <td class="table_cells">20.</td>
     <td class="table_cells">Hewlett-Packard</td>
     <td class="table_cells">Standard Template Library Programmer's Guide.<br> 
-      <a href="http://www.sgi.com/tech/stl/">http://www.sgi.com/tech/stl/</a>, 
+      <a href="https://www.boost.org/sgi/stl/">https://www.boost.org/sgi/stl/</a>, 
       Hewlett-Packard Company, 1994</td>
   </tr>
   <tr> 
@@ -209,7 +209,7 @@ href="http://www.research.att.com/%7Ebs/whitespace98.pdf">Generalizing Overloadi
   <tr> 
     <td class="table_cells">22.</td>
     <td class="table_cells">Brian McNamara and Yannis Smaragdakis</td>
-    <td class="table_cells"> FC++: Functional Programming in C++. <a href="http://www.cc.gatech.edu/%7Eyannis/fc%2B%2B/">http://www.cc.gatech.edu/~yannis/fc++/</a></td>
+    <td class="table_cells"> FC++: Functional Programming in C++. <a href="https://people.cs.umass.edu/~yannis/fc++/">https://people.cs.umass.edu/~yannis/fc++/</a></td>
   </tr>
   <tr> 
     <td class="table_cells">23.</td>

--- a/classic/phoenix/doc/polymorphic_functions.html
+++ b/classic/phoenix/doc/polymorphic_functions.html
@@ -28,7 +28,7 @@
 <p>
 We've seen the examples and we are already aware that lazy functions are polymorphic. This is important and is reiterated over and over again. Monomorphic functions are passe and simply lacks the horse power in this day and age of generic programming.</p>
 <p>
-The framework provides facilities for defining truly polymorphic functions (in <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+The framework provides facilities for defining truly polymorphic functions (in <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> jargon, these are called rank-2 polymorphic functoids). For instance, the plus example above can apply to integers, floating points, user defined complex numbers or even strings. Example:</p>
 <code><pre>
         <span class=identifier>add</span><span class=special>(</span><span class=identifier>arg1</span><span class=special>, </span><span class=identifier>arg2</span><span class=special>)(</span><span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span><span class=special>(</span><span class=string>&quot;Hello&quot;</span><span class=special>), </span><span class=string>&quot; World&quot;</span><span class=special>)

--- a/classic/phoenix/doc/preface.html
+++ b/classic/phoenix/doc/preface.html
@@ -25,41 +25,41 @@
    </tr>
 </table>
 <blockquote><p><i>Functional programming is so called because a program consists entirely of functions. The main program itself is written as a function which receives the program's input as its argument and delivers the program's output as its result. Typically the main function is defined in terms of other functions, which in turn are defined in terms of still more functions until at the bottom level the functions are language primitives.</i></p></blockquote><blockquote><p><b><i>John Hughes</i></b>-- <i>Why Functional Programming Matters</i></p></blockquote><a name="influences_and_related_work"></a><h2>Influences and Related Work</h2><p>
-The design and implementation of Phoenix is highly influenced by <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+The design and implementation of Phoenix is highly influenced by <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> by Yannis Smaragdakis and Brian McNamara and the (<a href="http://www.boost.org">
 Boost</a> Lambda Library) <a href="http://www.boost.org/libs/lambda/doc/index.html">
-BLL</a> by Jaakko Järvi and Gary Powell. Phoenix is a blend of <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+BLL</a> by Jaakko Järvi and Gary Powell. Phoenix is a blend of <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> and <a href="http://www.boost.org/libs/lambda/doc/index.html">
 BLL</a> using the implementation techniques used in the <a href="http://spirit.sourceforge.net">
 Spirit</a> inline parser.</p>
 <p>
-Is Phoenix better than <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+Is Phoenix better than <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> or <a href="http://www.boost.org/libs/lambda/doc/index.html">
-BLL</a>? Well, there are concepts found in Phoenix that are not found in either library. <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a> has rank-2 polymorphic functions (<a href="http://www.cc.gatech.edu/~yannis/fc++/">
+BLL</a>? Well, there are concepts found in Phoenix that are not found in either library. <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a> has rank-2 polymorphic functions (<a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> jargon) which Phoenix also has, <a href="http://www.boost.org/libs/lambda/doc/index.html">
-BLL</a> has syntactic sugared operators which <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+BLL</a> has syntactic sugared operators which <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> lack, that Phoenix also has.</p>
 <p>
-Phoenix inherits <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a>'s rank-2 polymorphic functions. Rank-2 polymorphic functions are higher order functions that can accept polymorphic arguments. <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a> is the first library to enable higher order polymorphic functions. Before <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+Phoenix inherits <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a>'s rank-2 polymorphic functions. Rank-2 polymorphic functions are higher order functions that can accept polymorphic arguments. <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a> is the first library to enable higher order polymorphic functions. Before <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a>, polymorphic functions couldn't be used as arguments to other functions.</p>
 <p>
 What really motivated the author to write Phoenix is the lack of access to a true stack-frame with local variables (closures) in all C++ FP libraries in existence so far. When emulating functions in the form of functors, the most basic ingredient is missing: local variables and a stack. Current FP libraries emulate closures using state variables in functors. In more evolved FP applications, this &quot;poor man's closure&quot; is simply inadequate.</p>
 <p>
 Perhaps <a href="http://www.boost.org/libs/lambda/doc/index.html">
-BLL</a> does not need this at all since unnamed lambda functions cannot call itself anyway; at least not directly. <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+BLL</a> does not need this at all since unnamed lambda functions cannot call itself anyway; at least not directly. <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> arguably does not need this since it is purely functional without side-effects, thus there is no need to destructively write to a variable. The highly recursive nature of the <a href="http://spirit.sourceforge.net">
 Spirit</a> framework from which Phoenix is a derivative work necessitated true reentrant closures. Later on, Phoenix will inherit the <a href="http://spirit.sourceforge.net">
 Spirit</a> framework's true closures which implement access to true hardware stack based local variables.</p>
 <p>
-Phoenix is also extremely modular by design. One can extract and use only a small subset of the full framework, literally tearing the framework into small pieces, without fear that the pieces won't work anymore. For instance, one can use only the <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+Phoenix is also extremely modular by design. One can extract and use only a small subset of the full framework, literally tearing the framework into small pieces, without fear that the pieces won't work anymore. For instance, one can use only the <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> style programming layer with rank-2 polymorphic functions without the sugared operators.</p>
 <p>
 Emphasis is given to make Phoenix much more portable to current generation C++ compilers such as Borland and MSVC. Borland for example chokes on both <a href="http://www.boost.org/libs/lambda/doc/index.html">
-BLL</a> and <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a> code. Forget MSVC support in <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+BLL</a> and <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a> code. Forget MSVC support in <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> and <a href="http://www.boost.org/libs/lambda/doc/index.html">
 BLL</a>. On the other hand, although Phoenix is not yet ported to MSVC, Phoenix uses the same tried and true implementation techniques used by the <a href="http://spirit.sourceforge.net">
 Spirit</a> framework. Since <a href="http://spirit.sourceforge.net">

--- a/classic/phoenix/doc/quick_start.html
+++ b/classic/phoenix/doc/quick_start.html
@@ -73,7 +73,7 @@ Call the lazy is_odd function:</p>
 <p>
 is_odd_ is the actual functor. It has been proxied in function&lt;is_odd_&gt; by is_odd (note no trailing underscore) which makes it a lazy function. is_odd_::operator() is the main function body. is_odd_::result is a type computer that answers the question &quot;What should be our return type given an argument of type ArgT?&quot;.</p>
 <p>
-Like 2, and unlike 1, function pointers or plain C++ functors, is_odd is a true lazy, polymorphic functor (rank-2 polymorphic functoid, in <a href="http://www.cc.gatech.edu/~yannis/fc++/">
+Like 2, and unlike 1, function pointers or plain C++ functors, is_odd is a true lazy, polymorphic functor (rank-2 polymorphic functoid, in <a href="https://people.cs.umass.edu/~yannis/fc++/">
 FC++</a> jargon). The Phoenix functor version is fully polymorphic and works with any container (of ints, of doubles, of complex, etc.) as long as its elements can handle the &quot;arg1 % 2 == 1&quot; expression. However, unlike 2, this is more efficient and has less overhead especially when dealing with much more complex functions.</p>
 <p>
 This is just the tip of the iceberg. There are more nifty things you can do with the framework. There are quite interesting concepts such as rank-2 polymorphic lazy functions, lazy statements, binders etc; enough to whet the appetite of anyone wishing to squeeze more power from C++.</p>

--- a/classic/phoenix/doc/references.html
+++ b/classic/phoenix/doc/references.html
@@ -25,20 +25,20 @@
    </tr>
 </table>
 <p>
-Why Functional Programming Matters, John Hughes, 1989.<br> Available online at <a href="http://www.math.chalmers.se/~rjmh/Papers/whyfp.html">
-http://www.math.chalmers.se/~rjmh/Papers/whyfp.html</a>.</p>
+Why Functional Programming Matters, John Hughes, 1989.<br> Available online at <a href="https://doi.org/10.1093/comjnl/32.2.98">
+https://doi.org/10.1093/comjnl/32.2.98</a>.</p>
 <p>
 <a href="http://www.boost.org">
 Boost</a>.Lambda library, Jaakko Jarvi, 1999-2002 Jaakko Järvi, Gary Powell.<br> Available online at <a href="http://www.boost.org/libs/lambda/">
 http://www.boost.org/libs/lambda/</a>.</p>
 <p>
-Functional Programming in C++ using the <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a> Library: a short article introducing <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-FC++</a>, Brian McNamara and Yannis Smaragdakis, April 2001. Available online at <a href="http://www.cc.gatech.edu/~yannis/fc++/">
-http://www.cc.gatech.edu/~yannis/fc++/</a>.</p>
+Functional Programming in C++ using the <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a> Library: a short article introducing <a href="https://people.cs.umass.edu/~yannis/fc++/">
+FC++</a>, Brian McNamara and Yannis Smaragdakis, April 2001. Available online at <a href="https://people.cs.umass.edu/~yannis/fc++/">
+https://people.cs.umass.edu/~yannis/fc++/</a>.</p>
 <p>
-Side-effects and partial function application in C++, Jaakko Jarvi and Gary Powell, 2001.<br> Available online at <a href="http://osl.iu.edu/~jajarvi/publications/papers/mpool01.pdf">
-http://osl.iu.edu/~jajarvi/publications/papers/mpool01.pdf</a>.</p>
+Side-effects and partial function application in C++, Jaakko Jarvi and Gary Powell, 2001.<br> Available online at <a href="https://parasol.tamu.edu/~jarvi/papers/mpool01.pdf">
+https://parasol.tamu.edu/~jarvi/papers/mpool01.pdf</a>.</p>
 <p>
 <a href="http://spirit.sourceforge.net">
 Spirit</a> Version 1.2, Joel de Guzman, Nov 2001.<br> Available online at <a href="http://spirit.sourceforge.net/index.php?doc=docs/v1_2/index.html">

--- a/doc/references.qbk
+++ b/doc/references.qbk
@@ -10,7 +10,7 @@
 
 [table
 [[ ]   [Authors]                    [Title, Publisher/link, Date Published]]
-[[1.]  [Todd Veldhuizen]            [[@http://www.extreme.indiana.edu/%7Etveldhui/papers/Expression-Templates/exprtmpl.html
+[[1.]  [Todd Veldhuizen]            [[@https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.43.248
                                     "Expression Templates"]. C++ Report, June 1995.]]
 [[2.]  [Peter Naur (ed.)]           [[@http://www.masswerk.at/algol60/report.htm
                                     "Report on the Algorithmic Language ALGOL 60"]. CACM, May 1960.]]
@@ -54,7 +54,7 @@
                                     RDP, A Recursive Descent Compiler Compiler].
                                     Technical Report CSD TR 97 25, Dept. of Computer Science,
                                     Egham, Surrey, England, Dec. 20, 1997.]]
-[[13.] [Adrian Johnstone]           [[@http://www.cs.rhul.ac.uk/research/languages/projects/lookahead_backtrack.shtml
+[[13.] [Adrian Johnstone]           [[@https://www.cs.rhul.ac.uk/research/languages/csle/lookahead_backtrack.html
                                     Languages and Architectures,
                                     Parser generators with backtrack or extended lookahead capability]
                                     Department of Computer Science, Royal Holloway, University of London,
@@ -79,12 +79,12 @@
         Edited by Graham Hutton]    [[@http://www.cs.nott.ac.uk/~gmh//faq.html
                                     Frequently Asked Questions for comp.lang.functional].
                                     Edited by Graham Hutton, University of Nottingham.]]
-[[20.] [Hewlett-Packard]            [[@https://web.archive.org/web/20171225062613/http://www.sgi.com/tech/stl/
+[[20.] [Hewlett-Packard]            [[@https://www.boost.org/sgi/stl/
                                     Standard Template Library Programmer's Guide.], Hewlett-Packard Company, 1994]]
 [[21.] [Boost Libraries]            [[@http://boost.org/libs/libraries.htm
                                     Boost Libraries Documentation].]]
 [[22.] [Brian McNamara and
-        Yannis Smaragdakis]         [[@http://www.cc.gatech.edu/~yannis/fc++/ FC++:Functional Programming in C++].]]
+        Yannis Smaragdakis]         [[@https://people.cs.umass.edu/~yannis/fc++/ FC++:Functional Programming in C++].]]
 [[23.] [Todd Veldhuizen]            [[@ftp://ftp.cs.indiana.edu/pub/techreports/TR542.pdf Techniques for Scientific C++.]]]
 ]
 

--- a/doc/spirit2.qbk
+++ b/doc/spirit2.qbk
@@ -26,7 +26,7 @@
 [def __version__                V2.5.8]
 
 [def __spirit__                 [@http://boost-spirit.com Spirit]]
-[def __spirit_list__            [@http://www.nabble.com/The-Spirit-Parser-Library-f3430.html Spirit General List]]
+[def __spirit_list__            [@http://boost.2283326.n4.nabble.com/spirit-general-f2672582.html Spirit General List]]
 [def __phoenix__                [@boost:/libs/phoenix/doc/html/index.html Boost.Phoenix]]
 [def __fusion__                 [@boost:/libs/fusion/doc/html/index.html Boost.Fusion]]
 [def __mpl__                    [@http://www.boost.org/libs/mpl/index.html Boost.Mpl]]

--- a/repository/doc/spirit2_repository.qbk
+++ b/repository/doc/spirit2_repository.qbk
@@ -22,7 +22,7 @@
 [/ May 26, 2009 ]
 
 [def __spirit__                 [@http://boost-spirit.com Spirit]]
-[def __spirit_list__            [@http://www.nabble.com/The-Spirit-Parser-Library-f3430.html Spirit General List]]
+[def __spirit_list__            [@http://boost.2283326.n4.nabble.com/spirit-general-f2672582.html Spirit General List]]
 [def __phoenix__                [@boost:/libs/phoenix/doc/html/index.html Boost.Phoenix]]
 [def __fusion__                 [@http://spirit.sourceforge.net/dl_more/fusion_v2/libs/fusion/doc/html/index.html Fusion]]
 [def __mpl__                    [@http://www.boost.org/libs/mpl/index.html MPL]]


### PR DESCRIPTION
Hi, this PR fixes a couple for broken links. I did my best to ensure that they refer to the same information as the original links (using the web archive). Some modified files (like classic/phoenix/doc/preface.html) state that they are generated at the top but I failed to find the corresponding source files for their generation in the repository, so I modified them anyway.