### PR TITLE
Classic: Remove workarounds for unsupported Borland versions

### DIFF
--- a/classic/test/grammar_tests.cpp
+++ b/classic/test/grammar_tests.cpp
@@ -17,15 +17,6 @@
 #include <boost/spirit/include/classic_grammar_def.hpp>
 using namespace BOOST_SPIRIT_CLASSIC_NS;
 
-///////////////////////////////////////////////////////////////////////////////
-//  This feature is disabled on non compliant compilers (e.g. Borland 5.5.1
-//  VC6 and VC7)
-#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && \
-    !BOOST_WORKAROUND(__BORLANDC__, <= 0x551) && \
-    !BOOST_WORKAROUND(__GNUC__, < 3)
-# define BOOST_SPIRIT_USE_GRAMMARDEF
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 //
 //  Grammar tests
@@ -40,27 +31,22 @@ struct num_list : public grammar<num_list>
 
     template <typename ScannerT>
     struct definition
-#if defined(BOOST_SPIRIT_USE_GRAMMARDEF)
     :   public grammar_def<rule<ScannerT>, same>
-#endif
     {
         definition(num_list const& /*self*/)
         {
             num = int_p;
             r = num >> *(',' >> num);
 
-#if defined(BOOST_SPIRIT_USE_GRAMMARDEF)
             this->start_parsers(r, num);
-#endif
+
             BOOST_SPIRIT_DEBUG_RULE(num);
             BOOST_SPIRIT_DEBUG_RULE(r);
         }
 
         rule<ScannerT> r, num;
 
-#if !defined(BOOST_SPIRIT_USE_GRAMMARDEF)
         rule<ScannerT> const& start() const { return r; }
-#endif
     };
 };
 
@@ -74,18 +60,15 @@ struct num_list_ex : public grammar<num_list_ex>
 
     template <typename ScannerT>
     struct definition
-#if defined(BOOST_SPIRIT_USE_GRAMMARDEF)
     :   public grammar_def<rule<ScannerT>, same, int_parser<int, 10, 1, -1> >
-#endif
     {
         definition(num_list_ex const& /*self*/)
         {
             num = integer;
             r = num >> *(',' >> num);
 
-#if defined(BOOST_SPIRIT_USE_GRAMMARDEF)
             this->start_parsers(r, num, integer);
-#endif
+
             BOOST_SPIRIT_DEBUG_RULE(num);
             BOOST_SPIRIT_DEBUG_RULE(r);
         }
@@ -93,9 +76,7 @@ struct num_list_ex : public grammar<num_list_ex>
         rule<ScannerT> r, num;
         int_parser<int, 10, 1, -1> integer;
 
-#if !defined(BOOST_SPIRIT_USE_GRAMMARDEF)
         rule<ScannerT> const& start() const { return r; }
-#endif
     };
 };
 
@@ -110,7 +91,6 @@ grammar_tests()
     BOOST_TEST(pi.hit);
     BOOST_TEST(pi.full);
 
-#if defined(BOOST_SPIRIT_USE_GRAMMARDEF)
     num_list_ex nlistex;
     BOOST_SPIRIT_DEBUG_GRAMMAR(nlistex);
 
@@ -140,7 +120,6 @@ grammar_tests()
         space_p);
     BOOST_TEST(pi.hit);
     BOOST_TEST(pi.full);
-#endif // defined(BOOST_SPIRIT_USE_GRAMMARDEF)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
@@ -114,8 +114,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
 
         class rule_base_access
         {
-#if defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS) \
-    || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#if defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
         public: // YUCK!
 #else
             template <

--- a/include/boost/spirit/home/classic/phoenix/tuples.hpp
+++ b/include/boost/spirit/home/classic/phoenix/tuples.hpp
@@ -21,36 +21,6 @@
 #define PHOENIX_LIMIT 3
 #endif
 
-#if defined(__BORLANDC__) && (__BORLANDC__ <= 0x561)
-namespace phoenix { namespace borland_only
-{
-    namespace ftors
-    {
-        //  We define these dummy template functions. Borland complains when
-        //  a template class has the same name as a template function,
-        //  regardless if they are in different namespaces.
-
-        template <typename T> void if_(T) {}
-        template <typename T> void for_(T) {}
-        template <typename T> void while_(T) {}
-        template <typename T> void do_(T) {}
-    }
-
-    namespace tmpls
-    {
-        //  We define these dummy template functions. Borland complains when
-        //  a template class has the same name as a template function,
-        //  regardless if they are in different namespaces.
-
-        template <typename T> struct if_ {};
-        template <typename T> struct for_ {};
-        template <typename T> struct while_ {};
-        template <typename T> struct do_ {};
-    }
-
-}} // namespace phoenix::borland_only
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/static_assert.hpp>
 #include <boost/call_traits.hpp>


### PR DESCRIPTION
We have had a hard error for `__BORLANDC__ <= 0x570` for a long time to safely remove workarounds for these versions.