### PR TITLE
Cease dependence on Filesystem

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -7,10 +7,6 @@
 #if !defined(BOOST_SPIRIT_X3_ERROR_REPORTING_MAY_19_2014_00405PM)
 #define BOOST_SPIRIT_X3_ERROR_REPORTING_MAY_19_2014_00405PM
 
-#ifndef BOOST_SPIRIT_X3_NO_FILESYSTEM
-#include <boost/filesystem/path.hpp>
-#endif
-
 #include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
 #include <boost/spirit/home/x3/support/utility/utf8.hpp>
 #include <ostream>
@@ -84,12 +80,7 @@ namespace boost { namespace spirit { namespace x3
     {
         if (file != "")
         {
-#ifdef BOOST_SPIRIT_X3_NO_FILESYSTEM
             err_out << "In file " << file << ", ";
-#else
-            namespace fs = boost::filesystem;
-            err_out << "In file " << fs::path(file).generic_string() << ", ";
-#endif
         }
         else
         {

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -63,8 +63,6 @@ rule compile-fail ( sources + : requirements * : target-name ? )
 
 ###############################################################################
 
-alias boost_filesystem : /boost/filesystem//boost_filesystem : <warnings>off <warnings-as-errors>off ;
-
 run actions.cpp ;
 run alternative.cpp ;
 run and_predicate.cpp ;
@@ -124,7 +122,7 @@ run unused_type.cpp ;
 run attribute_type_check.cpp ;
 run fusion_map.cpp ;
 run x3_variant.cpp ;
-run error_handler.cpp boost_filesystem ;
+run error_handler.cpp ;
 run iterator_check.cpp ;
 
 run to_utf8.cpp ;


### PR DESCRIPTION
The `path(string).generic_string()` is effectively a no-op.