### PR TITLE
X3: constexprize parsers constructors

### DIFF
--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -33,9 +33,9 @@ namespace boost { namespace spirit { namespace x3
         static bool const handles_container =
             traits::is_container<attribute_type>::value;
         
-        attr_parser(Value const& value)
+        constexpr attr_parser(Value const& value)
           : value_(value) {}
-        attr_parser(Value&& value)
+        constexpr attr_parser(Value&& value)
           : value_(std::move(value)) {}
 
         template <typename Iterator, typename Context
@@ -102,7 +102,7 @@ namespace boost { namespace spirit { namespace x3
     struct attr_gen
     {
         template <typename Value>
-        attr_parser<typename remove_cv<
+        constexpr attr_parser<typename remove_cv<
             typename remove_reference<Value>::type>::type>
         operator()(Value&& value) const
         {
@@ -123,7 +123,7 @@ namespace boost { namespace spirit { namespace x3
         }
     };
 
-    auto const attr = attr_gen{};
+    constexpr auto attr = attr_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/auxiliary/eoi.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eoi.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace spirit { namespace x3
         result_type operator()(eoi_parser const &) const { return "eoi"; }
     };
 
-    auto const eoi = eoi_parser{};
+    constexpr auto eoi = eoi_parser{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/auxiliary/eol.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eol.hpp
@@ -49,7 +49,7 @@ namespace boost { namespace spirit { namespace x3
         result_type operator()(eol_parser const &) const { return "eol"; }
     };
 
-    auto const eol = eol_parser{};
+    constexpr auto eol = eol_parser{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unused_type attribute_type;
         static bool const has_attribute = false;
 
-        semantic_predicate(bool predicate)
+        constexpr semantic_predicate(bool predicate)
           : predicate(predicate) {}
 
         template <typename Iterator, typename Context, typename Attribute>
@@ -40,7 +40,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unused_type attribute_type;
         static bool const has_attribute = false;
 
-        lazy_semantic_predicate(F f)
+        constexpr lazy_semantic_predicate(F f)
           : f(f) {}
 
         template <typename Iterator, typename Context, typename Attribute>
@@ -68,19 +68,19 @@ namespace boost { namespace spirit { namespace x3
             return true;
         }
 
-        inline semantic_predicate operator()(bool predicate) const
+        inline constexpr semantic_predicate operator()(bool predicate) const
         {
             return { predicate };
         }
 
         template <typename F>
-        lazy_semantic_predicate<F> operator()(F f) const
+        constexpr lazy_semantic_predicate<F> operator()(F f) const
         {
             return { f };
         }
     };
 
-    auto const eps = eps_parser{};
+    constexpr auto eps = eps_parser{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace spirit { namespace x3
             return true;
         }
 
-        inline constexpr semantic_predicate operator()(bool predicate) const
+        constexpr semantic_predicate operator()(bool predicate) const
         {
             return { predicate };
         }

--- a/include/boost/spirit/home/x3/auxiliary/guard.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/guard.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unary_parser<Subject, guard<Subject, Handler>> base_type;
         static bool const is_pass_through_unary = true;
 
-        guard(Subject const& subject, Handler handler)
+        constexpr guard(Subject const& subject, Handler handler)
           : base_type(subject), handler(handler) {}
 
         template <typename Iterator, typename Context

--- a/include/boost/spirit/home/x3/binary/binary.hpp
+++ b/include/boost/spirit/home/x3/binary/binary.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_attribute = false;
         typedef unused_type attribute_type;
 
-        binary_lit_parser(V n_)
+        constexpr binary_lit_parser(V n_)
           : n(n_) {}
 
         template <typename Iterator, typename Context, typename Attribute>
@@ -91,7 +91,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename V>
-        binary_lit_parser< V, T, endian, bits> operator()(V n) const
+        constexpr binary_lit_parser< V, T, endian, bits> operator()(V n) const
         {
             return {n};
         }
@@ -99,7 +99,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_MAKE_BINARY_PRIMITIVE(name, endiantype, attrtype, bits)                  \
     typedef any_binary_parser< attrtype, boost::endian::order::endiantype, bits > name##type; \
-    name##type const name = name##type();
+    constexpr name##type name = name##type();
 
 
     BOOST_SPIRIT_MAKE_BINARY_PRIMITIVE(byte_, native, uint_least8_t, 8)

--- a/include/boost/spirit/home/x3/char/char.hpp
+++ b/include/boost/spirit/home/x3/char/char.hpp
@@ -18,15 +18,15 @@ namespace boost { namespace spirit { namespace x3
     namespace standard
     {
         typedef any_char<char_encoding::standard> char_type;
-        auto const char_ = char_type{};
+        constexpr auto char_ = char_type{};
 
-        inline literal_char<char_encoding::standard, unused_type>
+        inline constexpr literal_char<char_encoding::standard, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline literal_char<char_encoding::standard, unused_type>
+        inline constexpr literal_char<char_encoding::standard, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -42,9 +42,9 @@ namespace boost { namespace spirit { namespace x3
     namespace standard_wide
     {
         typedef any_char<char_encoding::standard_wide> char_type;
-        auto const char_ = char_type{};
+        constexpr auto char_ = char_type{};
 
-        inline literal_char<char_encoding::standard_wide, unused_type>
+        inline constexpr literal_char<char_encoding::standard_wide, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -55,15 +55,15 @@ namespace boost { namespace spirit { namespace x3
     namespace ascii
     {
         typedef any_char<char_encoding::ascii> char_type;
-        auto const char_ = char_type{};
+        constexpr auto char_ = char_type{};
 
-        inline literal_char<char_encoding::ascii, unused_type>
+        inline constexpr literal_char<char_encoding::ascii, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline literal_char<char_encoding::ascii, unused_type>
+        inline constexpr literal_char<char_encoding::ascii, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -73,15 +73,15 @@ namespace boost { namespace spirit { namespace x3
     namespace iso8859_1
     {
         typedef any_char<char_encoding::iso8859_1> char_type;
-        auto const char_ = char_type{};
+        constexpr auto char_ = char_type{};
 
-        inline literal_char<char_encoding::iso8859_1, unused_type>
+        inline constexpr literal_char<char_encoding::iso8859_1, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline literal_char<char_encoding::iso8859_1, unused_type>
+        inline constexpr literal_char<char_encoding::iso8859_1, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -99,7 +99,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(char ch)
+            static constexpr type call(char ch)
             {
                 return { ch };
             }
@@ -115,7 +115,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(wchar_t ch)
+            static constexpr type call(wchar_t ch)
             {
                 return { ch };
             }
@@ -131,7 +131,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(char const ch[])
+            static constexpr type call(char const ch[])
             {
                 return { ch[0] };
             }
@@ -147,7 +147,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(wchar_t const ch[] )
+            static constexpr type call(wchar_t const ch[] )
             {
                 return { ch[0] };
             }

--- a/include/boost/spirit/home/x3/char/char.hpp
+++ b/include/boost/spirit/home/x3/char/char.hpp
@@ -20,13 +20,13 @@ namespace boost { namespace spirit { namespace x3
         typedef any_char<char_encoding::standard> char_type;
         constexpr auto char_ = char_type{};
 
-        inline constexpr literal_char<char_encoding::standard, unused_type>
+        constexpr literal_char<char_encoding::standard, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline constexpr literal_char<char_encoding::standard, unused_type>
+        constexpr literal_char<char_encoding::standard, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -44,7 +44,7 @@ namespace boost { namespace spirit { namespace x3
         typedef any_char<char_encoding::standard_wide> char_type;
         constexpr auto char_ = char_type{};
 
-        inline constexpr literal_char<char_encoding::standard_wide, unused_type>
+        constexpr literal_char<char_encoding::standard_wide, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -57,13 +57,13 @@ namespace boost { namespace spirit { namespace x3
         typedef any_char<char_encoding::ascii> char_type;
         constexpr auto char_ = char_type{};
 
-        inline constexpr literal_char<char_encoding::ascii, unused_type>
+        constexpr literal_char<char_encoding::ascii, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline constexpr literal_char<char_encoding::ascii, unused_type>
+        constexpr literal_char<char_encoding::ascii, unused_type>
         lit(wchar_t ch)
         {
             return { ch };
@@ -75,13 +75,13 @@ namespace boost { namespace spirit { namespace x3
         typedef any_char<char_encoding::iso8859_1> char_type;
         constexpr auto char_ = char_type{};
 
-        inline constexpr literal_char<char_encoding::iso8859_1, unused_type>
+        constexpr literal_char<char_encoding::iso8859_1, unused_type>
         lit(char ch)
         {
             return { ch };
         }
 
-        inline constexpr literal_char<char_encoding::iso8859_1, unused_type>
+        constexpr literal_char<char_encoding::iso8859_1, unused_type>
         lit(wchar_t ch)
         {
             return { ch };

--- a/include/boost/spirit/home/x3/char/char_class.hpp
+++ b/include/boost/spirit/home/x3/char/char_class.hpp
@@ -71,7 +71,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_CHAR_CLASS(encoding, name)                                 \
     typedef char_class<char_encoding::encoding, name##_tag> name##_type;           \
-    name##_type const name = name##_type();                                        \
+    constexpr name##_type name = name##_type();                                        \
     /***/
 
 #define BOOST_SPIRIT_X3_CHAR_CLASSES(encoding)                                     \

--- a/include/boost/spirit/home/x3/char/char_class.hpp
+++ b/include/boost/spirit/home/x3/char/char_class.hpp
@@ -71,7 +71,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_CHAR_CLASS(encoding, name)                                 \
     typedef char_class<char_encoding::encoding, name##_tag> name##_type;           \
-    constexpr name##_type name = name##_type();                                        \
+    constexpr name##_type name = name##_type();                                    \
     /***/
 
 #define BOOST_SPIRIT_X3_CHAR_CLASSES(encoding)                                     \

--- a/include/boost/spirit/home/x3/char/char_set.hpp
+++ b/include/boost/spirit/home/x3/char/char_set.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
             !is_same<unused_type, attribute_type>::value;
 
 
-        char_range(char_type from_, char_type to_)
+        constexpr char_range(char_type from_, char_type to_)
           : from(from_), to(to_) {}
 
         template <typename Char, typename Context>

--- a/include/boost/spirit/home/x3/char/literal_char.hpp
+++ b/include/boost/spirit/home/x3/char/literal_char.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace x3
             !is_same<unused_type, attribute_type>::value;
 
         template <typename Char>
-        literal_char(Char ch)
+        constexpr literal_char(Char ch)
           : ch(static_cast<char_type>(ch)) {}
 
         template <typename Char, typename Context>

--- a/include/boost/spirit/home/x3/char/negated_char_parser.hpp
+++ b/include/boost/spirit/home/x3/char/negated_char_parser.hpp
@@ -33,14 +33,14 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Positive>
-    inline constexpr negated_char_parser<Positive>
+    constexpr negated_char_parser<Positive>
     operator~(char_parser<Positive> const& cp)
     {
         return { cp.derived() };
     }
 
     template <typename Positive>
-    inline constexpr Positive const&
+    constexpr Positive const&
     operator~(negated_char_parser<Positive> const& cp)
     {
         return cp.positive;

--- a/include/boost/spirit/home/x3/char/negated_char_parser.hpp
+++ b/include/boost/spirit/home/x3/char/negated_char_parser.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace spirit { namespace x3
     struct negated_char_parser :
         char_parser<negated_char_parser<Positive>>
     {
-        negated_char_parser(Positive const& positive)
+        constexpr negated_char_parser(Positive const& positive)
           : positive(positive) {}
 
         template <typename CharParam, typename Context>
@@ -33,14 +33,14 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Positive>
-    inline negated_char_parser<Positive>
+    inline constexpr negated_char_parser<Positive>
     operator~(char_parser<Positive> const& cp)
     {
         return { cp.derived() };
     }
 
     template <typename Positive>
-    inline Positive const&
+    inline constexpr Positive const&
     operator~(negated_char_parser<Positive> const& cp)
     {
         return cp.positive;

--- a/include/boost/spirit/home/x3/char/unicode.hpp
+++ b/include/boost/spirit/home/x3/char/unicode.hpp
@@ -420,13 +420,13 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_CHAR_CLASS(name)                                         \
     typedef unicode_char_class<name##_tag> name##_type;                          \
-    name##_type const name = name##_type();                                      \
+    constexpr name##_type name = name##_type();                                      \
     /***/
 
     namespace unicode
     {
         typedef any_char<char_encoding::unicode> char_type;
-        auto const char_ = char_type{};
+        constexpr auto char_ = char_type{};
 
     ///////////////////////////////////////////////////////////////////////////
     //  Unicode Major Categories

--- a/include/boost/spirit/home/x3/char/unicode.hpp
+++ b/include/boost/spirit/home/x3/char/unicode.hpp
@@ -420,7 +420,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_CHAR_CLASS(name)                                         \
     typedef unicode_char_class<name##_tag> name##_type;                          \
-    constexpr name##_type name = name##_type();                                      \
+    constexpr name##_type name = name##_type();                                  \
     /***/
 
     namespace unicode

--- a/include/boost/spirit/home/x3/core/action.hpp
+++ b/include/boost/spirit/home/x3/core/action.hpp
@@ -100,7 +100,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename P, typename Action>
-    inline constexpr action<typename extension::as_parser<P>::value_type, Action>
+    constexpr action<typename extension::as_parser<P>::value_type, Action>
     operator/(P const& p, Action f)
     {
         return { as_parser(p), f };

--- a/include/boost/spirit/home/x3/core/action.hpp
+++ b/include/boost/spirit/home/x3/core/action.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const has_action = true;
 
-        action(Subject const& subject, Action f)
+        constexpr action(Subject const& subject, Action f)
           : base_type(subject), f(f) {}
 
         template <typename Iterator, typename Context, typename RuleContext, typename Attribute>
@@ -100,7 +100,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename P, typename Action>
-    inline action<typename extension::as_parser<P>::value_type, Action>
+    inline constexpr action<typename extension::as_parser<P>::value_type, Action>
     operator/(P const& p, Action f)
     {
         return { as_parser(p), f };

--- a/include/boost/spirit/home/x3/core/parser.hpp
+++ b/include/boost/spirit/home/x3/core/parser.hpp
@@ -45,19 +45,19 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = false;
         static bool const has_action = false;
 
-        Derived const& derived() const
+        constexpr Derived const& derived() const
         {
             return *static_cast<Derived const*>(this);
         }
 
         template <typename Action>
-        action<Derived, Action> operator[](Action f) const
+        constexpr action<Derived, Action> operator[](Action f) const
         {
             return { this->derived(), f };
         }
 
         template <typename Handler>
-        guard<Derived, Handler> on_error(Handler f) const
+        constexpr guard<Derived, Handler> on_error(Handler f) const
         {
             return { this->derived(), f };
         }
@@ -73,7 +73,7 @@ namespace boost { namespace spirit { namespace x3
         typedef Subject subject_type;
         static bool const has_action = Subject::has_action;
 
-        unary_parser(Subject const& subject)
+        constexpr unary_parser(Subject const& subject)
             : subject(subject) {}
 
         unary_parser const& get_unary() const { return *this; }
@@ -90,7 +90,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_action =
             left_type::has_action || right_type::has_action;
 
-        binary_parser(Left const& left, Right const& right)
+        constexpr binary_parser(Left const& left, Right const& right)
             : left(left), right(right) {}
 
         binary_parser const& get_binary() const { return *this; }
@@ -141,7 +141,7 @@ namespace boost { namespace spirit { namespace x3
         {
             typedef unused_type type;
             typedef unused_type value_type;
-            static type call(unused_type)
+            static constexpr type call(unused_type)
             {
                 return unused;
             }
@@ -153,7 +153,7 @@ namespace boost { namespace spirit { namespace x3
         {
             typedef Derived const& type;
             typedef Derived value_type;
-            static type call(Derived const& p)
+            static constexpr type call(Derived const& p)
             {
                 return p;
             }
@@ -164,7 +164,7 @@ namespace boost { namespace spirit { namespace x3
         {
             typedef Derived const& type;
             typedef Derived value_type;
-            static type call(parser<Derived> const& p)
+            static constexpr type call(parser<Derived> const& p)
             {
                 return p.derived();
             }
@@ -172,14 +172,14 @@ namespace boost { namespace spirit { namespace x3
     }
 
     template <typename T>
-    inline typename extension::as_parser<T>::type
+    inline constexpr typename extension::as_parser<T>::type
     as_parser(T const& x)
     {
         return extension::as_parser<T>::call(x);
     }
 
     template <typename Derived>
-    inline Derived const&
+    inline constexpr Derived const&
     as_parser(parser<Derived> const& p)
     {
         return p.derived();

--- a/include/boost/spirit/home/x3/core/parser.hpp
+++ b/include/boost/spirit/home/x3/core/parser.hpp
@@ -172,14 +172,14 @@ namespace boost { namespace spirit { namespace x3
     }
 
     template <typename T>
-    inline constexpr typename extension::as_parser<T>::type
+    constexpr typename extension::as_parser<T>::type
     as_parser(T const& x)
     {
         return extension::as_parser<T>::call(x);
     }
 
     template <typename Derived>
-    inline constexpr Derived const&
+    constexpr Derived const&
     as_parser(parser<Derived> const& p)
     {
         return p.derived();

--- a/include/boost/spirit/home/x3/core/proxy.hpp
+++ b/include/boost/spirit/home/x3/core/proxy.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace spirit { namespace x3
     {
         static bool const is_pass_through_unary = true;
 
-        proxy(Subject const& subject)
+        constexpr proxy(Subject const& subject)
           : unary_parser<Subject, Derived>(subject) {}
 
         // Overload this when appropriate. The proxy parser will pick up

--- a/include/boost/spirit/home/x3/directive/confix.hpp
+++ b/include/boost/spirit/home/x3/directive/confix.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        confix_directive(Prefix const& prefix
+        constexpr confix_directive(Prefix const& prefix
                          , Subject const& subject
                          , Postfix const& postfix) :
             base_type(subject),
@@ -58,7 +58,7 @@ namespace boost { namespace spirit { namespace x3
     struct confix_gen
     {
         template<typename Subject>
-        confix_directive<
+        constexpr confix_directive<
             Prefix, typename extension::as_parser<Subject>::value_type, Postfix>
         operator[](Subject const& subject) const
         {
@@ -71,7 +71,7 @@ namespace boost { namespace spirit { namespace x3
 
 
     template<typename Prefix, typename Postfix>
-    confix_gen<typename extension::as_parser<Prefix>::value_type,
+    constexpr confix_gen<typename extension::as_parser<Prefix>::value_type,
                typename extension::as_parser<Postfix>::value_type>
     confix(Prefix const& prefix, Postfix const& postfix)
     {

--- a/include/boost/spirit/home/x3/directive/expect.hpp
+++ b/include/boost/spirit/home/x3/directive/expect.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unary_parser<Subject, expect_directive<Subject> > base_type;
         static bool const is_pass_through_unary = true;
 
-        expect_directive(Subject const& subject)
+        constexpr expect_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -66,14 +66,14 @@ namespace boost { namespace spirit { namespace x3
     struct expect_gen
     {
         template <typename Subject>
-        expect_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr expect_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const expect = expect_gen{};
+    constexpr auto expect = expect_gen{};
 }}}
 
 namespace boost { namespace spirit { namespace x3 { namespace detail

--- a/include/boost/spirit/home/x3/directive/lexeme.hpp
+++ b/include/boost/spirit/home/x3/directive/lexeme.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        lexeme_directive(Subject const& subject)
+        constexpr lexeme_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -65,14 +65,14 @@ namespace boost { namespace spirit { namespace x3
     struct lexeme_gen
     {
         template <typename Subject>
-        lexeme_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr lexeme_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const lexeme = lexeme_gen{};
+    constexpr auto lexeme = lexeme_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/matches.hpp
+++ b/include/boost/spirit/home/x3/directive/matches.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_attribute = true;
         using attribute_type = bool;
 
-        matches_directive(Subject const& subject) : base_type(subject) {}
+        constexpr matches_directive(Subject const& subject) : base_type(subject) {}
 
         template <typename Iterator, typename Context
           , typename RContext, typename Attribute>
@@ -38,14 +38,14 @@ namespace boost { namespace spirit { namespace x3
     struct matches_gen
     {
         template <typename Subject>
-        matches_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr matches_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const matches = matches_gen{};
+    constexpr auto matches = matches_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/no_case.hpp
+++ b/include/boost/spirit/home/x3/directive/no_case.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        no_case_directive(Subject const& subject)
+        constexpr no_case_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -41,14 +41,14 @@ namespace boost { namespace spirit { namespace x3
     struct no_case_gen
     {
         template <typename Subject>
-        no_case_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr no_case_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const no_case = no_case_gen{};
+    constexpr auto no_case = no_case_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/no_skip.hpp
+++ b/include/boost/spirit/home/x3/directive/no_skip.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        no_skip_directive(Subject const& subject)
+        constexpr no_skip_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -65,14 +65,14 @@ namespace boost { namespace spirit { namespace x3
     struct no_skip_gen
     {
         template <typename Subject>
-        no_skip_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr no_skip_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const no_skip = no_skip_gen{};
+    constexpr auto no_skip = no_skip_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/omit.hpp
+++ b/include/boost/spirit/home/x3/directive/omit.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_attribute = false;
 
         typedef Subject subject_type;
-        omit_directive(Subject const& subject)
+        constexpr omit_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context, typename RContext>
@@ -38,14 +38,14 @@ namespace boost { namespace spirit { namespace x3
     struct omit_gen
     {
         template <typename Subject>
-        omit_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr omit_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const omit = omit_gen{};
+    constexpr auto omit = omit_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/raw.hpp
+++ b/include/boost/spirit/home/x3/directive/raw.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const handles_container = Subject::handles_container;
         typedef Subject subject_type;
 
-        raw_directive(Subject const& subject)
+        constexpr raw_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -58,14 +58,14 @@ namespace boost { namespace spirit { namespace x3
     struct raw_gen
     {
         template <typename Subject>
-        raw_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr raw_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const raw = raw_gen{};
+    constexpr auto raw = raw_gen{};
 
     namespace traits
     {

--- a/include/boost/spirit/home/x3/directive/repeat.hpp
+++ b/include/boost/spirit/home/x3/directive/repeat.hpp
@@ -55,7 +55,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = true;
 
-        repeat_directive(Subject const& subject, RepeatCountLimit const& repeat_limit_)
+        constexpr repeat_directive(Subject const& subject, RepeatCountLimit const& repeat_limit_)
           : base_type(subject)
           , repeat_limit(repeat_limit_)
         {}
@@ -91,12 +91,12 @@ namespace boost { namespace spirit { namespace x3
 
     // Infinite loop tag type
     struct inf_type {};
-    const inf_type inf = inf_type();
+    constexpr inf_type inf = inf_type();
 
     struct repeat_gen
     {
         template<typename Subject>
-        auto operator[](Subject const& subject) const
+        constexpr auto operator[](Subject const& subject) const
         {
             return *as_parser(subject);
         }
@@ -104,12 +104,12 @@ namespace boost { namespace spirit { namespace x3
         template <typename T>
         struct repeat_gen_lvl1
         {
-            repeat_gen_lvl1(T&& repeat_limit_)
+            constexpr repeat_gen_lvl1(T&& repeat_limit_)
               : repeat_limit(repeat_limit_)
             {}
 
             template<typename Subject>
-            repeat_directive< typename extension::as_parser<Subject>::value_type, T>
+            constexpr repeat_directive< typename extension::as_parser<Subject>::value_type, T>
             operator[](Subject const& subject) const
             {
                 return { as_parser(subject),repeat_limit };
@@ -119,28 +119,28 @@ namespace boost { namespace spirit { namespace x3
         };
 
         template <typename T>
-        repeat_gen_lvl1<detail::exact_count<T>>
+        constexpr repeat_gen_lvl1<detail::exact_count<T>>
         operator()(T const exact) const
         {
             return { detail::exact_count<T>{exact} };
         }
 
         template <typename T>
-        repeat_gen_lvl1<detail::finite_count<T>>
+        constexpr repeat_gen_lvl1<detail::finite_count<T>>
         operator()(T const min_val, T const max_val) const
         {
             return { detail::finite_count<T>{min_val,max_val} };
         }
 
         template <typename T>
-        repeat_gen_lvl1<detail::infinite_count<T>>
+        constexpr repeat_gen_lvl1<detail::infinite_count<T>>
         operator()(T const min_val, inf_type const &) const
         {
             return { detail::infinite_count<T>{min_val} };
         }
     };
 
-    auto const repeat = repeat_gen{};
+    constexpr auto repeat = repeat_gen{};
 }}}
 
 namespace boost { namespace spirit { namespace x3 { namespace traits

--- a/include/boost/spirit/home/x3/directive/seek.hpp
+++ b/include/boost/spirit/home/x3/directive/seek.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        seek_directive(Subject const& subject) :
+        constexpr seek_directive(Subject const& subject) :
             base_type(subject) {}
 
         template<typename Iterator, typename Context
@@ -53,14 +53,14 @@ namespace boost { namespace spirit { namespace x3
     struct seek_gen
     {
         template<typename Subject>
-        seek_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr seek_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const seek = seek_gen{};
+    constexpr auto seek = seek_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/skip.hpp
+++ b/include/boost/spirit/home/x3/directive/skip.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        reskip_directive(Subject const& subject)
+        constexpr reskip_directive(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -62,7 +62,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const is_pass_through_unary = true;
         static bool const handles_container = Subject::handles_container;
 
-        skip_directive(Subject const& subject, Skipper const& skipper)
+        constexpr skip_directive(Subject const& subject, Skipper const& skipper)
           : base_type(subject)
           , skipper(skipper)
         {}
@@ -87,11 +87,11 @@ namespace boost { namespace spirit { namespace x3
         template <typename Skipper>
         struct skip_gen
         {
-            skip_gen(Skipper const& skipper)
+            constexpr skip_gen(Skipper const& skipper)
               : skipper_(skipper) {}
 
             template <typename Subject>
-            skip_directive<typename extension::as_parser<Subject>::value_type, Skipper>
+            constexpr skip_directive<typename extension::as_parser<Subject>::value_type, Skipper>
             operator[](Subject const& subject) const
             {
                 return { as_parser(subject), skipper_ };
@@ -101,20 +101,20 @@ namespace boost { namespace spirit { namespace x3
         };
 
         template <typename Skipper>
-        skip_gen<Skipper> const operator()(Skipper const& skipper) const
+        constexpr skip_gen<Skipper> const operator()(Skipper const& skipper) const
         {
             return { skipper };
         }
 
         template <typename Subject>
-        reskip_directive<typename extension::as_parser<Subject>::value_type>
+        constexpr reskip_directive<typename extension::as_parser<Subject>::value_type>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject) };
         }
     };
 
-    auto const skip = reskip_gen{};
+    constexpr auto skip = reskip_gen{};
 }}}
 
 #endif

--- a/include/boost/spirit/home/x3/directive/with.hpp
+++ b/include/boost/spirit/home/x3/directive/with.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace spirit { namespace x3
 
         typedef Subject subject_type;
 
-        with_directive(Subject const& subject, T&& val)
+        constexpr with_directive(Subject const& subject, T&& val)
           : base_type(subject, std::forward<T>(val)) {}
 
         template <typename Iterator, typename Context
@@ -69,7 +69,7 @@ namespace boost { namespace spirit { namespace x3
         T&& val;
 
         template <typename Subject>
-        with_directive<typename extension::as_parser<Subject>::value_type, ID, T>
+        constexpr with_directive<typename extension::as_parser<Subject>::value_type, ID, T>
         operator[](Subject const& subject) const
         {
             return { as_parser(subject), std::forward<T>(val) };
@@ -77,7 +77,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename ID, typename T>
-    inline with_gen<ID, T> with(T&& val)
+    inline constexpr with_gen<ID, T> with(T&& val)
     {
         return { std::forward<T>(val) };
     }

--- a/include/boost/spirit/home/x3/directive/with.hpp
+++ b/include/boost/spirit/home/x3/directive/with.hpp
@@ -77,7 +77,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename ID, typename T>
-    inline constexpr with_gen<ID, T> with(T&& val)
+    constexpr with_gen<ID, T> with(T&& val)
     {
         return { std::forward<T>(val) };
     }

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const force_attribute =
             force_attribute_;
 
-        rule_definition(RHS const& rhs, char const* name)
+        constexpr rule_definition(RHS const& rhs, char const* name)
           : rhs(rhs), name(name) {}
 
         template <typename Iterator, typename Context, typename Attribute_>
@@ -87,13 +87,13 @@ namespace boost { namespace spirit { namespace x3
 #if !defined(BOOST_SPIRIT_X3_NO_RTTI)
         rule() : name(typeid(rule).name()) {}
 #else
-        rule() : name("unnamed") {}
+        constexpr rule() : name("unnamed") {}
 #endif
 
-        rule(char const* name)
+        constexpr rule(char const* name)
           : name(name) {}
 
-        rule(rule const& r)
+        constexpr rule(rule const& r)
           : name(r.name)
         {
             // Assert that we are not copying an unitialized static rule. If
@@ -103,7 +103,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename RHS>
-        rule_definition<
+        constexpr rule_definition<
             ID, typename extension::as_parser<RHS>::value_type, Attribute, force_attribute_>
         operator=(RHS const& rhs) const
         {
@@ -111,7 +111,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename RHS>
-        rule_definition<
+        constexpr rule_definition<
             ID, typename extension::as_parser<RHS>::value_type, Attribute, true>
         operator%=(RHS const& rhs) const
         {

--- a/include/boost/spirit/home/x3/numeric/bool.hpp
+++ b/include/boost/spirit/home/x3/numeric/bool.hpp
@@ -21,10 +21,10 @@ namespace boost { namespace spirit { namespace x3
         typedef T attribute_type;
         static bool const has_attribute = true;
 
-        bool_parser()
+        constexpr bool_parser()
         	: policies() {}
 
-        bool_parser(BoolPolicies const& policies)
+        constexpr bool_parser(BoolPolicies const& policies)
         	: policies(policies) {}
 
         template <typename Iterator, typename Context>
@@ -61,11 +61,11 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_attribute = true;
 
         template <typename Value>
-        literal_bool_parser(Value const& n)
+        constexpr literal_bool_parser(Value const& n)
         	: policies(), n_(n) {}
 
         template <typename Value>
-        literal_bool_parser(Value const& n, BoolPolicies const& policies)
+        constexpr literal_bool_parser(Value const& n, BoolPolicies const& policies)
         	: policies(policies), n_(n) {}
 
         template <typename Iterator, typename Context>
@@ -105,51 +105,51 @@ namespace boost { namespace spirit { namespace x3
     namespace standard
     {
         typedef bool_parser<bool, char_encoding::standard> bool_type;
-        bool_type const bool_ = {};
+        constexpr bool_type bool_ = {};
 
         typedef literal_bool_parser<bool, char_encoding::standard> true_type;
-        true_type const true_ = { true };
+        constexpr true_type true_ = { true };
 
         typedef literal_bool_parser<bool, char_encoding::standard> false_type;
-        false_type const false_ = { false };
+        constexpr false_type false_ = { false };
     }
 
 #ifndef BOOST_SPIRIT_NO_STANDARD_WIDE
     namespace standard_wide
     {
         typedef bool_parser<bool, char_encoding::standard_wide> bool_type;
-        bool_type const bool_ = {};
+        constexpr bool_type bool_ = {};
 
         typedef literal_bool_parser<bool, char_encoding::standard_wide> true_type;
-        true_type const true_ = { true };
+        constexpr true_type true_ = { true };
 
         typedef literal_bool_parser<bool, char_encoding::standard_wide> false_type;
-        false_type const false_ = { false };
+        constexpr false_type false_ = { false };
     }
 #endif
 
     namespace ascii
     {
         typedef bool_parser<bool, char_encoding::ascii> bool_type;
-        bool_type const bool_ = {};
+        constexpr bool_type bool_ = {};
 
         typedef literal_bool_parser<bool, char_encoding::ascii> true_type;
-        true_type const true_ = { true };
+        constexpr true_type true_ = { true };
 
         typedef literal_bool_parser<bool, char_encoding::ascii> false_type;
-        false_type const false_ = { false };
+        constexpr false_type false_ = { false };
     }
 
     namespace iso8859_1
     {
         typedef bool_parser<bool, char_encoding::iso8859_1> bool_type;
-        bool_type const bool_ = {};
+        constexpr bool_type bool_ = {};
 
         typedef literal_bool_parser<bool, char_encoding::iso8859_1> true_type;
-        true_type const true_ = { true };
+        constexpr true_type true_ = { true };
 
         typedef literal_bool_parser<bool, char_encoding::iso8859_1> false_type;
-        false_type const false_ = { false };
+        constexpr false_type false_ = { false };
     }
 
     using standard::bool_;

--- a/include/boost/spirit/home/x3/numeric/int.hpp
+++ b/include/boost/spirit/home/x3/numeric/int.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_INT_PARSER(int_type, name)                              \
     typedef int_parser<int_type> name##type;                                    \
-    constexpr name##type name = {};                                                 \
+    constexpr name##type name = {};                                             \
     /***/
 
     BOOST_SPIRIT_X3_INT_PARSER(long, long_)

--- a/include/boost/spirit/home/x3/numeric/int.hpp
+++ b/include/boost/spirit/home/x3/numeric/int.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_INT_PARSER(int_type, name)                              \
     typedef int_parser<int_type> name##type;                                    \
-    name##type const name = {};                                                 \
+    constexpr name##type name = {};                                                 \
     /***/
 
     BOOST_SPIRIT_X3_INT_PARSER(long, long_)

--- a/include/boost/spirit/home/x3/numeric/real.hpp
+++ b/include/boost/spirit/home/x3/numeric/real.hpp
@@ -20,10 +20,10 @@ namespace boost { namespace spirit { namespace x3
         typedef T attribute_type;
         static bool const has_attribute = true;
 
-        real_parser()
+        constexpr real_parser()
         	: policies() {}
 
-        real_parser(RealPolicies const& policies)
+        constexpr real_parser(RealPolicies const& policies)
         	: policies(policies) {}
 
         template <typename Iterator, typename Context>
@@ -52,13 +52,13 @@ namespace boost { namespace spirit { namespace x3
     };
 
     typedef real_parser<float> float_type;
-    float_type const float_ = {};
+    constexpr float_type float_ = {};
 
     typedef real_parser<double> double_type;
-    double_type const double_ = {};
+    constexpr double_type double_ = {};
 
     typedef real_parser<long double> long_double_type;
-    long_double_type const long_double = {};
+    constexpr long_double_type long_double = {};
 
 }}}
 

--- a/include/boost/spirit/home/x3/numeric/uint.hpp
+++ b/include/boost/spirit/home/x3/numeric/uint.hpp
@@ -60,7 +60,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_UINT_PARSER(uint_type, radix, name)                     \
     typedef uint_parser<uint_type, radix> name##type;                           \
-    constexpr name##type name = name##type();                                       \
+    constexpr name##type name = name##type();                                   \
     /***/
 
     BOOST_SPIRIT_X3_UINT_PARSER(unsigned, 2, bin)

--- a/include/boost/spirit/home/x3/numeric/uint.hpp
+++ b/include/boost/spirit/home/x3/numeric/uint.hpp
@@ -60,7 +60,7 @@ namespace boost { namespace spirit { namespace x3
 
 #define BOOST_SPIRIT_X3_UINT_PARSER(uint_type, radix, name)                     \
     typedef uint_parser<uint_type, radix> name##type;                           \
-    name##type const name = name##type();                                       \
+    constexpr name##type name = name##type();                                       \
     /***/
 
     BOOST_SPIRIT_X3_UINT_PARSER(unsigned, 2, bin)

--- a/include/boost/spirit/home/x3/operator/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/alternative.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline constexpr alternative<
+    constexpr alternative<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator|(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/alternative.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef binary_parser<Left, Right, alternative<Left, Right>> base_type;
 
-        alternative(Left const& left, Right const& right)
+        constexpr alternative(Left const& left, Right const& right)
             : base_type(left, right) {}
 
         template <typename Iterator, typename Context, typename RContext>
@@ -42,7 +42,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline alternative<
+    inline constexpr alternative<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator|(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/and_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/and_predicate.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline constexpr and_predicate<typename extension::as_parser<Subject>::value_type>
+    constexpr and_predicate<typename extension::as_parser<Subject>::value_type>
     operator&(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/and_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/and_predicate.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unused_type attribute_type;
         static bool const has_attribute = false;
 
-        and_predicate(Subject const& subject)
+        constexpr and_predicate(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -33,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline and_predicate<typename extension::as_parser<Subject>::value_type>
+    inline constexpr and_predicate<typename extension::as_parser<Subject>::value_type>
     operator&(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/difference.hpp
+++ b/include/boost/spirit/home/x3/operator/difference.hpp
@@ -48,7 +48,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline constexpr difference<
+    constexpr difference<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator-(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/difference.hpp
+++ b/include/boost/spirit/home/x3/operator/difference.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
         typedef binary_parser<Left, Right, difference<Left, Right>> base_type;
         static bool const handles_container = Left::handles_container;
 
-        difference(Left const& left, Right const& right)
+        constexpr difference(Left const& left, Right const& right)
           : base_type(left, right) {}
 
         template <typename Iterator, typename Context
@@ -40,7 +40,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename Left_, typename Right_>
-        difference<Left_, Right_>
+        constexpr difference<Left_, Right_>
         make(Left_ const& left, Right_ const& right) const
         {
             return { left, right };
@@ -48,7 +48,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline difference<
+    inline constexpr difference<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator-(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/kleene.hpp
+++ b/include/boost/spirit/home/x3/operator/kleene.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline constexpr kleene<typename extension::as_parser<Subject>::value_type>
+    constexpr kleene<typename extension::as_parser<Subject>::value_type>
     operator*(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/kleene.hpp
+++ b/include/boost/spirit/home/x3/operator/kleene.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unary_parser<Subject, kleene<Subject>> base_type;
         static bool const handles_container = true;
 
-        kleene(Subject const& subject)
+        constexpr kleene(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -37,7 +37,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline kleene<typename extension::as_parser<Subject>::value_type>
+    inline constexpr kleene<typename extension::as_parser<Subject>::value_type>
     operator*(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/list.hpp
+++ b/include/boost/spirit/home/x3/operator/list.hpp
@@ -48,7 +48,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline constexpr list<
+    constexpr list<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator%(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/list.hpp
+++ b/include/boost/spirit/home/x3/operator/list.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const handles_container = true;
         static bool const has_attribute = true;
 
-        list(Left const& left, Right const& right)
+        constexpr list(Left const& left, Right const& right)
           : base_type(left, right) {}
 
         template <typename Iterator, typename Context
@@ -48,7 +48,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline list<
+    inline constexpr list<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator%(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/not_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/not_predicate.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unused_type attribute_type;
         static bool const has_attribute = false;
 
-        not_predicate(Subject const& subject)
+        constexpr not_predicate(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -33,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline not_predicate<typename extension::as_parser<Subject>::value_type>
+    inline constexpr not_predicate<typename extension::as_parser<Subject>::value_type>
     operator!(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/not_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/not_predicate.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline constexpr not_predicate<typename extension::as_parser<Subject>::value_type>
+    constexpr not_predicate<typename extension::as_parser<Subject>::value_type>
     operator!(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/optional.hpp
+++ b/include/boost/spirit/home/x3/operator/optional.hpp
@@ -64,7 +64,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline constexpr optional<typename extension::as_parser<Subject>::value_type>
+    constexpr optional<typename extension::as_parser<Subject>::value_type>
     operator-(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/optional.hpp
+++ b/include/boost/spirit/home/x3/operator/optional.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace spirit { namespace x3
         typedef proxy<Subject, optional<Subject>> base_type;
         static bool const handles_container = true;
 
-        optional(Subject const& subject)
+        constexpr optional(Subject const& subject)
           : base_type(subject) {}
 
         using base_type::parse_subject;
@@ -64,7 +64,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline optional<typename extension::as_parser<Subject>::value_type>
+    inline constexpr optional<typename extension::as_parser<Subject>::value_type>
     operator-(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/plus.hpp
+++ b/include/boost/spirit/home/x3/operator/plus.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline constexpr plus<typename extension::as_parser<Subject>::value_type>
+    constexpr plus<typename extension::as_parser<Subject>::value_type>
     operator+(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/plus.hpp
+++ b/include/boost/spirit/home/x3/operator/plus.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace spirit { namespace x3
         typedef unary_parser<Subject, plus<Subject>> base_type;
         static bool const handles_container = true;
 
-        plus(Subject const& subject)
+        constexpr plus(Subject const& subject)
           : base_type(subject) {}
 
         template <typename Iterator, typename Context
@@ -41,7 +41,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Subject>
-    inline plus<typename extension::as_parser<Subject>::value_type>
+    inline constexpr plus<typename extension::as_parser<Subject>::value_type>
     operator+(Subject const& subject)
     {
         return { as_parser(subject) };

--- a/include/boost/spirit/home/x3/operator/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/sequence.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline constexpr sequence<
+    constexpr sequence<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator>>(Left const& left, Right const& right)

--- a/include/boost/spirit/home/x3/operator/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/sequence.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef binary_parser<Left, Right, sequence<Left, Right>> base_type;
 
-        sequence(Left const& left, Right const& right)
+        constexpr sequence(Left const& left, Right const& right)
             : base_type(left, right) {}
 
         template <typename Iterator, typename Context, typename RContext>
@@ -47,7 +47,7 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Left, typename Right>
-    inline sequence<
+    inline constexpr sequence<
         typename extension::as_parser<Left>::value_type
       , typename extension::as_parser<Right>::value_type>
     operator>>(Left const& left, Right const& right)
@@ -56,7 +56,7 @@ namespace boost { namespace spirit { namespace x3
     }
 
     template <typename Left, typename Right>
-    auto operator>(Left const& left, Right const& right)
+    constexpr auto operator>(Left const& left, Right const& right)
     {
         return left >> expect[right];
     }

--- a/include/boost/spirit/home/x3/string/literal_string.hpp
+++ b/include/boost/spirit/home/x3/string/literal_string.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace standard
     {
-        inline constexpr literal_string<char const*, char_encoding::standard>
+        constexpr literal_string<char const*, char_encoding::standard>
         string(char const* s)
         {
             return { s };
@@ -80,7 +80,7 @@ namespace boost { namespace spirit { namespace x3
 #ifndef BOOST_SPIRIT_NO_STANDARD_WIDE
     namespace standard_wide
     {
-        inline constexpr literal_string<wchar_t const*, char_encoding::standard_wide>
+        constexpr literal_string<wchar_t const*, char_encoding::standard_wide>
         string(wchar_t const* s)
         {
             return { s };
@@ -92,7 +92,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline constexpr literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
+        constexpr literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
         lit(wchar_t const* s)
         {
             return { s };
@@ -109,7 +109,7 @@ namespace boost { namespace spirit { namespace x3
 #if defined(BOOST_SPIRIT_X3_UNICODE)
     namespace unicode
     {
-        inline constexpr literal_string<char32_t const*, char_encoding::unicode>
+        constexpr literal_string<char32_t const*, char_encoding::unicode>
         string(char32_t const* s)
         {
             return { s };
@@ -121,7 +121,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline constexpr literal_string<char32_t const*, char_encoding::unicode, unused_type>
+        constexpr literal_string<char32_t const*, char_encoding::unicode, unused_type>
         lit(char32_t const* s)
         {
             return { s };
@@ -137,7 +137,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace ascii
     {
-        inline constexpr literal_string<wchar_t const*, char_encoding::ascii>
+        constexpr literal_string<wchar_t const*, char_encoding::ascii>
         string(wchar_t const* s)
         {
             return { s };
@@ -149,7 +149,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline constexpr literal_string<char const*, char_encoding::ascii, unused_type>
+        constexpr literal_string<char const*, char_encoding::ascii, unused_type>
         lit(char const* s)
         {
             return { s };
@@ -165,7 +165,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace iso8859_1
     {
-        inline constexpr literal_string<wchar_t const*, char_encoding::iso8859_1>
+        constexpr literal_string<wchar_t const*, char_encoding::iso8859_1>
         string(wchar_t const* s)
         {
             return { s };
@@ -177,7 +177,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline constexpr literal_string<char const*, char_encoding::iso8859_1, unused_type>
+        constexpr literal_string<char const*, char_encoding::iso8859_1, unused_type>
         lit(char const* s)
         {
             return { s };

--- a/include/boost/spirit/home/x3/string/literal_string.hpp
+++ b/include/boost/spirit/home/x3/string/literal_string.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace spirit { namespace x3
             !is_same<unused_type, attribute_type>::value;
         static bool const handles_container = has_attribute;
 
-        literal_string(typename add_reference< typename add_const<String>::type >::type str)
+        constexpr literal_string(typename add_reference< typename add_const<String>::type >::type str)
           : str(str)
         {}
 
@@ -51,7 +51,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace standard
     {
-        inline literal_string<char const*, char_encoding::standard>
+        inline constexpr literal_string<char const*, char_encoding::standard>
         string(char const* s)
         {
             return { s };
@@ -63,7 +63,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<char const*, char_encoding::standard, unused_type>
+        inline constexpr literal_string<char const*, char_encoding::standard, unused_type>
         lit(char const* s)
         {
             return { s };
@@ -80,7 +80,7 @@ namespace boost { namespace spirit { namespace x3
 #ifndef BOOST_SPIRIT_NO_STANDARD_WIDE
     namespace standard_wide
     {
-        inline literal_string<wchar_t const*, char_encoding::standard_wide>
+        inline constexpr literal_string<wchar_t const*, char_encoding::standard_wide>
         string(wchar_t const* s)
         {
             return { s };
@@ -92,7 +92,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
+        inline constexpr literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
         lit(wchar_t const* s)
         {
             return { s };
@@ -109,7 +109,7 @@ namespace boost { namespace spirit { namespace x3
 #if defined(BOOST_SPIRIT_X3_UNICODE)
     namespace unicode
     {
-        inline literal_string<char32_t const*, char_encoding::unicode>
+        inline constexpr literal_string<char32_t const*, char_encoding::unicode>
         string(char32_t const* s)
         {
             return { s };
@@ -121,7 +121,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<char32_t const*, char_encoding::unicode, unused_type>
+        inline constexpr literal_string<char32_t const*, char_encoding::unicode, unused_type>
         lit(char32_t const* s)
         {
             return { s };
@@ -137,7 +137,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace ascii
     {
-        inline literal_string<wchar_t const*, char_encoding::ascii>
+        inline constexpr literal_string<wchar_t const*, char_encoding::ascii>
         string(wchar_t const* s)
         {
             return { s };
@@ -149,7 +149,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<char const*, char_encoding::ascii, unused_type>
+        inline constexpr literal_string<char const*, char_encoding::ascii, unused_type>
         lit(char const* s)
         {
             return { s };
@@ -165,7 +165,7 @@ namespace boost { namespace spirit { namespace x3
 
     namespace iso8859_1
     {
-        inline literal_string<wchar_t const*, char_encoding::iso8859_1>
+        inline constexpr literal_string<wchar_t const*, char_encoding::iso8859_1>
         string(wchar_t const* s)
         {
             return { s };
@@ -177,7 +177,7 @@ namespace boost { namespace spirit { namespace x3
             return { s };
         }
 
-        inline literal_string<char const*, char_encoding::iso8859_1, unused_type>
+        inline constexpr literal_string<char const*, char_encoding::iso8859_1, unused_type>
         lit(char const* s)
         {
             return { s };
@@ -209,7 +209,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(char const* s)
+            static constexpr type call(char const* s)
             {
                 return type(s);
             }
@@ -228,7 +228,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(wchar_t const* s)
+            static constexpr type call(wchar_t const* s)
             {
                 return type(s);
             }
@@ -247,7 +247,7 @@ namespace boost { namespace spirit { namespace x3
 
             typedef type value_type;
 
-            static type call(char const* s)
+            static constexpr type call(char const* s)
             {
                 return type(s);
             }

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -132,3 +132,5 @@ run rule_separate_tu.cpp rule_separate_tu_grammar ;
 
 obj grammar_linker : grammar.cpp ;
 run grammar_linker.cpp grammar_linker ;
+
+run constexpr.cpp ;

--- a/test/x3/constexpr.cpp
+++ b/test/x3/constexpr.cpp
@@ -1,0 +1,75 @@
+/*=============================================================================
+    Copyright (c) 2015 Joel de Guzman
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#include <boost/detail/lightweight_test.hpp>
+
+#define BOOST_SPIRIT_X3_DISABLE_SIOF_CHECK
+
+#include <boost/spirit/home/x3.hpp>
+#include "test.hpp"
+
+namespace x3 = boost::spirit::x3;
+
+struct my_tag;
+
+constexpr auto parserWord = x3::omit[(x3::alpha | x3::lit('_')) >> *(x3::alnum | x3::lit('_'))];
+
+constexpr x3::rule<struct SIdRule1> rule1("");
+constexpr auto rule1_def = parserWord >>
+	-(
+		x3::lit('[') >>
+		rule1 >>
+		x3::lit(']')
+	);
+
+BOOST_SPIRIT_DEFINE(rule1)
+
+int main()
+{
+    using spirit_test::test_attr;
+    using spirit_test::test;
+
+    {
+        constexpr auto r  = x3::int_ % ',';
+        BOOST_TEST(test("123,456", r));
+    }
+
+    {
+        BOOST_TEST(test("a[b_[c2d]]", rule1));
+    }
+
+    {
+
+        constexpr auto a = x3::lit('a');
+        constexpr auto b = x3::lit('b');
+        constexpr auto c = x3::lit('c');
+        constexpr x3::rule<class r> r("");
+
+        {
+            constexpr auto start =
+                r = *(a | b | c);
+
+            BOOST_TEST(test("abcabcacb", start));
+            BOOST_TEST(test(" a b c a b c a c b ", start, x3::space));
+        }
+
+        {
+            constexpr auto start =
+                r = (a | b) >> (r | b);
+
+            BOOST_TEST(test("aaaabababaaabbb", start));
+            BOOST_TEST(test("aaaabababaaabba", start, false));
+
+            // ignore the skipper!
+            BOOST_TEST(test("aaaabababaaabba", start, x3::space, false));
+
+            BOOST_TEST(test(" a a a a b a b a b a a a b b b ", start, x3::space));
+            BOOST_TEST(test(" a a a a b a b a b a a a b b a ", start, x3::space, false));
+        }
+    }
+
+    return boost::report_errors();
+}

--- a/test/x3/constexpr.cpp
+++ b/test/x3/constexpr.cpp
@@ -5,9 +5,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
-
-#define BOOST_SPIRIT_X3_DISABLE_SIOF_CHECK
-
 #include <boost/spirit/home/x3.hpp>
 #include "test.hpp"
 


### PR DESCRIPTION
Constexpr constructor and constexpr factory function could save valuable execution time. Especially for local parsers, whose construction time could take up to 40% of total execution time in release build and up to 90% in debug build.

1. Some x3 parsers's constructor could easily be constexpr. 
2. unary_parser and binary_parser and all their derived classes cannot directly be constexpr because we introduced Static Initialization Order Fiasco (SIOF) checking (not constexpr) in their constructors in pull request [229](https://github.com/boostorg/spirit/pull/229). I propose that users could have an option to disable this SIOF checking by defining a macro `BOOST_SPIRIT_X3_DISABLE_SIOF_CHECK`. Because

    1) It does not check release build.
    2) The coding style that triggers SIOF is forbidden in many groups. This checking does not bring any benefit in such groups.

Summary: users could use constexpr parsers (except a few ones, e.g. x3::symbols_parser) by defining a macro `BOOST_SPIRIT_X3_DISABLE_SIOF_CHECK` before including x3 headers. This macro will disable SIOF checking. Unit tests are added.