### PR TITLE
Add missing include

### DIFF
--- a/include/boost/spirit/home/support/char_encoding/standard.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard.hpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <cctype>
+#include <climits>
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
 


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev