### PR TITLE
Fix C++20 clang 10 warning -Wdeprecated-anon-enum-enum-conversion in …

### DIFF
--- a/include/boost/spirit/home/karma/detail/output_iterator.hpp
+++ b/include/boost/spirit/home/karma/detail/output_iterator.hpp
@@ -383,7 +383,7 @@ namespace boost { namespace spirit { namespace karma { namespace detail
           , output_iterator<OutputIterator, Properties, Derived>
         >::type most_derived_type;
 
-        enum { properties = Properties::value };
+        static const generator_properties::enum_type properties = static_cast<generator_properties::enum_type>(Properties::value);
 
         typedef typename mpl::if_c<
             (properties & generator_properties::tracking) ? true : false


### PR DESCRIPTION
…output_iterator.hpp

```
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/include/karma.hpp:18:
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma.hpp:15:
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/char.hpp:15:
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/char/char.hpp:25:
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/char/char_generator.hpp:18:
In file included from /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/detail/generate_to.hpp:17:
/data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/detail/output_iterator.hpp:391:25: error: bitwise operation between different enumeration types ('boost::spirit::k
arma::detail::make_output_iterator<std::back_insert_iterator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, mpl_::int_<3>, boost::spirit::unused_
type>::(anonymous enum at /data/mwrep/res/osp/Boost/20-0-0-0/include/boost/spirit/home/karma/detail/output_iterator.hpp:388:9)' and 'boost::spirit::karma::generator_properties::enum
_type') is deprecated [-Werror,-Wdeprecated-anon-enum-enum-conversion]
            (properties & generator_properties::tracking) ? true : false
             ~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```



I am actually unsure "int" is the right type to use here. If for some reason you really want to keep the anonymous enum, then in all operation where you use the "&" operator static_cast<int>(properties) works too.