### PR TITLE
standard_wide: Remove redundant asserts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,10 +111,8 @@ before_install:
     feature.feature known-warnings : suppress : optional incidental propagated ;
     toolset.flags gcc.compile OPTIONS <known-warnings>suppress :
         -Wno-maybe-uninitialized  # this warning is known to give false positives
-        -Wno-sign-compare
       # -Wextra warnings:
         -Wno-deprecated-copy      # Proto, Phoenix, GCC bug 92145
-        -Wno-type-limits
       : unchecked ;
     toolset.flags clang-linux.compile OPTIONS <known-warnings>suppress :
         -Wno-deprecated-copy      # Proto, Phoenix

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -75,24 +75,10 @@ namespace boost { namespace spirit { namespace char_encoding
             ) != 0;     // any wchar_t, but no other bits set
         }
 
-        // *** Note on assertions: The precondition is that the calls to
-        // these functions do not violate the required range of ch (type int)
-        // which is that strict_ischar(ch) should be true. It is the
-        // responsibility of the caller to make sure this precondition is not
-        // violated.
-
-        static bool
-        strict_ischar(int ch)
-        {
-            // ch should be representable as a wchar_t
-            return ch >= WCHAR_MIN && ch <= WCHAR_MAX;
-        }
-
         static bool
         isalnum(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswalnum(to_int_type(ch)) != 0;
         }
 
@@ -100,7 +86,6 @@ namespace boost { namespace spirit { namespace char_encoding
         isalpha(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswalpha(to_int_type(ch)) != 0;
         }
 
@@ -108,7 +93,6 @@ namespace boost { namespace spirit { namespace char_encoding
         iscntrl(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswcntrl(to_int_type(ch)) != 0;
         }
 
@@ -116,7 +100,6 @@ namespace boost { namespace spirit { namespace char_encoding
         isdigit(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswdigit(to_int_type(ch)) != 0;
         }
 
@@ -124,7 +107,6 @@ namespace boost { namespace spirit { namespace char_encoding
         isgraph(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswgraph(to_int_type(ch)) != 0;
         }
 
@@ -132,7 +114,6 @@ namespace boost { namespace spirit { namespace char_encoding
         islower(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswlower(to_int_type(ch)) != 0;
         }
 
@@ -147,7 +128,6 @@ namespace boost { namespace spirit { namespace char_encoding
         ispunct(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswpunct(to_int_type(ch)) != 0;
         }
 
@@ -155,7 +135,6 @@ namespace boost { namespace spirit { namespace char_encoding
         isspace(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswspace(to_int_type(ch)) != 0;
         }
 
@@ -163,7 +142,6 @@ namespace boost { namespace spirit { namespace char_encoding
         isupper(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswupper(to_int_type(ch)) != 0;
         }
 
@@ -171,14 +149,12 @@ namespace boost { namespace spirit { namespace char_encoding
         isxdigit(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return iswxdigit(to_int_type(ch)) != 0;
         }
 
         static bool
         isblank BOOST_PREVENT_MACRO_SUBSTITUTION (wchar_t ch)
         {
-            BOOST_ASSERT(strict_ischar(ch));
             return (ch == L' ' || ch == L'\t');
         }
 
@@ -190,7 +166,6 @@ namespace boost { namespace spirit { namespace char_encoding
         tolower(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return isupper(ch) ?
                 to_char_type<wchar_t>(towlower(to_int_type(ch))) : ch;
         }
@@ -199,7 +174,6 @@ namespace boost { namespace spirit { namespace char_encoding
         toupper(wchar_t ch)
         {
             using namespace std;
-            BOOST_ASSERT(strict_ischar(ch));
             return islower(ch) ?
                 to_char_type<wchar_t>(towupper(to_int_type(ch))) : ch;
         }

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -19,6 +19,8 @@
 #include <boost/cstdint.hpp>
 #include <boost/spirit/home/support/assert_msg.hpp>
 
+#include <boost/type_traits/make_unsigned.hpp>
+
 namespace boost { namespace spirit { namespace traits
 {
     template <std::size_t N>
@@ -203,10 +205,9 @@ namespace boost { namespace spirit { namespace char_encoding
         }
 
         static ::boost::uint32_t
-        toucs4(int ch)
+        toucs4(wchar_t ch)
         {
-            BOOST_ASSERT(strict_ischar(ch));
-            return ch;
+            return static_cast<make_unsigned<wchar_t>::type>(ch);
         }
     };
 }}}

--- a/test/support/Jamfile
+++ b/test/support/Jamfile
@@ -46,6 +46,7 @@ rule compile-fail ( sources + : requirements * : target-name ? )
 
 ###############################################################################
 
+run char_encoding.cpp ;
 run istream_iterator_basic.cpp ;
 run unused_type.cpp ;
 run utree.cpp ;

--- a/test/support/char_encoding.cpp
+++ b/test/support/char_encoding.cpp
@@ -1,0 +1,27 @@
+/*=============================================================================
+    Copyright (c) 2020 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/home/support/char_encoding/standard_wide.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+# pragma warning(disable: 4428) // universal-character-name encountered in source
+#endif
+
+int main()
+{
+    {
+        using boost::spirit::char_encoding::standard_wide;
+        BOOST_TEST(0xFFFFu == standard_wide::toucs4(L'\uFFFF'));
+        BOOST_TEST(0x7FFFu == standard_wide::toucs4(L'\u7FFF'));
+        BOOST_TEST(0x0000u == standard_wide::toucs4(L'\u0000'));
+    }
+
+    return boost::report_errors();
+}

--- a/test/support/char_encoding.cpp
+++ b/test/support/char_encoding.cpp
@@ -18,9 +18,9 @@ int main()
 {
     {
         using boost::spirit::char_encoding::standard_wide;
-        BOOST_TEST(0xFFFFu == standard_wide::toucs4(L'\uFFFF'));
-        BOOST_TEST(0x7FFFu == standard_wide::toucs4(L'\u7FFF'));
-        BOOST_TEST(0x0000u == standard_wide::toucs4(L'\u0000'));
+        BOOST_TEST_EQ(standard_wide::toucs4(L'\uFFFF'), 0xFFFFu);
+        BOOST_TEST_EQ(standard_wide::toucs4(L'\u7FFF'), 0x7FFFu);
+        BOOST_TEST_EQ(standard_wide::toucs4(L'\u0024'), 0x0024u);
     }
 
     return boost::report_errors();


### PR DESCRIPTION
> For all functions described in this subclause that accept an argument of type wint_t, the value shall
> be representable as a wchar_t or shall equal the value of the macro WEOF. If this argument has any
> other value, the behavior is undefined.

There is no way to produce a `wint_t` value non-representable as `wchar_t` with `std::char_traits<wchar_t>::to_int_type`.

Closes #616