### PR TITLE
X3: Remove bool->char->bool conversion

### DIFF
--- a/include/boost/spirit/home/x3/support/no_case.hpp
+++ b/include/boost/spirit/home/x3/support/no_case.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
     struct case_compare
     {
         template < template <typename> class basic_charset>
-        typename Encoding::char_type
+        bool
         in_set( typename Encoding::char_type const ch
               , basic_charset<typename Encoding::char_type> const &set)
         {
@@ -45,7 +45,7 @@ namespace boost { namespace spirit { namespace x3
     struct no_case_compare
     {
         template < template <typename> class basic_charset>
-        typename Encoding::char_type
+        bool
         in_set( typename Encoding::char_type const ch
               , basic_charset<typename Encoding::char_type> const &set)
         {


### PR DESCRIPTION
MSVC barfs on implicit conversion to `bool` here, and it is indeed suspicious.

I have no idea why `in_set` return type is a char type, the method name itself suggests that it returns boolean value. The only used template parameter type seems to be `basic_set` and its `test` method return `bool`. https://github.com/boostorg/spirit/blob/9cf7a3ef739d57d091ed3812a54481cc877b0a56/include/boost/spirit/home/support/char_set/basic_chset.hpp#L35-L39
The usages of `in_set` method also seem to expect a boolean value from it. https://github.com/boostorg/spirit/blob/9cf7a3ef739d57d091ed3812a54481cc877b0a56/include/boost/spirit/home/x3/char/char_set.hpp#L99