### PR TITLE
Fix for #520 any_char accepts outside encoding

### DIFF
--- a/include/boost/spirit/home/x3/char/any_char.hpp
+++ b/include/boost/spirit/home/x3/char/any_char.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace spirit { namespace x3
         template <typename Char, typename Context>
         bool test(Char ch_, Context const&) const
         {
-            return ((sizeof(Char) <= sizeof(char_type)) || encoding::ischar(ch_));
+            return ((sizeof(Char) <= sizeof(char_type)) && encoding::ischar(ch_));
         }
 
         template <typename Char>


### PR DESCRIPTION
The following assert fails:

    int main() {
        namespace x3 = boost::spirit::x3;

        char const* input = "\x80";
        assert(!x3::parse(input, input+1, x3::ascii::char_));
    }

The assert should pass because char_encoding::ascii::test disallows
non-7bit ASCII, so "\x80" is outside the encoding.

The corresponding Qi test case DOES pass:

    int main() {
        namespace qi = boost::spirit::qi;

        char const* input = "\x80";
        assert(!qi::parse(input, input+1, qi::ascii::char_));
    }

This simple fix requires the encoding's `ischar` to return true always,
making the behavior as specified and consistent with Qi and docs.