### PR TITLE
Karma: Do not limit precision of real_inserter

### DIFF
--- a/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
@@ -84,12 +84,6 @@ namespace boost { namespace spirit { namespace karma
 
             // get correct precision for generated number
             unsigned precision = p.precision(n);
-            if (std::numeric_limits<U>::digits10) 
-            {
-                // limit generated precision to digits10, if defined
-                precision = (std::min)(precision, 
-                    (unsigned)std::numeric_limits<U>::digits10 + 1);
-            }
 
             // allow for ADL to find the correct overloads for log10 et.al.
             using namespace std;

--- a/include/boost/spirit/home/karma/numeric/real_policies.hpp
+++ b/include/boost/spirit/home/karma/numeric/real_policies.hpp
@@ -162,8 +162,7 @@ namespace boost { namespace spirit { namespace karma
         //
         //  Note:     If the trailing_zeros flag is not in effect additional
         //            comments apply. See the comment for the fraction_part()
-        //            function below. Moreover, this precision will be limited
-        //            to the value of std::numeric_limits<T>::digits10 + 1
+        //            function below.
         ///////////////////////////////////////////////////////////////////////
         static unsigned precision(T)
         {


### PR DESCRIPTION
Users should be able to decide how much they want to print.
Especially since this implementation does not care about significant digits, which hinders unique serialization when using fixed notation with leading zeros.

AFAIK digits10 and max_digits10 are about the **significant** digits, not the digits in the fractional part.
And for serialization and a string-float-string round-trip you should actually at least allow max_digits10 instead of digits10.

Closes #585