### PR TITLE
Add missing include

### DIFF
--- a/include/boost/spirit/home/x3/string/tst.hpp
+++ b/include/boost/spirit/home/x3/string/tst.hpp
@@ -9,6 +9,8 @@
 
 #include <boost/spirit/home/x3/string/detail/tst.hpp>
 
+#include <string>
+
 namespace boost { namespace spirit { namespace x3
 {
     struct tst_pass_through


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev