### PR TITLE
allow unicode symbols_parser to be matched against regular chars

### DIFF
--- a/include/boost/spirit/home/x3/support/no_case.hpp
+++ b/include/boost/spirit/home/x3/support/no_case.hpp
@@ -24,8 +24,8 @@ namespace boost { namespace spirit { namespace x3
             return set.test(ch);
         }
 
-        template <typename Char>
-        int32_t operator()(Char lc, Char rc) const
+        template <typename Char, typename Char2>
+        int32_t operator()(Char lc, Char2 rc) const
         {
             return lc - rc;
         }
@@ -50,8 +50,8 @@ namespace boost { namespace spirit { namespace x3
                     ? Encoding::toupper(ch) : Encoding::tolower(ch));
         }
 
-        template <typename Char>
-        int32_t operator()(Char lc_, Char const rc_) const
+        template <typename Char, typename Char2>
+        int32_t operator()(Char lc_, Char2 const rc_) const
         {
             using char_type = typename Encoding::classify_type;
             auto lc = char_type(lc_);

--- a/test/x3/symbols3.cpp
+++ b/test/x3/symbols3.cpp
@@ -91,6 +91,8 @@ main()
         int r;
         BOOST_TEST((test_attr(U"a3", foo, r)));
         BOOST_TEST(r == 3);
+        BOOST_TEST((test_attr("a3", foo, r)));
+        BOOST_TEST(r == 3);
     }
 
     return boost::report_errors();


### PR DESCRIPTION
Hi,

First, let me say that I'm almost certain this patch is bad, there is surely a better way to solve the problem I'm facing:

I have a grammar that is pure ASCII, but it can be a subset of another grammar which requires Unicode, therefore I have defined a `symbols_parser` with UTF32 values in the former grammar.

Here's the error I get:

```
/Users/theo/Projects/boost/boost/spirit/home/x3/string/detail/tst.hpp:74:29: error: no matching function for call to object of type
      'boost::spirit::x3::case_compare<boost::spirit::char_encoding::unicode>'
                int32_t c = comp(*i,p->id);
                            ^~~~
/Users/theo/Projects/boost/boost/spirit/home/x3/string/tst.hpp:56:26: note: in instantiation of function template specialization
      'boost::spirit::x3::detail::tst_node<char32_t, int>::find<const char *, boost::spirit::x3::case_compare<boost::spirit::char_encoding::unicode> >' requested here
            return node::find(root, first, last, caseCompare);
                         ^
/Users/theo/Projects/boost/boost/spirit/home/x3/string/symbols.hpp:205:27: note: in instantiation of function template specialization 'boost::spirit::x3::tst<char32_t,
      int>::find<const char *, boost::spirit::x3::case_compare<boost::spirit::char_encoding::unicode> >' requested here
                = lookup->find(first, last, get_case_compare<Encoding>(context)))
                          ^
/Users/theo/Projects/boost/boost/spirit/home/x3/core/parse.hpp:36:29: note: in instantiation of function template specialization
      'boost::spirit::x3::symbols_parser<boost::spirit::char_encoding::unicode, int, boost::spirit::x3::tst<char32_t, int> >::parse<const char *,
      boost::spirit::x3::unused_type, int>' requested here
        return as_parser(p).parse(first, last, unused, unused, attr);
                            ^
/Users/theo/Projects/boost/boost/spirit/home/x3/core/parse.hpp:48:16: note: in instantiation of function template specialization 'boost::spirit::x3::parse_main<const char
      *, boost::spirit::x3::symbols_parser<boost::spirit::char_encoding::unicode, int, boost::spirit::x3::tst<char32_t, int> >, int>' requested here
        return parse_main(first, last, p, attr);
               ^
./test.hpp:73:35: note: in instantiation of function template specialization 'boost::spirit::x3::parse<const char *,
      boost::spirit::x3::symbols_parser<boost::spirit::char_encoding::unicode, int, boost::spirit::x3::tst<char32_t, int> >, int>' requested here
        return boost::spirit::x3::parse(in, last, p, attr)
                                  ^
symbols3.cpp:94:21: note: in instantiation of function template specialization 'spirit_test::test_attr<char,
      boost::spirit::x3::symbols_parser<boost::spirit::char_encoding::unicode, int, boost::spirit::x3::tst<char32_t, int> >, int>' requested here
        BOOST_TEST((test_attr("a3", foo, r)));
                    ^
/Users/theo/Projects/boost/boost/spirit/home/x3/support/no_case.hpp:28:17: note: candidate template ignored: deduced conflicting types for parameter 'Char'
      ('char' vs. 'char32_t')
        int32_t operator()(Char lc, Char rc) const
``` 