### PR TITLE
Cast to correct char type to avoid assertion failure

### DIFF
--- a/include/boost/spirit/home/support/char_class.hpp
+++ b/include/boost/spirit/home/support/char_class.hpp
@@ -281,7 +281,7 @@ namespace boost { namespace spirit { namespace char_class
     template <typename CharEncoding>
     struct classify
     {
-        typedef typename CharEncoding::char_type char_type;
+        typedef typename CharEncoding::classify_type char_type;
 
 #define BOOST_SPIRIT_CLASSIFY(name, isname)                                     \
         template <typename Char>                                                \
@@ -507,7 +507,7 @@ namespace boost { namespace spirit { namespace char_class
     template <typename CharEncoding>
     struct convert
     {
-        typedef typename CharEncoding::char_type char_type;
+        typedef typename CharEncoding::classify_type char_type;
 
         template <typename Char>
         static Char

--- a/test/qi/char_class.cpp
+++ b/test/qi/char_class.cpp
@@ -139,6 +139,7 @@ main()
         BOOST_TEST(test("0", xdigit));
         BOOST_TEST(test("f", xdigit));
         BOOST_TEST(!test("g", xdigit));
+        BOOST_TEST(!test("\xF1", print));
     }
 
     {


### PR DESCRIPTION
I'm getting an assertion failure in boost::spirit using boost 1.74.0:
```
boost/spirit/home/support/char_encoding/standard.hpp:59: static bool boost::spirit::char_encoding::standard::isalnum(int): Assertion `strict_ischar(ch)' failed.
```
This is being called from `boost::spirit::char_class::classify<boost::spirit::char_encoding::standard>::is<unsigned int>()`.

Comparing that function with the functions in `home/x3/support/no_case.hpp`, the wrong type is being used in the cast.