### PR TITLE
_WIN32 does not always imply wchar_t is UTF-16

### DIFF
--- a/include/boost/spirit/home/karma/detail/output_iterator.hpp
+++ b/include/boost/spirit/home/karma/detail/output_iterator.hpp
@@ -191,7 +191,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
        // wchar_t is only 16-bits on Windows. If BOOST_SPIRIT_UNICODE is
        // defined, the character type is 32-bits wide so we need to make
        // sure the buffer is at least that wide.
-#if (defined(_WIN32) || defined(__CYGWIN__)) && defined(BOOST_SPIRIT_UNICODE)
+#if (defined(_MSC_VER) || (__SIZEOF_WCHAR_T__ == 2 && defined(__STDC_ISO_10646__))) && defined(BOOST_SPIRIT_UNICODE)
        typedef spirit::char_encoding::unicode::char_type buffer_char_type;
 #else
        typedef wchar_t buffer_char_type;

--- a/include/boost/spirit/home/support/utf8.hpp
+++ b/include/boost/spirit/home/support/utf8.hpp
@@ -68,8 +68,8 @@ namespace boost { namespace spirit
         return result;
     }
 
-    // Assume wchar_t content is UTF-16 on Windows and UCS-4 on Unix
-#if defined(_WIN32) || defined(__CYGWIN__)
+    // Assume wchar_t content is UTF-16 on MSVC, or mingw/wineg++ with -fshort-wchar
+#if defined(_MSC_VER) || (__SIZEOF_WCHAR_T__ == 2 && defined(__STDC_ISO_10646__))
     inline utf8_string to_utf8(wchar_t value)
     {
         utf8_string result;

--- a/include/boost/spirit/home/x3/support/utility/utf8.hpp
+++ b/include/boost/spirit/home/x3/support/utility/utf8.hpp
@@ -63,8 +63,8 @@ namespace boost { namespace spirit { namespace x3
         return result;
     }
 
-    // Assume wchar_t content is UTF-16 on Windows and UCS-4 on Unix
-#if defined(_WIN32) || defined(__CYGWIN__)
+    // Assume wchar_t content is UTF-16 on MSVC, or mingw/wineg++ with -fshort-wchar
+#if defined(_MSC_VER) || (__SIZEOF_WCHAR_T__ == 2 && defined(__STDC_ISO_10646__))
     inline utf8_string to_utf8(wchar_t value)
     {
         utf8_string result;

--- a/test/qi/to_utf8.cpp
+++ b/test/qi/to_utf8.cpp
@@ -15,8 +15,8 @@ int main()
 {
     using boost::spirit::to_utf8;
 
-    // Assume wchar_t is 16-bit on Windows and 32-bit on Unix
-#if defined(_WIN32) || defined(__CYGWIN__)
+    // Assume wchar_t content is UTF-16 on MSVC, or mingw/wineg++ with -fshort-wchar
+#if defined(_MSC_VER) || (__SIZEOF_WCHAR_T__ == 2 && defined(__STDC_ISO_10646__))
     BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(L'\uFFE1').c_str());
 #else
     BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(L'\U0001F9D0').c_str());

--- a/test/x3/to_utf8.cpp
+++ b/test/x3/to_utf8.cpp
@@ -11,8 +11,8 @@ int main()
 {
     using boost::spirit::x3::to_utf8;
 
-    // Assume wchar_t is 16-bit on Windows and 32-bit on Unix
-#if defined(_WIN32) || defined(__CYGWIN__)
+    // Assume wchar_t content is UTF-16 on MSVC, or mingw/wineg++ with -fshort-wchar
+#if defined(_MSC_VER) || (__SIZEOF_WCHAR_T__ == 2 && defined(__STDC_ISO_10646__))
     BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(L'\uFFE1').c_str());
 #else
     BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(L'\U0001F9D0').c_str());


### PR DESCRIPTION
Upon upgrading to from 1.67.0 to boost 1.72.0, I just discovered #413 has broken builds for us, albiet on a fairly exotic platform (using spirit::qi in a [winelib](https://wiki.winehq.org/Winelib) project)

---

Win32 only defines the types from wtypes.h, like WCHAR, LPWCSTR, etc.
These may or may not be the same thing as wchar_t.

MinGW, cygwin, and wineg++ all support `-f(no-)short-wchar`,
with the caveat that libstdc++ must be compiled with the same option.
Doing so is quite unusual for MinGW or cygwin, but more common for wineg++
as it enables building a winelib app with system glibc/libstdc++.
Win32's WCHAR is then unsigned short, or with C++11 perhaps char16_t.

MSVC does explicitly document that its wchar_t is always UTF16:
https://docs.microsoft.com/en-us/cpp/cpp/char-wchar-t-char16-t-char32-t?view=vs-2019

C99/C++11 compilers should provide `__STDC_ISO_10646__` if wchar_t is unicode

GCC, Clang, and ICC all provide `__SIZEOF_WCHAR_T__` to distinguish
-fshort-wchar (defaulted by mingw/cygwin) from -fno-short-wchar
https://gcc.gnu.org/onlinedocs/gcc-9.2.0/cpp/Common-Predefined-Macros.html

This takes the approach of assuming that a 2-byte unicode wchar_t
might be UTF-16 (and still works if its's actually UCS-2, it just never
finds any surrogate pairs), and 4-byte unicode must be UCS-4.