### PR TITLE
X3: Alternate rule placeholder static initialization fiasco check

### DIFF
--- a/include/boost/spirit/home/x3/core/parser.hpp
+++ b/include/boost/spirit/home/x3/core/parser.hpp
@@ -63,23 +63,6 @@ namespace boost { namespace spirit { namespace x3
         }
     };
 
-    namespace detail {
-        template <typename Parser>
-        static void assert_initialized_rule(Parser const& p) {
-            boost::ignore_unused(p);
-
-            // Assert that we are not copying an unitialized static rule. If
-            // the static is in another TU, it may be initialized after we copy
-            // it. If so, its name member will be nullptr.
-            //
-            // Rather than hardcoding behaviour for rule-type subject parsers,
-            // we simply allow get_info<> to do the check in debug builds.
-#ifndef NDEBUG
-            what(p); // note: allows get_info<> to diagnose the issue
-#endif
-        }
-    }
-
     struct unary_category;
     struct binary_category;
 
@@ -91,7 +74,7 @@ namespace boost { namespace spirit { namespace x3
         static bool const has_action = Subject::has_action;
 
         unary_parser(Subject const& subject)
-            : subject(subject) { detail::assert_initialized_rule(subject); }
+            : subject(subject) {}
 
         unary_parser const& get_unary() const { return *this; }
 
@@ -108,11 +91,7 @@ namespace boost { namespace spirit { namespace x3
             left_type::has_action || right_type::has_action;
 
         binary_parser(Left const& left, Right const& right)
-            : left(left), right(right)
-        {
-            detail::assert_initialized_rule(left);
-            detail::assert_initialized_rule(right);
-        }
+            : left(left), right(right) {}
 
         binary_parser const& get_binary() const { return *this; }
 

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -93,6 +93,15 @@ namespace boost { namespace spirit { namespace x3
         rule(char const* name)
           : name(name) {}
 
+        rule(rule const& r)
+          : name(r.name)
+        {
+            // Assert that we are not copying an unitialized static rule. If
+            // the static is in another TU, it may be initialized after we copy
+            // it. If so, its name member will be nullptr.
+            BOOST_ASSERT_MSG(r.name, "uninitialized rule"); // static initialization order fiasco
+        }
+
         template <typename RHS>
         rule_definition<
             ID, typename extension::as_parser<RHS>::value_type, Attribute, force_attribute_>


### PR DESCRIPTION
The previous check was done in a very intrusive way, it also was not catching
the issue when a parser is not inherited from `unary_parser`/`binary_parser`.