### PR TITLE
Add missing include

### DIFF
--- a/include/boost/spirit/home/support/algorithm/any_if_ns_so.hpp
+++ b/include/boost/spirit/home/support/algorithm/any_if_ns_so.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #endif
 
+#include <boost/spirit/home/support/algorithm/any_if.hpp>
 #include <boost/spirit/home/support/algorithm/any_ns_so.hpp>
 
 namespace boost { namespace spirit


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev