### PR TITLE
Use char32_t as unicode encoding char_type

### DIFF
--- a/include/boost/spirit/home/support/char_encoding/unicode.hpp
+++ b/include/boost/spirit/home/support/char_encoding/unicode.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace spirit { namespace char_encoding
     ///////////////////////////////////////////////////////////////////////////
     struct unicode
     {
-        typedef ::boost::uint32_t char_type;
+        typedef char32_t char_type;
         typedef ::boost::uint32_t classify_type;
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/support/char_set/range_functions.hpp
+++ b/include/boost/spirit/home/support/char_set/range_functions.hpp
@@ -47,14 +47,14 @@ namespace boost { namespace spirit { namespace support { namespace detail
         // another range 'other', so we can merge them
 
         typedef typename Range::value_type value_type;
-        typedef integer_traits<value_type> integer_traits;
+        typedef std::numeric_limits<value_type> limits;
 
         value_type decr_first =
-            range.first == integer_traits::const_min
+            range.first == limits::min()
             ? range.first : range.first-1;
 
         value_type incr_last =
-            range.last == integer_traits::const_max
+            range.last == limits::max()
             ? range.last : range.last+1;
 
         return (decr_first <= other.last) && (incr_last >= other.first);

--- a/include/boost/spirit/home/x3/support/traits/print_attribute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/print_attribute.hpp
@@ -80,6 +80,26 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
             out << val;
         }
 
+        static void call(Out& out, char32_t val, plain_attribute)
+        {
+            if (val >= 0 && val < 127)
+            {
+              if (iscntrl(val))
+                out << "\\" << std::oct << int(val) << std::dec;
+              else if (isprint(val))
+                out << char(val);
+              else
+                out << "\\x" << std::hex << int(val) << std::dec;
+            }
+            else
+              out << "\\x" << std::hex << int(val) << std::dec;
+        }
+
+        static void call(Out& out, char val, plain_attribute tag)
+        {
+            call(out, static_cast<char32_t>(val), tag);
+        }
+
         // for fusion data types
         template <typename T_>
         static void call(Out& out, T_ const& val, tuple_attribute)

--- a/include/boost/spirit/home/x3/support/traits/print_token.hpp
+++ b/include/boost/spirit/home/x3/support/traits/print_token.hpp
@@ -36,10 +36,17 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
                     case '\t': o << "\\t"; break;
                     case '\v': o << "\\v"; break;
                     default:
-                        if (c >= 0 && c < 127 && iscntrl(c))
+                        if (c >= 0 && c < 127)
+                        {
+                          if (iscntrl(c))
                             o << "\\" << std::oct << int(c);
+                          else if (isprint(c))
+                            o << char(c);
+                          else
+                            o << "\\x" << std::hex << int(c);
+                        }
                         else
-                            o << Char(c);
+                          o << "\\x" << std::hex << int(c);
                 }
             }
         };

--- a/test/x3/symbols3.cpp
+++ b/test/x3/symbols3.cpp
@@ -6,8 +6,10 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
+#define BOOST_SPIRIT_X3_DEBUG
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/spirit/home/x3.hpp>
+#include <boost/spirit/home/support/char_encoding/unicode.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
@@ -80,6 +82,15 @@ main()
         foo = {"a1", "a2", "a3"};
 
         BOOST_TEST((test("a3", foo)));
+    }
+
+    { // unicode | construction from initializer-list
+        using namespace boost::spirit;
+        x3::symbols_parser<char_encoding::unicode, int> foo = {{U"a1", 1}, {U"a2", 2}, {U"a3", 3}};
+
+        int r;
+        BOOST_TEST((test_attr(U"a3", foo, r)));
+        BOOST_TEST(r == 3);
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Allows to use a `symbols_parser` with unicode encoding.