### PR TITLE
Improve what() info for distinct directive

### DIFF
--- a/include/boost/spirit/repository/home/qi/directive/distinct.hpp
+++ b/include/boost/spirit/repository/home/qi/directive/distinct.hpp
@@ -94,9 +94,9 @@ namespace boost { namespace spirit { namespace repository {namespace qi
         }
 
         template <typename Context>
-        info what(Context& /*ctx*/) const
+        info what(Context& ctx) const
         {
-            return info("distinct");
+            return info("distinct", subject.what(ctx));
         }
 
         Subject subject;


### PR DESCRIPTION
Like on similar directives, propagate the info from the subject parser
for improved debug/diagnostics.

The idea taken from and demonstrated here: https://stackoverflow.com/questions/65087474/how-to-get-boost-spirit-build-in-error-message-distinct-possible-symbols/65098082#65098082

With this change, user won't need to tediously create a custom `my_distinct` directive just to override the `what()` behaviour.