### PR TITLE
Small documentation improvements

### DIFF
--- a/doc/qi/numeric.qbk
+++ b/doc/qi/numeric.qbk
@@ -771,9 +771,10 @@ For models of `RealPolicies` the following expressions must be valid:
                                             If successful, place the result into `n`.]]
     [[`RP::parse_dot(f, l)`]                [Parse the decimal point.
                                             Return `true` if successful, otherwise `false`.]]
-    [[`RP::parse_frac_n(f, l, n)`]          [Parse the fraction after the decimal point.
+    [[`RP::parse_frac_n(f, l, n, d)`]       [Parse the fraction after the decimal point.
                                             Return `true` if successful, otherwise `false`.
-                                            If successful, place the result into `n`.]]
+                                            If successful, place the result into `n` and the
+                                            number of digits into `d`]]
     [[`RP::parse_exp(f, l)`]                [Parse the exponent prefix (e.g. 'e').
                                             Return `true` if successful, otherwise `false`.]]
     [[`RP::parse_exp_n(f, l, n)`]           [Parse the actual exponent.

--- a/example/karma/complex_number_adapt.cpp
+++ b/example/karma/complex_number_adapt.cpp
@@ -90,7 +90,7 @@ namespace client
             //  Begin grammar
             (
                &true_ << '(' << double_ << ", " << double_ << ')'
-            |   omit[bool_]  << double_ 
+            |   omit[bool_]  << double_ << omit[double_]
             ),
             //  End grammar
 

--- a/example/karma/complex_number_easier.cpp
+++ b/example/karma/complex_number_easier.cpp
@@ -70,7 +70,7 @@ namespace client
             //  Begin grammar
             (
                !double_(0.0) << '(' << double_ << ", " << double_ << ')'
-            |   omit[double_] << double_
+            |   omit[double_] << double_ << omit[double_]
             ),
             //  End grammar
 


### PR DESCRIPTION
Bring qi's `RealPolicies` valid expressions section in line with example
- qi's `parse_frac_n` requires four arguments, not three

Bring karma tutorial `complex` example code in line with discussion below
- Discussed code line examples beneath two `complex` examples differed from the full code snippet above (last `omit[double_]` is omitted there because it's redundant, but to me it felt confusing for it to be missing there and appearing in the discussion later without an explanation)