### PR TITLE
X3: Remove unneeded reserve before insert

### DIFF
--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -50,13 +50,6 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <typename T>
     using is_associative = typename detail::is_associative_impl<T>::type;
 
-    template<typename T, typename Enable = void>
-    struct is_reservable : mpl::false_ {};
-
-    template<typename T>
-    struct is_reservable<T, decltype(std::declval<T&>().reserve(0))>
-      : mpl::true_ {};
-
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
@@ -163,18 +156,6 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
     private:
         template <typename Iterator>
-        static void reserve(Container& /* c */, Iterator /* first */, Iterator /* last */, mpl::false_)
-        {
-            // Not all containers have "reserve"
-        }
-
-        template <typename Iterator>
-        static void reserve(Container& c, Iterator first, Iterator last, mpl::true_)
-        {
-            c.reserve(c.size() + std::distance(first, last));
-        }
-
-        template <typename Iterator>
         static void insert(Container& c, Iterator first, Iterator last, mpl::false_)
         {
             c.insert(c.end(), first, last);
@@ -190,7 +171,6 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         template <typename Iterator>
         static bool call(Container& c, Iterator first, Iterator last)
         {
-            reserve(c, first, last, is_reservable<Container>{});
             insert(c, first, last, is_associative<Container>{});
             return true;
         }

--- a/test/x3/container_support.cpp
+++ b/test/x3/container_support.cpp
@@ -209,25 +209,6 @@ int
 main()
 {
     using x3::traits::is_associative;
-    using x3::traits::is_reservable;
-
-    static_assert(is_reservable<std::vector<int>>::value, "is_reservable problem");
-    static_assert(is_reservable<std::string>::value, "is_reservable problem");
-    static_assert(is_reservable<std::unordered_set<int>>::value, "is_reservable problem");
-    static_assert(is_reservable<boost::unordered_set<int>>::value, "is_reservable problem");
-    static_assert(is_reservable<std::unordered_multiset<int>>::value, "is_reservable problem");
-    static_assert(is_reservable<boost::unordered_multiset<int>>::value, "is_reservable problem");
-    static_assert(is_reservable<std::unordered_map<int,int>>::value, "is_reservable problem");
-    static_assert(is_reservable<boost::unordered_map<int,int>>::value, "is_reservable problem");
-    static_assert(is_reservable<std::unordered_multimap<int,int>>::value, "is_reservable problem");
-    static_assert(is_reservable<boost::unordered_multimap<int,int>>::value, "is_reservable problem");
-
-    static_assert(!is_reservable<std::deque<int>>::value, "is_reservable problem");
-    static_assert(!is_reservable<std::list<int>>::value, "is_reservable problem");
-    static_assert(!is_reservable<std::set<int>>::value, "is_reservable problem");
-    static_assert(!is_reservable<std::multiset<int>>::value, "is_reservable problem");
-    static_assert(!is_reservable<std::map<int,int>>::value, "is_reservable problem");
-    static_assert(!is_reservable<std::multimap<int,int>>::value, "is_reservable problem");
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
Every sane container implementation will make preallocation if possible, calling `reserve` ourselves increases code size and creates a dead branch inside `insert` which cannot be removed by compiler.

`vector<T>::insert` of major standard library implementations:
- https://github.com/gcc-mirror/gcc/blob/2e0303d60a97ddfcdd8340184bb5dc45e0433327/libstdc%2B%2B-v3/include/bits/vector.tcc#L679
- https://github.com/llvm/llvm-project/blob/fd3295fb6f981a5c030d7540b9eda67f9c723e0f/libcxx/include/vector#L1984
- https://github.com/microsoft/STL/blob/7447ad59d61f50c13861878f340d051c298458df/stl/inc/vector#L911

codegen comparison: https://godbolt.org/z/xJe3jr
single allocation proof: https://godbolt.org/z/bXUyKG
