### PR TITLE
X3: Optional parser is not a passthrough parser

### DIFF
--- a/include/boost/spirit/home/x3/operator/optional.hpp
+++ b/include/boost/spirit/home/x3/operator/optional.hpp
@@ -21,6 +21,7 @@ namespace boost { namespace spirit { namespace x3
     struct optional : proxy<Subject, optional<Subject>>
     {
         typedef proxy<Subject, optional<Subject>> base_type;
+        static bool const is_pass_through_unary = false;
         static bool const handles_container = true;
 
         constexpr optional(Subject const& subject)

--- a/test/x3/sequence.cpp
+++ b/test/x3/sequence.cpp
@@ -383,30 +383,6 @@ main()
     }
 
     // test from spirit mailing list
-    // "Optional operator causes string attribute concatenation"
-    {
-        typedef vector<char, char, int> attr_type;
-        attr_type attr;
-
-        auto node = alnum >> -('[' >> alnum >> '=' >> int_ >> ']');
-
-        BOOST_TEST(test_attr("x[y=123]", node, attr));
-        BOOST_TEST(attr == attr_type('x', 'y', 123));
-    }
-
-    // test from spirit mailing list (variation of above)
-    // "Optional operator causes string attribute concatenation"
-    {
-        typedef vector<std::string, std::string, int> attr_type;
-        attr_type attr;
-
-        auto node = +alnum >> -('[' >> +alnum >> '=' >> int_ >> ']');
-
-        BOOST_TEST(test_attr("xxx[yyy=123]", node, attr));
-        BOOST_TEST(attr == attr_type("xxx", "yyy", 123));
-    }
-
-    // test from spirit mailing list
     // "Error with container within sequence"
     {
         typedef vector<std::string> attr_type;
@@ -430,6 +406,23 @@ main()
         BOOST_TEST(at_c<0>(attr).size() == 2);
         BOOST_TEST(at_c<0>(attr)[0] == 123);
         BOOST_TEST(at_c<0>(attr)[1] == 456);
+    }
+
+    { // non-flat optional
+        vector<int, boost::optional<vector<int, int>>> v;
+        auto const p = int_ >> -(':' >> int_ >> '-' >> int_);
+        BOOST_TEST(test_attr("1:2-3", p, v))
+            && BOOST_TEST(at_c<1>(v)) && BOOST_TEST_EQ(at_c<0>(*at_c<1>(v)), 2);
+    }
+
+    { // optional with container attribute
+        vector<char, boost::optional<std::string>> v;
+        auto const p = char_ >> -(':' >> +char_);
+        BOOST_TEST(test_attr("x", p, v))
+            && BOOST_TEST(!at_c<1>(v));
+        v = {};
+        BOOST_TEST(test_attr("x:abc", p, v))
+            && BOOST_TEST(at_c<1>(v)) && BOOST_TEST(*at_c<1>(v) == "abc");
     }
 
     {


### PR DESCRIPTION
Removes flat sequence parser through optional to fix:
* Non-flat `tuple<..., optional<tuple<...>>, ...>` parsing.
* Optional container parsing when it is a part of the sequence and the optional parser subject is a sequence too.

The removed test cases are invalid (see #664) variants of flat through optional. There are a valid ones (like `int_ >> -(int_ >> int_)` into `tuple<int, optional<int>, optional<int>>`) that would be broken after the change, but at the moment I do not have a popper way to make it work.

Fixes #519