### PR TITLE
X3: Hide `unused_type` streaming operators

### DIFF
--- a/include/boost/spirit/home/x3/support/unused.hpp
+++ b/include/boost/spirit/home/x3/support/unused.hpp
@@ -43,19 +43,19 @@ namespace boost { namespace spirit { namespace x3
         {
             return {};
         }
+
+        friend std::ostream& operator<<(std::ostream& out, unused_type const&)
+        {
+            return out;
+        }
+
+        friend std::istream& operator>>(std::istream& in, unused_type&)
+        {
+            return in;
+        }
     };
 
     auto const unused = unused_type{};
-
-    inline std::ostream& operator<<(std::ostream& out, unused_type const&)
-    {
-        return out;
-    }
-
-    inline std::istream& operator>>(std::istream& in, unused_type&)
-    {
-        return in;
-    }
 }}}
 
 #endif

--- a/test/x3/unused_type.cpp
+++ b/test/x3/unused_type.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/spirit/home/x3/support/unused.hpp>
 #include <type_traits>
+#include <iostream>
 
 void test_use(boost::spirit::x3::unused_type) {}
 
@@ -31,4 +32,8 @@ int main()
     test_use(0);
     test_use(unused);
     test_use(unused_mut);
+
+    std::cout << unused;
+    std::cout << unused_mut;
+    std::cin >> unused_mut;
 }


### PR DESCRIPTION
The `unused_type` has an implicit constructor from any type, because of that
ADL can find and match its streaming operator for any type. Removing they from namespace scope fixes #552.
