### PR TITLE
X3: Fix multiple times missed force_attribute parameter

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -34,6 +34,9 @@ namespace boost { namespace spirit { namespace x3
 
     namespace detail
     {
+        template <typename ID>
+        struct rule_id {};
+
         // we use this so we can detect if the default parse_rule
         // is the being called.
         struct default_parse_rule_result
@@ -46,11 +49,11 @@ namespace boost { namespace spirit { namespace x3
     }
 
     // default parse_rule implementation
-    template <typename ID, typename Attribute, typename Iterator
+    template <typename ID, typename Iterator
       , typename Context, typename ActualAttribute>
     inline detail::default_parse_rule_result
     parse_rule(
-        rule<ID, Attribute> rule_
+        detail::rule_id<ID>
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr);
 }}}
@@ -192,7 +195,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             // see if the user has a BOOST_SPIRIT_DEFINE for this rule
             typedef
                 decltype(parse_rule(
-                    rule<ID, Attribute>(), first, last
+                    detail::rule_id<ID>{}, first, last
                   , make_unique_context<ID>(rhs, context), std::declval<Attribute&>()))
             parse_rule_result;
 

--- a/test/x3/rule_separate_tu_grammar.hpp
+++ b/test/x3/rule_separate_tu_grammar.hpp
@@ -42,7 +42,7 @@ using skipper_type = x3::rule<class skipper_r>;
 const skipper_type skipper;
 BOOST_SPIRIT_DECLARE(skipper_type)
 
-using grammar_type = x3::rule<class grammar_r, int>;
+using grammar_type = x3::rule<class grammar_r, int, true>;
 const grammar_type grammar;
 BOOST_SPIRIT_DECLARE(grammar_type)
 


### PR DESCRIPTION
Switched `parse_rule` to dispatch only on the rule id only instead.