### PR TITLE
X3: Simplify string_traits

### DIFF
--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -67,18 +67,11 @@ namespace boost { namespace spirit { namespace x3
         {
             using spirit::x3::detail::cast_char;
 
-            typedef typename
-                remove_const<
-                    typename traits::char_type_of<String>::type
-                >::type
-            in_type;
-
-            in_type const* definition =
-                (in_type const*)traits::get_c_string(str);
-            in_type ch = *definition++;
+            auto* definition = traits::get_c_string(str);
+            auto ch = *definition++;
             while (ch)
             {
-                in_type next = *definition++;
+                auto next = *definition++;
                 if (next == '-')
                 {
                     next = *definition++;

--- a/include/boost/spirit/home/x3/support/traits/string_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/string_traits.hpp
@@ -11,65 +11,9 @@
 
 #include <string>
 #include <boost/mpl/bool.hpp>
-#include <boost/mpl/identity.hpp>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // Get the underlying char type of a string
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    struct char_type_of;
-
-    template <typename T>
-    struct char_type_of<T const> : char_type_of<T> {};
-
-    template <>
-    struct char_type_of<char> : mpl::identity<char> {};
-
-    template <>
-    struct char_type_of<wchar_t> : mpl::identity<wchar_t> {};
-
-    template <>
-    struct char_type_of<char const*> : mpl::identity<char const> {};
-
-    template <>
-    struct char_type_of<wchar_t const*> : mpl::identity<wchar_t const> {};
-
-    template <>
-    struct char_type_of<char*> : mpl::identity<char> {};
-
-    template <>
-    struct char_type_of<wchar_t*> : mpl::identity<wchar_t> {};
-
-    template <std::size_t N>
-    struct char_type_of<char[N]> : mpl::identity<char> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t[N]> : mpl::identity<wchar_t> {};
-
-    template <std::size_t N>
-    struct char_type_of<char const[N]> : mpl::identity<char const> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t const[N]> : mpl::identity<wchar_t const> {};
-
-    template <std::size_t N>
-    struct char_type_of<char(&)[N]> : mpl::identity<char> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t(&)[N]> : mpl::identity<wchar_t> {};
-
-    template <std::size_t N>
-    struct char_type_of<char const(&)[N]> : mpl::identity<char const> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t const(&)[N]> : mpl::identity<wchar_t const> {};
-
-    template <typename T, typename Traits, typename Allocator>
-    struct char_type_of<std::basic_string<T, Traits, Allocator> >
-      : mpl::identity<T> {};
-
     ///////////////////////////////////////////////////////////////////////////
     // Get the C string from a string
     ///////////////////////////////////////////////////////////////////////////
@@ -79,8 +23,6 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename String>
     struct extract_c_string
     {
-        typedef typename char_type_of<String>::type char_type;
-
         template <typename T>
         static T const* call (T* str)
         {
@@ -98,9 +40,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename T>
     struct extract_c_string<T const>
     {
-        typedef typename extract_c_string<T>::char_type char_type;
-
-        static typename extract_c_string<T>::char_type const* call (T const str)
+        static decltype(auto) call(T const str)
         {
             return extract_c_string<T>::call(str);
         }
@@ -110,9 +50,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename T>
     struct extract_c_string<T&>
     {
-        typedef typename extract_c_string<T>::char_type char_type;
-
-        static typename extract_c_string<T>::char_type const* call (T& str)
+        static decltype(auto) call(T& str)
         {
             return extract_c_string<T>::call(str);
         }
@@ -122,9 +60,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename T>
     struct extract_c_string<T const&>
     {
-        typedef typename extract_c_string<T>::char_type char_type;
-
-        static typename extract_c_string<T>::char_type const* call (T const& str)
+        static decltype(auto) call(T const& str)
         {
             return extract_c_string<T>::call(str);
         }
@@ -133,8 +69,6 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename T, typename Traits, typename Allocator>
     struct extract_c_string<std::basic_string<T, Traits, Allocator> >
     {
-        typedef T char_type;
-
         typedef std::basic_string<T, Traits, Allocator> string;
 
         static T const* call (string const& str)
@@ -144,29 +78,25 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     };
 
     template <typename T>
-    typename extract_c_string<T*>::char_type const*
-    get_c_string(T* str)
+    decltype(auto) get_c_string(T* str)
     {
         return extract_c_string<T*>::call(str);
     }
 
     template <typename T>
-    typename extract_c_string<T const*>::char_type const*
-    get_c_string(T const* str)
+    decltype(auto) get_c_string(T const* str)
     {
         return extract_c_string<T const*>::call(str);
     }
 
     template <typename String>
-    typename extract_c_string<String>::char_type const*
-    get_c_string(String& str)
+    decltype(auto) get_c_string(String& str)
     {
         return extract_c_string<String>::call(str);
     }
 
     template <typename String>
-    typename extract_c_string<String>::char_type const*
-    get_c_string(String const& str)
+    decltype(auto) get_c_string(String const& str)
     {
         return extract_c_string<String>::call(str);
     }

--- a/include/boost/spirit/home/x3/support/traits/string_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/string_traits.hpp
@@ -16,69 +16,6 @@
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
     ///////////////////////////////////////////////////////////////////////////
-    // Determine if T is a character type
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    struct is_char : mpl::false_ {};
-
-    template <typename T>
-    struct is_char<T const> : is_char<T> {};
-
-    template <>
-    struct is_char<char> : mpl::true_ {};
-
-    template <>
-    struct is_char<wchar_t> : mpl::true_ {};
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Determine if T is a string
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    struct is_string : mpl::false_ {};
-
-    template <typename T>
-    struct is_string<T const> : is_string<T> {};
-
-    template <>
-    struct is_string<char const*> : mpl::true_ {};
-
-    template <>
-    struct is_string<wchar_t const*> : mpl::true_ {};
-
-    template <>
-    struct is_string<char*> : mpl::true_ {};
-
-    template <>
-    struct is_string<wchar_t*> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char const[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t const[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char const(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t const(&)[N]> : mpl::true_ {};
-
-    template <typename T, typename Traits, typename Allocator>
-    struct is_string<std::basic_string<T, Traits, Allocator> > : mpl::true_ {};
-
-    ///////////////////////////////////////////////////////////////////////////
     // Get the underlying char type of a string
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>


### PR DESCRIPTION
We probably may completely remove `string_traits.hpp` by rewriting things further.