### PR TITLE
X3: Corner cases in alternative parser with container attribute

### DIFF
--- a/test/x3/alternative.cpp
+++ b/test/x3/alternative.cpp
@@ -250,5 +250,25 @@ main()
         BOOST_TEST_EQ(st.val, 42);
     }
 
+    { // attributeless parsers must not insert values
+        std::vector<int> v;
+        BOOST_TEST(test_attr("1 2 3 - 5 - - 7 -", (int_ | '-') % ' ', v));
+        BOOST_TEST_EQ(v.size(), 5)
+            && BOOST_TEST_EQ(v[0], 1)
+            && BOOST_TEST_EQ(v[1], 2)
+            && BOOST_TEST_EQ(v[2], 3)
+            && BOOST_TEST_EQ(v[3], 5)
+            && BOOST_TEST_EQ(v[4], 7)
+            ;
+    }
+
+    { // regressing test for #603
+        using boost::spirit::x3::attr;
+        struct X {};
+        std::vector<boost::variant<std::string, int, X>> v;
+        BOOST_TEST(test_attr("xx42x9y", *(int_ | +char_('x') | 'y' >> attr(X{})), v));
+        BOOST_TEST_EQ(v.size(), 5);
+    }
+
     return boost::report_errors();
 }


### PR DESCRIPTION
Alternative parser were appending empty values with attributeless parsers, while it should not append anything at all.
A container parser of alternative parser of container parser with container of variant of container attribute was failing to compile.

It would be cleaner to simply store every subparser wrapped inside `alternative` because even the general way to call subparsers is via `parse_alternative`, but it will hurt parser expression tree readability.

Fixes #603
Fixes #394