### PR TITLE
Avoid using deprecated header to silence compiler warnings

### DIFF
--- a/include/boost/spirit/home/support/detail/scoped_enum_emulation.hpp
+++ b/include/boost/spirit/home/support/detail/scoped_enum_emulation.hpp
@@ -14,7 +14,9 @@
 #include <boost/version.hpp>
 #include <boost/config.hpp>
 
-#if BOOST_VERSION >= 104000
+#if BOOST_VERSION >= 105600
+# include <boost/core/scoped_enum.hpp>
+#elif BOOST_VERSION >= 104000
 # include <boost/detail/scoped_enum_emulation.hpp>
 #else
 # if !defined(BOOST_NO_CXX11_SCOPED_ENUMS)


### PR DESCRIPTION
`boost/detail/scoped_enum_emulation.hpp` is deprecated in favor of `boost/core/scoped_enum.hpp` and generates warnings. It will be removed in a future release.
