### PR TITLE
X3: Fix list parser's has_attribute

### DIFF
--- a/include/boost/spirit/home/x3/operator/list.hpp
+++ b/include/boost/spirit/home/x3/operator/list.hpp
@@ -20,7 +20,6 @@ namespace boost { namespace spirit { namespace x3
     {
         typedef binary_parser<Left, Right, list<Left, Right>> base_type;
         static bool const handles_container = true;
-        static bool const has_attribute = true;
 
         constexpr list(Left const& left, Right const& right)
           : base_type(left, right) {}
@@ -63,6 +62,10 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     struct attribute_of<x3::list<Left, Right>, Context>
         : traits::build_container<
             typename attribute_of<Left, Context>::type> {};
+
+    template <typename Left, typename Right, typename Context>
+    struct has_attribute<x3::list<Left, Right>, Context>
+        : has_attribute<Left, Context> {};
 }}}}
 
 #endif

--- a/test/x3/list.cpp
+++ b/test/x3/list.cpp
@@ -57,6 +57,15 @@ main()
         BOOST_TEST(s == "abcdefg");
     }
 
+    { // regression test for has_attribute
+        using boost::spirit::x3::int_;
+        using boost::spirit::x3::omit;
+
+        int i;
+        BOOST_TEST(test_attr("1:2,3", int_ >> ':' >> omit[int_] % ',', i))
+          && BOOST_TEST_EQ(i, 1);
+    }
+
     {
         using boost::spirit::x3::int_;
 


### PR DESCRIPTION
List parser has an attribute only when its subject has (left operand of %).