### PR TITLE
Qi: Removed interfering specializations from including auto

### DIFF
--- a/include/boost/spirit/home/qi/detail/parse_auto.hpp
+++ b/include/boost/spirit/home/qi/detail/parse_auto.hpp
@@ -42,41 +42,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         }
     };
 
-    // the following specializations are needed to explicitly disambiguate 
-    // the two possible specializations for parse_impl<char> and 
-    // parse_impl<wchar_t>
-    template <>
-    struct parse_impl<char>
-    {
-        template <typename Iterator>
-        static bool call(Iterator& first, Iterator last, char& expr)
-        {
-            return qi::parse(first, last, create_parser<char>(), expr);
-        }
-
-        template <typename Iterator>
-        static bool call(Iterator& first, Iterator last, char const&)
-        {
-            return qi::parse(first, last, create_parser<char>());
-        }
-    };
-
-    template <>
-    struct parse_impl<wchar_t>
-    {
-        template <typename Iterator>
-        static bool call(Iterator& first, Iterator last, wchar_t& expr)
-        {
-            return qi::parse(first, last, create_parser<wchar_t>(), expr);
-        }
-
-        template <typename Iterator>
-        static bool call(Iterator& first, Iterator last, wchar_t const&)
-        {
-            return qi::parse(first, last, create_parser<wchar_t>());
-        }
-    };
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename Expr>
     struct phrase_parse_impl<Expr
@@ -100,49 +65,6 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         {
             return qi::phrase_parse(first, last, create_parser<Expr>()
               , skipper, post_skip, const_cast<Expr&>(expr));
-        }
-    };
-
-    // the following specializations are needed to explicitly disambiguate 
-    // the two possible specializations for phrase_parse_impl<char> and 
-    // phrase_parse_impl<wchar_t>
-    template <>
-    struct phrase_parse_impl<char>
-    {
-        template <typename Iterator, typename Skipper>
-        static bool call(Iterator& first, Iterator last, char& expr
-          , Skipper const& skipper, BOOST_SCOPED_ENUM(skip_flag) post_skip)
-        {
-            return qi::phrase_parse(first, last, create_parser<char>()
-              , skipper, post_skip, expr);
-        }
-
-        template <typename Iterator, typename Skipper>
-        static bool call(Iterator& first, Iterator last, char const&
-          , Skipper const& skipper, BOOST_SCOPED_ENUM(skip_flag) post_skip)
-        {
-            return qi::phrase_parse(first, last, create_parser<char>()
-              , skipper, post_skip);
-        }
-    };
-
-    template <>
-    struct phrase_parse_impl<wchar_t>
-    {
-        template <typename Iterator, typename Skipper>
-        static bool call(Iterator& first, Iterator last, wchar_t& expr
-          , Skipper const& skipper, BOOST_SCOPED_ENUM(skip_flag) post_skip)
-        {
-            return qi::phrase_parse(first, last, create_parser<wchar_t>()
-              , skipper, post_skip, expr);
-        }
-
-        template <typename Iterator, typename Skipper>
-        static bool call(Iterator& first, Iterator last, wchar_t const&
-          , Skipper const& skipper, BOOST_SCOPED_ENUM(skip_flag) post_skip)
-        {
-            return qi::phrase_parse(first, last, create_parser<wchar_t>()
-              , skipper, post_skip);
         }
     };
 }}}}

--- a/test/qi/Jamfile
+++ b/test/qi/Jamfile
@@ -66,7 +66,7 @@ run auto.cpp ;
 run binary.cpp ;
 run bool1.cpp ;
 run bool2.cpp ;
-run char1.cpp : : : <pch>off ; # Enable PCH after fixing interference from including auto.
+run char1.cpp ;
 run char2.cpp ;
 run char_class.cpp : : : <pch>off ;
 run debug.cpp : : : <pch>off ;

--- a/test/qi/auto.cpp
+++ b/test/qi/auto.cpp
@@ -243,5 +243,18 @@ int main()
         BOOST_TEST(test_rule("1 2.0", p, qi::space));
     }
 
+    {
+        // test literal char interference
+        using spirit_test::test;
+        BOOST_TEST(test("x", 'x'));
+        BOOST_TEST(test("x", 'x', qi::space));
+        BOOST_TEST(!test("y", 'x'));
+        BOOST_TEST(!test("y", 'x', qi::space));
+        BOOST_TEST(test(L"x", L'x'));
+        BOOST_TEST(test(L"x", L'x', qi::space));
+        BOOST_TEST(!test(L"y", L'x'));
+        BOOST_TEST(!test(L"y", L'x', qi::space));
+    }
+
     return boost::report_errors();
 }


### PR DESCRIPTION
The specializations replace literal char parsers with auto parser that does
not perform attribute matching.