### PR TITLE
Sprinkle BOOST_CONSTEXPR on constexpr ifs.

### DIFF
--- a/include/boost/spirit/home/classic/core/primitives/impl/numerics.ipp
+++ b/include/boost/spirit/home/classic/core/primitives/impl/numerics.ipp
@@ -162,7 +162,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             //  Use this accumulator if number is positive
             static bool add(T& n, T digit)
             {
-                if (std::numeric_limits<T>::is_specialized)
+                if BOOST_CONSTEXPR (std::numeric_limits<T>::is_specialized)
                 {
                     static T const max = (std::numeric_limits<T>::max)();
                     static T const max_div_radix = max/Radix;
@@ -192,7 +192,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
             //  Use this accumulator if number is negative
             static bool add(T& n, T digit)
             {
-                if (std::numeric_limits<T>::is_specialized)
+                if BOOST_CONSTEXPR (std::numeric_limits<T>::is_specialized)
                 {
                     typedef std::numeric_limits<T> num_limits;
                     static T const min =
@@ -384,8 +384,11 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
                 bool            got_a_number = n_match;
                 exp_match_t     e_hit;
 
-                if (!got_a_number && !RealPoliciesT::allow_leading_dot)
-                     return scan.no_match();
+                if (!got_a_numberà
+                {
+                    if BOOST_CONSTEXPR (!RealPoliciesT::allow_leading_dot)
+                        return scan.no_match();
+                }
                 else
                     count += n_match.length();
 
@@ -410,11 +413,10 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
                         else
                             n += hit.value();
                         count += hit.length() + 1;
-
                     }
-
-                    else if (!got_a_number ||
-                        !RealPoliciesT::allow_trailing_dot)
+                    else if BOOST_CONSTEXPR (!RealPoliciesT::allow_trailing_dot)
+                        return scan.no_match();
+                    else if(!got_a_number)
                         return scan.no_match();
 
                     e_hit = RealPoliciesT::parse_exp(scan);
@@ -430,8 +432,11 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
                     //  If we must expect a dot and we didn't see
                     //  an exponent, return early with a no-match.
                     e_hit = RealPoliciesT::parse_exp(scan);
-                    if (RealPoliciesT::expect_dot && !e_hit)
-                        return scan.no_match();
+                    if BOOST_CONSTEXPR (RealPoliciesT::expect_dot)
+                    {
+                        if(!e_hit)
+                            return scan.no_match();
+                    }
                 }
 
                 if (e_hit)

--- a/include/boost/spirit/home/classic/utility/impl/escape_char.ipp
+++ b/include/boost/spirit/home/classic/utility/impl/escape_char.ipp
@@ -80,19 +80,22 @@ namespace impl {
                                 while (scan.first != scan.last)
                                 {
                                     char_t c = *scan.first;
-                                    if (hex > lim && impl::isxdigit_(c))
+                                    if BOOST_CONSTEXPR ( impl::isxdigit_(c))
                                     {
-                                        // overflow detected
-                                        scan.first = save;
-                                        return scan.no_match();
+                                        if(hex > lim)
+                                        {
+                                            // overflow detected
+                                            scan.first = save;
+                                            return scan.no_match();
+                                        }
                                     }
-                                    if (impl::isdigit_(c))
+                                    if BOOST_CONSTEXPR (impl::isdigit_(c))
                                     {
                                         hex <<= 4;
                                         hex |= c - '0';
                                         ++scan.first;
                                     }
-                                    else if (impl::isxdigit_(c))
+                                    else if BOOST_CONSTEXPR (impl::isxdigit_(c))
                                     {
                                         hex <<= 4;
                                         c = impl::toupper_(c);
@@ -166,7 +169,7 @@ namespace impl {
             return scan.no_match(); // overflow detected
         }
     };
-#if (defined(BOOST_MSVC) && (BOOST_MSVC <= 1310))
+#if (defined(BOOST_MSVC))
 #pragma warning(pop)
 #endif
 

--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -304,7 +304,7 @@ namespace boost { namespace spirit { namespace karma
                 if (f(sink, context, delim))
                 {
                     // do a post-delimit if this is an implied verbatim
-                    if (is_same<delimiter_type, unused_type>::value)
+                    if BOOST_CONSTEXPR (is_same<delimiter_type, unused_type>::value)
                         karma::delimit_out(sink, delim);
 
                     return true;
@@ -340,7 +340,7 @@ namespace boost { namespace spirit { namespace karma
                 if (f(sink, context, delim))
                 {
                     // do a post-delimit if this is an implied verbatim
-                    if (is_same<delimiter_type, unused_type>::value)
+                    if BOOST_CONSTEXPR (is_same<delimiter_type, unused_type>::value)
                         karma::delimit_out(sink, delim);
 
                     return true;

--- a/include/boost/spirit/home/qi/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/qi/nonterminal/rule.hpp
@@ -288,7 +288,7 @@ namespace boost { namespace spirit { namespace qi
             if (f)
             {
                 // do a preskip if this is an implied lexeme
-                if (is_same<skipper_type, unused_type>::value)
+                if BOOST_CONSTEXPR (is_same<skipper_type, unused_type>::value)
                     qi::skip_over(first, last, skipper);
 
                 // do down-stream transformation, provides attribute for
@@ -339,7 +339,7 @@ namespace boost { namespace spirit { namespace qi
             if (f)
             {
                 // do a preskip if this is an implied lexeme
-                if (is_same<skipper_type, unused_type>::value)
+                if BOOST_CONSTEXPR (is_same<skipper_type, unused_type>::value)
                     qi::skip_over(first, last, skipper);
 
                 // do down-stream transformation, provides attribute for

--- a/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/numeric_utils.hpp
@@ -123,7 +123,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         template <typename Char>
         inline static unsigned digit(Char ch)
         {
-            if (Radix <= 10 || (ch >= '0' && ch <= '9'))
+            if BOOST_CONSTEXPR (Radix <= 10)
+                return ch - '0';
+            else if (ch >= '0' && ch <= '9')
                 return ch - '0';
             return spirit::char_encoding::ascii::tolower(ch) - 'a' + 10;
         }
@@ -210,9 +212,10 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         {
             std::size_t const overflow_free = digits_traits<T, Radix>::value - 1;
 
-            if (!AlwaysCheckOverflow && (count < overflow_free))
+            if BOOST_CONSTEXPR (!AlwaysCheckOverflow)
             {
-                Accumulator::add(n, ch, mpl::false_());
+                if(count < overflow_free))
+                    Accumulator::add(n, ch, mpl::false_());
             }
             else
             {
@@ -294,7 +297,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         }                                                                     \
         if (!extractor::call(ch, count, val))                                 \
         {                                                                     \
-            if (IgnoreOverflowDigits)                                         \
+            if BOOST_CONSTEXPR (IgnoreOverflowDigits)                                         \
             {                                                                 \
                 first = it;                                                   \
             }                                                                 \
@@ -330,7 +333,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
             Iterator it = first;
             std::size_t leading_zeros = 0;
-            if (!Accumulate)
+            if BOOST_CONSTEXPR (!Accumulate)
             {
                 // skip leading zeros
                 while (it != last && *it == '0' && (MaxDigits < 0 || leading_zeros < static_cast< std::size_t >(MaxDigits)))
@@ -433,7 +436,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
             Iterator it = first;
             std::size_t count = 0;
-            if (!Accumulate)
+            if BOOST_CONSTEXPR (!Accumulate)
             {
                 // skip leading zeros
                 while (it != last && *it == '0')

--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -69,8 +69,11 @@ namespace boost { namespace spirit { namespace traits
 
             // return false if exp exceeds the max_exp
             // do this check only for primitive types!
-            if (is_floating_point<T>() && (exp > max_exp))
-                return false;
+            if BOOST_CONSTEXPR (is_floating_point<T>())
+            {
+                if (exp > max_exp)
+                    return false;
+            }
             n = acc_n * pow10<T>(exp);
         }
         else
@@ -84,9 +87,11 @@ namespace boost { namespace spirit { namespace traits
                 // return false if exp still exceeds the min_exp
                 // do this check only for primitive types!
                 exp += -min_exp;
-                if (is_floating_point<T>() && exp < min_exp)
-                    return false;
-
+                if BOOST_CONSTEXPR (is_floating_point<T>())
+                {
+                    if(exp < min_exp)
+                        return false;
+                }
                 n /= pow10<T>(-exp);
             }
             else

--- a/include/boost/spirit/home/support/detail/hold_any.hpp
+++ b/include/boost/spirit/home/support/detail/hold_any.hpp
@@ -271,7 +271,7 @@ namespace boost { namespace spirit
             if (table == x_table) {
             // if so, we can avoid deallocating and re-use memory
                 table->destruct(&object);    // first destruct the old content
-                if (spirit::detail::get_table<T>::is_small::value) {
+                if BOOST_CONSTEXPR (spirit::detail::get_table<T>::is_small::value) {
                     // create copy on-top of object pointer itself
                     new (&object) T(x);
                 }
@@ -281,7 +281,7 @@ namespace boost { namespace spirit
                 }
             }
             else {
-                if (spirit::detail::get_table<T>::is_small::value) {
+                if BOOST_CONSTEXPR (spirit::detail::get_table<T>::is_small::value) {
                     // create copy on-top of object pointer itself
                     table->destruct(&object); // first destruct the old content
                     new (&object) T(x);
@@ -352,9 +352,10 @@ namespace boost { namespace spirit
             if (type() != BOOST_CORE_TYPEID(T))
               throw bad_any_cast(type(), BOOST_CORE_TYPEID(T));
 
-            return spirit::detail::get_table<T>::is_small::value ?
-                *reinterpret_cast<T const*>(&object) :
-                *reinterpret_cast<T const*>(object);
+            if BOOST_CONSTEXPR (spirit::detail::get_table<T>::is_small::value)
+                return *reinterpret_cast<T const*>(&object)
+            else
+                return *reinterpret_cast<T const*>(object);
         }
 
 // implicit casting is disabled by default for compatibility with boost::any

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -112,7 +112,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         template <typename Char>
         inline static bool is_valid(Char ch)
         {
-            if (Radix <= 10)
+            if BOOST_CONSTEXPR (Radix <= 10)
                 return (ch >= '0' && ch <= static_cast<Char>('0' + Radix -1));
             return (ch >= '0' && ch <= '9')
                 || (ch >= 'a' && ch <= static_cast<Char>('a' + Radix -10 -1))
@@ -122,7 +122,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         template <typename Char>
         inline static unsigned digit(Char ch)
         {
-            if (Radix <= 10 || (ch >= '0' && ch <= '9'))
+            if BOOST_CONSTEXPR (Radix <= 10)
+                return ch - '0';
+            else if((ch >= '0' && ch <= '9'))
                 return ch - '0';
             return char_encoding::ascii::tolower(ch) - 'a' + 10;
         }
@@ -316,7 +318,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
             Iterator it = first;
             std::size_t leading_zeros = 0;
-            if (!Accumulate)
+            if BOOST_CONSTEXPR (!Accumulate)
             {
                 // skip leading zeros
                 while (it != last && *it == '0' && leading_zeros < MaxDigits)
@@ -414,7 +416,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
             Iterator it = first;
             std::size_t count = 0;
-            if (!Accumulate)
+            if BOOST_CONSTEXPR (!Accumulate)
             {
                 // skip leading zeros
                 while (it != last && *it == '0')

--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -39,8 +39,11 @@ namespace boost { namespace spirit { namespace x3 { namespace extension
         {
             // return false if exp exceeds the max_exp
             // do this check only for primitive types!
-            if (is_floating_point<T>() && exp > max_exp)
-                return false;
+            if BOOST_CONSTEXPR (is_floating_point<T>())
+            {
+                if(exp > max_exp)
+                    return false;
+            }
             n *= pow10<T>(exp);
         }
         else
@@ -52,9 +55,11 @@ namespace boost { namespace spirit { namespace x3 { namespace extension
                 // return false if exp still exceeds the min_exp
                 // do this check only for primitive types!
                 exp += -min_exp;
-                if (is_floating_point<T>() && exp < min_exp)
-                    return false;
-
+                if BOOST_CONSTEXPR (is_floating_point<T>())
+                {
+                    if(exp < min_exp)
+                        return false;
+                }
                 n /= pow10<T>(-exp);
             }
             else


### PR DESCRIPTION
These probably don't improve performance, but should inhibit any future compiler warnings about constant conditional expressions (outside of the already worked around MSVC's C4127).

Part 2 of fixes for #537 