### PR TITLE
Added static assertion for meaningless rule attribute qualifiers

### DIFF
--- a/include/boost/spirit/home/karma/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/karma/nonterminal/rule.hpp
@@ -15,8 +15,6 @@
 #include <boost/config.hpp>
 #include <boost/function.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #include <boost/fusion/include/vector.hpp>
@@ -40,8 +38,11 @@
 #include <boost/spirit/home/karma/nonterminal/detail/generator_binder.hpp>
 #include <boost/spirit/home/karma/nonterminal/detail/parameterized.hpp>
 
+#include <boost/static_assert.hpp>
 #include <boost/proto/extends.hpp>
 #include <boost/proto/traits.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_reference.hpp>
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
@@ -136,9 +137,10 @@ namespace boost { namespace spirit { namespace karma
         typedef typename
             spirit::detail::attr_from_sig<sig_type>::type
         attr_type;
-        typedef typename add_reference<
-            typename add_const<attr_type>::type>::type
-        attr_reference_type;
+        BOOST_STATIC_ASSERT_MSG(
+            !is_reference<attr_type>::value && !is_const<attr_type>::value,
+            "Const/reference qualifiers on Karma rule attribute are meaningless");
+        typedef attr_type const& attr_reference_type;
 
         // parameter_types is a sequence of types passed as parameters to the rule
         typedef typename

--- a/include/boost/spirit/home/qi/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/qi/nonterminal/rule.hpp
@@ -16,7 +16,6 @@
 #include <boost/config.hpp>
 #include <boost/function.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_same.hpp>
 
@@ -42,6 +41,7 @@
 
 #include <boost/proto/extends.hpp>
 #include <boost/proto/traits.hpp>
+#include <boost/type_traits/is_reference.hpp>
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
@@ -130,7 +130,10 @@ namespace boost { namespace spirit { namespace qi
         typedef typename
             spirit::detail::attr_from_sig<sig_type>::type
         attr_type;
-        typedef typename add_reference<attr_type>::type attr_reference_type;
+        BOOST_STATIC_ASSERT_MSG(
+            !is_reference<attr_type>::value,
+            "Reference qualifier on Qi rule attribute is meaningless");
+        typedef attr_type& attr_reference_type;
 
         // parameter_types is a sequence of types passed as parameters to the rule
         typedef typename

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -73,6 +73,9 @@ namespace boost { namespace spirit { namespace x3
     template <typename ID, typename Attribute, bool force_attribute_>
     struct rule : parser<rule<ID, Attribute>>
     {
+        static_assert(!std::is_reference<Attribute>::value,
+                      "Reference qualifier on rule attribute type is meaningless");
+
         typedef ID id;
         typedef Attribute attribute_type;
         static bool const has_attribute =

--- a/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/karma/nonterminal/subrule.hpp
@@ -27,6 +27,7 @@
 #include <boost/spirit/home/support/nonterminal/locals.hpp>
 #include <boost/spirit/repository/home/support/subrule_context.hpp>
 
+#include <boost/static_assert.hpp>
 #include <boost/fusion/include/as_map.hpp>
 #include <boost/fusion/include/at_key.hpp>
 #include <boost/fusion/include/cons.hpp>
@@ -43,7 +44,8 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/proto/extends.hpp>
 #include <boost/proto/traits.hpp>
-#include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
@@ -392,8 +394,10 @@ namespace boost { namespace spirit { namespace repository { namespace karma
         typedef typename
             spirit::detail::attr_from_sig<sig_type>::type
         attr_type;
-        typedef typename add_reference<
-            typename add_const<attr_type>::type>::type attr_reference_type;
+        BOOST_STATIC_ASSERT_MSG(
+            !is_reference<attr_type>::value && !is_const<attr_type>::value,
+            "Const/reference qualifiers on Karma subrule attribute are meaningless");
+        typedef attr_type const& attr_reference_type;
 
         // parameter_types is a sequence of types passed as parameters to the subrule
         typedef typename

--- a/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
+++ b/include/boost/spirit/repository/home/qi/nonterminal/subrule.hpp
@@ -27,6 +27,7 @@
 #include <boost/spirit/home/support/nonterminal/locals.hpp>
 #include <boost/spirit/repository/home/support/subrule_context.hpp>
 
+#include <boost/static_assert.hpp>
 #include <boost/fusion/include/as_map.hpp>
 #include <boost/fusion/include/at_key.hpp>
 #include <boost/fusion/include/cons.hpp>
@@ -43,7 +44,7 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/proto/extends.hpp>
 #include <boost/proto/traits.hpp>
-#include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
@@ -415,7 +416,10 @@ namespace boost { namespace spirit { namespace repository { namespace qi
         typedef typename
             spirit::detail::attr_from_sig<sig_type>::type
         attr_type;
-        typedef typename add_reference<attr_type>::type attr_reference_type;
+        BOOST_STATIC_ASSERT_MSG(
+            !is_reference<attr_type>::value,
+            "Reference qualifier on Qi subrule attribute type is meaningless");
+        typedef attr_type& attr_reference_type;
 
         // parameter_types is a sequence of types passed as parameters to the subrule
         typedef typename


### PR DESCRIPTION
```cpp
qi::rule<char const*, int()>        // ok
qi::rule<char const*, int const()>  // ok, but strange
qi::rule<char const*, int&()>       // meaningless reference
qi::rule<char const*, int const&()> // meaningless reference

ka::rule<char const*, int()>        // ok
ka::rule<char const*, int const()>  // meaningless const
ka::rule<char const*, int&()>       // meaningless reference
ka::rule<char const*, int const&()> // meaningless const and reference
```