### PR TITLE
Rename variables and suppress warnings about hiding global declaratio…

### DIFF
--- a/include/boost/spirit/home/x3/core/action.hpp
+++ b/include/boost/spirit/home/x3/core/action.hpp
@@ -83,8 +83,8 @@ namespace boost { namespace spirit { namespace x3
             attribute_type;
 
             // synthesize the attribute since one is not supplied
-            attribute_type attr{};
-            return parse_main(first, last, context, rcontext, attr);
+            attribute_type attribute{};
+            return parse_main(first, last, context, rcontext, attribute);
         }
         
         // main parse function

--- a/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/transform_attribute.hpp
@@ -25,9 +25,9 @@ namespace boost { namespace spirit { namespace x3
 
         static Transformed pre(Exposed&) { return Transformed(); }
 
-        static void post(Exposed& val, Transformed&& attr)
+        static void post(Exposed& val, Transformed&& attribute)
         {
-            traits::move_to(std::forward<Transformed>(attr), val);
+            traits::move_to(std::forward<Transformed>(attribute), val);
         }
     };
 

--- a/include/boost/spirit/home/x3/operator/detail/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/alternative.hpp
@@ -79,9 +79,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
         template <typename Attribute_>
         static Attribute_&
-        call(Attribute_& attr, mpl::true_)
+        call(Attribute_& attribute, mpl::true_)
         {
-            return attr;
+            return attribute;
         }
 
         template <typename Attribute_>
@@ -93,9 +93,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
         template <typename Attribute_>
         static type
-        call(Attribute_& attr)
+        call(Attribute_& attribute)
         {
-            return call(attr, is_same<Attribute_, typename remove_reference<type>::type>());
+            return call(attribute, is_same<Attribute_, typename remove_reference<type>::type>());
         }
     };
 
@@ -107,9 +107,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         typedef Attribute& type;
 
         static Attribute&
-        call(Attribute& attr)
+        call(Attribute& attribute)
         {
-            return attr;
+            return attribute;
         }
     };
 
@@ -170,25 +170,25 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     struct move_if<true>
     {
         template<typename T1, typename T2>
-        static void call(T1& attr_, T2& attr)
+        static void call(T1& attr_, T2& attribute)
         {
-            traits::move_to(attr_, attr);
+            traits::move_to(attr_, attribute);
         }
     };
 
     template <typename Parser, typename Iterator, typename Context
       , typename RContext, typename Attribute>
     bool parse_alternative(Parser const& p, Iterator& first, Iterator const& last
-      , Context const& context, RContext& rcontext, Attribute& attr)
+      , Context const& context, RContext& rcontext, Attribute& attribute)
     {
         using pass = detail::pass_variant_attribute<Parser, Attribute, Context>;
         using pseudo = traits::pseudo_attribute<Context, typename pass::type, Iterator>;
 
-        typename pseudo::type attr_ = pseudo::call(first, last, pass::call(attr));
+        typename pseudo::type attr_ = pseudo::call(first, last, pass::call(attribute));
 
         if (p.parse(first, last, context, rcontext, attr_))
         {
-            move_if<!std::is_reference<decltype(attr_)>::value>::call(attr_, attr);
+            move_if<!std::is_reference<decltype(attr_)>::value>::call(attr_, attribute);
             return true;
         }
         return false;
@@ -219,29 +219,29 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool call(
             parser_type const& parser
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr, mpl::false_)
+          , Context const& context, RContext& rcontext, Attribute& attribute, mpl::false_)
         {
-            return detail::parse_into_container(parser.left, first, last, context, rcontext, attr)
-                || detail::parse_into_container(parser.right, first, last, context, rcontext, attr);
+            return detail::parse_into_container(parser.left, first, last, context, rcontext, attribute)
+                || detail::parse_into_container(parser.right, first, last, context, rcontext, attribute);
         }
 
         template <typename Iterator, typename Attribute>
         static bool call(
             parser_type const& parser
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr, mpl::true_)
+          , Context const& context, RContext& rcontext, Attribute& attribute, mpl::true_)
         {
-            return detail::parse_into_container(alternative_helper<Left>{parser.left}, first, last, context, rcontext, attr)
-                || detail::parse_into_container(alternative_helper<Right>{parser.right}, first, last, context, rcontext, attr);
+            return detail::parse_into_container(alternative_helper<Left>{parser.left}, first, last, context, rcontext, attribute)
+                || detail::parse_into_container(alternative_helper<Right>{parser.right}, first, last, context, rcontext, attribute);
         }
 
         template <typename Iterator, typename Attribute>
         static bool call(
             parser_type const& parser
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr)
+          , Context const& context, RContext& rcontext, Attribute& attribute)
         {
-            return call(parser, first, last, context, rcontext, attr,
+            return call(parser, first, last, context, rcontext, attribute,
                 typename traits::is_variant<typename traits::container_value<Attribute>::type>::type{});
         }
     };

--- a/include/boost/spirit/home/x3/operator/detail/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/sequence.hpp
@@ -80,9 +80,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             typename fusion::result_of::begin<Attribute>::type
         >::type type;
 
-        static type call(Attribute& attr)
+        static type call(Attribute& attribute)
         {
-            return fusion::deref(fusion::begin(attr));
+            return fusion::deref(fusion::begin(attribute));
         }
     };
 
@@ -93,9 +93,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
         template <typename Attribute_>
         static Attribute_&
-        call(Attribute_& attr)
+        call(Attribute_& attribute)
         {
-            return attr;
+            return attribute;
         }
     };
 

--- a/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/detail/extract_int.hpp
@@ -298,6 +298,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 # pragma warning(push)
 # pragma warning(disable: 4127)   // conditional expression is constant
+# pragma warning(disable: 4459)   // declaration hides global declaration
 #endif
         template <typename Iterator, typename Attribute>
         inline static bool
@@ -396,6 +397,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 # pragma warning(push)
 # pragma warning(disable: 4127)   // conditional expression is constant
+# pragma warning(disable: 4459)   // declaration hides global declaration
 #endif
         template <typename Iterator, typename Attribute>
         inline static bool

--- a/include/boost/spirit/home/x3/support/traits/pseudo_attribute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/pseudo_attribute.hpp
@@ -24,9 +24,9 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         using attribute_type = Attribute;
         using type = Attribute;
 
-        static type&& call(Iterator&, Iterator const&, attribute_type&& attr)
+        static type&& call(Iterator&, Iterator const&, attribute_type&& attribute)
         {
-            return std::forward<type>(attr);
+            return std::forward<type>(attribute);
         }
     };
 }}}}


### PR DESCRIPTION
…ns with local declarations.

This silences some occurrences of C4459 when using VS2019.