### PR TITLE
X3: Skip rule definition injection into context

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -156,7 +156,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         return make_unique_context<ID>(rhs, context);
     }
 
-    template <typename Attribute, typename ID>
+    template <typename Attribute, typename ID, bool skip_definition_injection = false>
     struct rule_parser
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
@@ -211,7 +211,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             bool r = rhs.parse(
                 i
               , last
-              , make_rule_context<ID>(rhs, context, is_default_parse_rule())
+              , make_rule_context<ID>(rhs, context, std::conditional_t<skip_definition_injection, mpl::false_, is_default_parse_rule>())
               , rcontext
               , attr
             );

--- a/test/x3/rule2.cpp
+++ b/test/x3/rule2.cpp
@@ -13,6 +13,25 @@
 #include <iostream>
 #include "test.hpp"
 
+namespace x3 = boost::spirit::x3;
+
+struct check_no_rule_injection_parser
+    : x3::parser<check_no_rule_injection_parser>
+{
+    typedef x3::unused_type attribute_type;
+    static bool const has_attribute = false;
+
+    template <typename Iterator, typename Context
+      , typename RuleContext, typename Attribute>
+    bool parse(Iterator&, Iterator const&, Context const&,
+        RuleContext&, Attribute&) const
+    {
+        static_assert(std::is_same<Context, x3::unused_type>::value,
+            "no rule definition injection should occur");
+        return true;
+    }
+} const check_no_rule_injection;
+
 int
 main()
 {
@@ -102,6 +121,11 @@ main()
             BOOST_TEST(test("abcdef", r[f]));
             BOOST_TEST(s == "abcdef");
         }
+    }
+
+    {
+        BOOST_TEST(test("", rule<class a>{} = check_no_rule_injection));
+        BOOST_TEST(test("", rule<class a>{} %= check_no_rule_injection));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
When a rule placeholder constructed and immediately consumed it cannot be used recursively, that's why the rule definition injection into a parser context can be skipped.
This optimization has a huge impact on compile times because immediate rules are commonly used to cast an attribute like `as`/`attr_cast` does in Qi.

Closes #647