### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp
@@ -170,7 +170,7 @@ struct grammar_definition
         }
 
         int
-        undefine(grammar_t* target_grammar)
+        undefine(grammar_t* target_grammar) BOOST_OVERRIDE
         {
             typename grammar_t::object_id id = target_grammar->get_object_id();
 

--- a/include/boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp
@@ -102,7 +102,7 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
 #ifdef BOOST_SPIRIT_THREADSAFE
             boost::unique_lock<boost::mutex> lock(mutex);
 #endif
-            if (free_ids.size())
+            if (!free_ids.empty())
             {
                 object_id id = *free_ids.rbegin();
                 free_ids.pop_back();

--- a/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
+++ b/include/boost/spirit/home/classic/core/non_terminal/impl/rule.ipp
@@ -232,16 +232,16 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_BEGIN
         struct concrete_parser : abstract_parser<ScannerT, AttrT>
         {
             concrete_parser(ParserT const& p_) : p(p_) {}
-            virtual ~concrete_parser() {}
+            ~concrete_parser() BOOST_OVERRIDE {}
 
-            virtual typename match_result<ScannerT, AttrT>::type
-            do_parse_virtual(ScannerT const& scan) const
+            typename match_result<ScannerT, AttrT>::type
+            do_parse_virtual(ScannerT const& scan) const BOOST_OVERRIDE
             {
                 return p.parse(scan);
             }
 
-            virtual abstract_parser<ScannerT, AttrT>*
-            clone() const
+            abstract_parser<ScannerT, AttrT>*
+            clone() const BOOST_OVERRIDE
             {
                 return new concrete_parser(p);
             }

--- a/include/boost/spirit/home/classic/iterator/fixed_size_queue.hpp
+++ b/include/boost/spirit/home/classic/iterator/fixed_size_queue.hpp
@@ -9,9 +9,9 @@
 #ifndef BOOST_SPIRIT_CLASSIC_ITERATOR_FIXED_SIZE_QUEUE_HPP
 #define BOOST_SPIRIT_CLASSIC_ITERATOR_FIXED_SIZE_QUEUE_HPP
 
+#include <cstddef>
 #include <cstdlib>
 #include <iterator>
-#include <cstddef>
 
 #include <boost/spirit/home/classic/namespace.hpp>
 #include <boost/spirit/home/classic/core/assert.hpp> // for BOOST_SPIRIT_ASSERT

--- a/include/boost/spirit/home/classic/iterator/multi_pass.hpp
+++ b/include/boost/spirit/home/classic/iterator/multi_pass.hpp
@@ -150,10 +150,10 @@ class BOOST_SYMBOL_VISIBLE illegal_backtracking : public std::exception
 public:
 
     illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW {}
-    ~illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW {}
+    ~illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
-    virtual const char*
-    what() const BOOST_NOEXCEPT_OR_NOTHROW
+    const char*
+    what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     { return "BOOST_SPIRIT_CLASSIC_NS::illegal_backtracking"; }
 };
 
@@ -163,7 +163,7 @@ public:
 // This policy is most effective when used together with the std_deque
 // StoragePolicy.
 // If used with the fixed_size_queue StoragePolicy, it will not detect
-// iterator derefereces that are out of the range of the queue.
+// iterator dereferences that are out of the range of the queue.
 ///////////////////////////////////////////////////////////////////////////////
 class buf_id_check
 {
@@ -1296,5 +1296,3 @@ BOOST_SPIRIT_CLASSIC_NAMESPACE_END
 }} // namespace BOOST_SPIRIT_CLASSIC_NS
 
 #endif // BOOST_SPIRIT_ITERATOR_MULTI_PASS_HPP
-
-

--- a/include/boost/spirit/home/classic/iterator/position_iterator.hpp
+++ b/include/boost/spirit/home/classic/iterator/position_iterator.hpp
@@ -293,7 +293,7 @@ private:
 
 protected:
 
-    void newline(void)
+    void newline()
     {}
 
     ForwardIteratorT _end;
@@ -396,13 +396,13 @@ public:
         return *this;
     }
 
-    ForwardIteratorT get_currentline_begin(void) const
+    ForwardIteratorT get_currentline_begin() const
     { return _startline; }
 
-    ForwardIteratorT get_currentline_end(void) const
+    ForwardIteratorT get_currentline_end() const
     { return get_endline(); }
 
-    std::basic_string<value_type> get_currentline(void) const
+    std::basic_string<value_type> get_currentline() const
     {
         return std::basic_string<value_type>
             (get_currentline_begin(), get_currentline_end());
@@ -424,7 +424,7 @@ protected:
         return endline;
     }
 
-    void newline(void)
+    void newline()
     { _startline = this->base(); }
 };
 

--- a/include/boost/spirit/home/qi/detail/expectation_failure.hpp
+++ b/include/boost/spirit/home/qi/detail/expectation_failure.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace spirit { namespace qi {
             : std::runtime_error("boost::spirit::qi::expectation_failure")
             , first(first_), last(last_), what_(what)
         {}
-        ~expectation_failure() BOOST_NOEXCEPT_OR_NOTHROW {}
+        ~expectation_failure() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
         Iterator first;
         Iterator last;

--- a/include/boost/spirit/home/support/detail/hold_any.hpp
+++ b/include/boost/spirit/home/support/detail/hold_any.hpp
@@ -27,10 +27,10 @@
 #include <boost/assert.hpp>
 #include <boost/core/typeinfo.hpp>
 
-#include <stdexcept>
-#include <typeinfo>
 #include <algorithm>
 #include <iosfwd>
+#include <stdexcept>
+#include <typeinfo>
 
 ///////////////////////////////////////////////////////////////////////////////
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
@@ -49,7 +49,10 @@ namespace boost { namespace spirit
           : from(src.name()), to(dest.name())
         {}
 
-        virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW { return "bad any cast"; }
+        const char* what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
+        { 
+            return "bad any cast";
+        }
 
         const char* from;
         const char* to;

--- a/include/boost/spirit/home/support/info.hpp
+++ b/include/boost/spirit/home/support/info.hpp
@@ -132,7 +132,7 @@ namespace boost { namespace spirit
 
         void element(string const& tag, string const& value, int /*depth*/) const
         {
-            if (value == "")
+            if (value.empty())
                 out << '<' << tag << '>';
             else
                 out << '"' << value << '"';

--- a/include/boost/spirit/home/support/iterators/detail/buf_id_check_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/buf_id_check_policy.hpp
@@ -24,9 +24,9 @@ namespace boost { namespace spirit { namespace iterator_policies
     {
     public:
         illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW {}
-        ~illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW {}
+        ~illegal_backtracking() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
-        char const* what() const BOOST_NOEXCEPT_OR_NOTHROW
+        char const* what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
         { 
             return "boost::spirit::multi_pass::illegal_backtracking"; 
         }


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fix Clang-tidy readability-container-size-empty and modernize-redundant-void-arg warnings.
Alphabetical order of STL headers.

Closes #587