### PR TITLE
Add missing includes

### DIFF
--- a/include/boost/spirit/home/support/algorithm/any_if_ns_so.hpp
+++ b/include/boost/spirit/home/support/algorithm/any_if_ns_so.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #endif
 
+#include <boost/spirit/home/support/algorithm/any_if.hpp>
 #include <boost/spirit/home/support/algorithm/any_ns_so.hpp>
 
 namespace boost { namespace spirit

--- a/include/boost/spirit/home/support/char_encoding/standard.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard.hpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <cctype>
+#include <climits>
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
 

--- a/include/boost/spirit/home/x3/string/detail/tst.hpp
+++ b/include/boost/spirit/home/x3/string/detail/tst.hpp
@@ -10,6 +10,8 @@
 #include <boost/call_traits.hpp>
 #include <boost/assert.hpp>
 
+#include <string>
+
 namespace boost { namespace spirit { namespace x3 { namespace detail
 {
     // This file contains low level TST routines, not for

--- a/include/boost/spirit/home/x3/string/tst.hpp
+++ b/include/boost/spirit/home/x3/string/tst.hpp
@@ -9,6 +9,8 @@
 
 #include <boost/spirit/home/x3/string/detail/tst.hpp>
 
+#include <string>
+
 namespace boost { namespace spirit { namespace x3
 {
     struct tst_pass_through

--- a/include/boost/spirit/home/x3/support/traits/print_token.hpp
+++ b/include/boost/spirit/home/x3/support/traits/print_token.hpp
@@ -12,6 +12,7 @@
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <cctype>
+#include <ios>
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {


### PR DESCRIPTION
This patch makes the headers able to be built standalone, making possible C++ clang modules builds. 
@vgvassilev