### PR TITLE
Add missing includes of assert.hpp

### DIFF
--- a/include/boost/spirit/home/support/char_encoding/standard.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard.hpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <cctype>
+#include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
 
 namespace boost { namespace spirit { namespace char_encoding
@@ -164,4 +165,3 @@ namespace boost { namespace spirit { namespace char_encoding
 }}}
 
 #endif
-

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -15,6 +15,7 @@
 #include <cwctype>
 #include <string>
 
+#include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/spirit/home/support/assert_msg.hpp>
 
@@ -211,4 +212,3 @@ namespace boost { namespace spirit { namespace char_encoding
 }}}
 
 #endif
-


### PR DESCRIPTION
This fixes a regression introduced by 5a217a5e033d34b016fef41ee95e311bc1a24140.