### PR TITLE
Add missing include

### DIFF
--- a/include/boost/spirit/home/x3/string/detail/tst.hpp
+++ b/include/boost/spirit/home/x3/string/detail/tst.hpp
@@ -10,6 +10,8 @@
 #include <boost/call_traits.hpp>
 #include <boost/assert.hpp>
 
+#include <string>
+
 namespace boost { namespace spirit { namespace x3 { namespace detail
 {
     // This file contains low level TST routines, not for


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev