### PR TITLE
X3: Fix `parse_rule` definition check

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -20,6 +20,8 @@
 #include <boost/spirit/home/x3/nonterminal/simple_trace.hpp>
 #endif
 
+#include <type_traits>
+
 namespace boost { namespace spirit { namespace x3
 {
     template <typename ID>
@@ -191,7 +193,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             typedef
                 decltype(parse_rule(
                     rule<ID, Attribute>(), first, last
-                  , make_unique_context<ID>(rhs, context), attr))
+                  , make_unique_context<ID>(rhs, context), std::declval<Attribute&>()))
             parse_rule_result;
 
             // If there is no BOOST_SPIRIT_DEFINE for this rule,

--- a/test/x3/rule_separate_tu.cpp
+++ b/test/x3/rule_separate_tu.cpp
@@ -12,6 +12,30 @@
 
 #include "test.hpp"
 
+namespace sem_act {
+
+namespace x3 = boost::spirit::x3;
+
+auto nop = [](auto const&){};
+
+x3::rule<class used_attr1_r, int> used_attr1;
+auto const used_attr1_def = used_attr::grammar[nop];
+BOOST_SPIRIT_DEFINE(used_attr1);
+
+x3::rule<class used_attr2_r, int> used_attr2;
+auto const used_attr2_def = unused_attr::grammar[nop];
+BOOST_SPIRIT_DEFINE(used_attr2);
+
+x3::rule<class unused_attr1_r> unused_attr1;
+auto const unused_attr1_def = used_attr::grammar[nop];
+BOOST_SPIRIT_DEFINE(unused_attr1);
+
+x3::rule<class unused_attr2_r> unused_attr2;
+auto const unused_attr2_def = unused_attr::grammar[nop];
+BOOST_SPIRIT_DEFINE(unused_attr2);
+
+}
+
 int main()
 {
     using spirit_test::test;
@@ -33,6 +57,14 @@ int main()
         BOOST_TEST_EQ(i, 123);
         BOOST_TEST(test_attr(" 42", used_attr::grammar, i, used_attr::skipper));
         BOOST_TEST_EQ(i, 42);
+    }
+
+    {
+        long i;
+        BOOST_TEST(test_attr("123", sem_act::used_attr1, i));
+        BOOST_TEST(test_attr("===", sem_act::used_attr2, i));
+        BOOST_TEST(test("123", sem_act::unused_attr1));
+        BOOST_TEST(test("===", sem_act::unused_attr2));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Regressed in #457.

Fixes #548.