### PR TITLE
Unicode out-of-bounds category lookup fixes

### DIFF
--- a/include/boost/spirit/home/x3/char/unicode.hpp
+++ b/include/boost/spirit/home/x3/char/unicode.hpp
@@ -414,7 +414,7 @@ namespace boost { namespace spirit { namespace x3
         template <typename Char, typename Context>
         bool test(Char ch, Context const&) const
         {
-            return ((sizeof(Char) <= sizeof(char_type)) || encoding::ischar(ch))
+            return ((sizeof(Char) < sizeof(char_type)) || encoding::ischar(ch))
                 && unicode_char_class_base::is(tag(), ch);
         }
     };

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -208,6 +208,8 @@ main()
         // force unicode category lookup
         // related issue: https://github.com/boostorg/spirit/issues/524
         BOOST_TEST(test_failure(input, alpha));
+        BOOST_TEST(test_failure(input, upper));
+        BOOST_TEST(test_failure(input, lower));
     }
 
     {   // test attribute extraction

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -19,6 +19,7 @@ int
 main()
 {
     using spirit_test::test;
+    using spirit_test::test_failure;
     using spirit_test::test_attr;
 
     using boost::spirit::x3::unused_type;
@@ -194,6 +195,19 @@ main()
         BOOST_TEST(test("\xE9", alpha));
         BOOST_TEST(test("\xE9", lower));
         BOOST_TEST(!test("\xE9", upper));
+    }
+
+    {   // test invalid unicode literals
+        using namespace boost::spirit::x3::unicode;
+
+        auto const invalid_unicode = char32_t{0x7FFFFFFF};
+        auto const input           = boost::u32string_view(&invalid_unicode, 1);
+
+        BOOST_TEST(test_failure(input, char_));
+
+        // force unicode category lookup
+        // related issue: https://github.com/boostorg/spirit/issues/524
+        BOOST_TEST(test_failure(input, alpha));
     }
 
     {   // test attribute extraction

--- a/test/x3/test.hpp
+++ b/test/x3/test.hpp
@@ -47,7 +47,7 @@ namespace spirit_test
     template <typename Char, typename Parser>
     bool test_failure(Char const* in, Parser const& p)
     {
-        char const * const start = in;
+        Char const * const start = in;
         Char const* last = in;
         while (*last)
             last++;
@@ -56,7 +56,8 @@ namespace spirit_test
     }
 
     template <typename Char, typename Parser>
-    bool test_failure(boost::basic_string_view<Char> const in, Parser const& p)
+    bool test_failure(boost::basic_string_view<Char, std::char_traits<Char>> const in,
+                      Parser const& p)
     {
         auto pos = in.begin();
         return !boost::spirit::x3::parse(pos, in.end(), p) && (pos == in.begin());

--- a/test/x3/test.hpp
+++ b/test/x3/test.hpp
@@ -55,6 +55,13 @@ namespace spirit_test
         return !boost::spirit::x3::parse(in, last, p) && (in == start);
     }
 
+    template <typename Char, typename Parser>
+    bool test_failure(boost::basic_string_view<Char> const in, Parser const& p)
+    {
+        auto pos = in.begin();
+        return !boost::spirit::x3::parse(pos, in.end(), p) && (pos == in.begin());
+    }
+
     template <typename Char, typename Parser, typename Attr>
     bool test_attr(Char const* in, Parser const& p
         , Attr& attr, bool full_match = true)


### PR DESCRIPTION
Fixes https://github.com/boostorg/spirit/issues/524

Due to a bug in the condition evaluated by:
`((sizeof(Char) <= sizeof(char_type)) || encoding::ischar(ch))`
invalid Unicode literals would test `true` which is erroneous and when used with `x3::unicode::alpha` would create an out-of-bounds access in the `category_lookup(::boost::uint32_t ch)` function.