### PR TITLE
X3: Fix error_handler::get_line_start

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -154,8 +154,9 @@ namespace boost { namespace spirit { namespace x3
     template <class Iterator>
     inline Iterator error_handler<Iterator>::get_line_start(Iterator first, Iterator pos) const
     {
-        Iterator latest = first;
-        for (Iterator i = first; i != pos; ++i)
+        // if first line is empty, skip it
+        Iterator latest = (*first == '\r' || *first == '\n') ? first + 1 : first;
+        for (Iterator i = latest; i != pos; ++i)
             if (*i == '\r' || *i == '\n')
                 latest = i;
         return latest;

--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -155,18 +155,12 @@ namespace boost { namespace spirit { namespace x3
     inline Iterator error_handler<Iterator>::get_line_start(Iterator first, Iterator pos) const
     {
         Iterator latest = first;
-        for (Iterator i = first; i != pos; ++i)
+        for (Iterator i = first; i != pos;)
             if (*i == '\r' || *i == '\n')
-                latest = i;
-
-        if (latest == first) {
-            if (*first == '\n' || *first == '\r')
-                return latest + 1;
+                latest = ++i;
             else
-                return latest;
-        } else {
-            return latest + 1;
-        }
+                ++i;
+        return latest;
     }
 
     template <typename Iterator>

--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -154,12 +154,19 @@ namespace boost { namespace spirit { namespace x3
     template <class Iterator>
     inline Iterator error_handler<Iterator>::get_line_start(Iterator first, Iterator pos) const
     {
-        // if first line is empty, skip it
-        Iterator latest = (*first == '\r' || *first == '\n') ? first + 1 : first;
-        for (Iterator i = latest; i != pos; ++i)
+        Iterator latest = first;
+        for (Iterator i = first; i != pos; ++i)
             if (*i == '\r' || *i == '\n')
                 latest = i;
-        return latest;
+
+        if (latest == first) {
+            if (*first == '\n' || *first == '\r')
+                return latest + 1;
+            else
+                return latest;
+        } else {
+            return latest + 1;
+        }
     }
 
     template <typename Iterator>
@@ -200,8 +207,6 @@ namespace boost { namespace spirit { namespace x3
         err_out << error_message << std::endl;
 
         Iterator start = get_line_start(first, err_pos);
-        if (start != first)
-            ++start;
         print_line(start, last);
         print_indicator(start, err_pos, '_');
         err_out << "^_" << std::endl;
@@ -221,8 +226,6 @@ namespace boost { namespace spirit { namespace x3
         err_out << error_message << std::endl;
 
         Iterator start = get_line_start(first, err_first);
-        if (start != first)
-            ++start;
         print_line(start, last);
         print_indicator(start, err_first, ' ');
         print_indicator(start, err_last, '~');

--- a/test/x3/error_handler.cpp
+++ b/test/x3/error_handler.cpp
@@ -48,10 +48,29 @@ void test(std::string const& line_break) {
     BOOST_TEST_EQ(stream.str(), "In line 2:\nError! Expecting: \"bar\" here:\n  foo\n__^_\n");
 }
 
+void test_line_break_first(std::string const& line_break) {
+    std::string const input(line_break + "foo  foo" + line_break + "git");
+    auto const begin = std::begin(input);
+    auto const end = std::end(input);
+
+    std::stringstream stream;
+    x3::error_handler<std::string::const_iterator> error_handler{begin, end, stream};
+
+    auto const parser = x3::with<x3::error_handler_tag>(std::ref(error_handler))[test_rule];
+    x3::phrase_parse(begin, end, parser, x3::space);
+
+    BOOST_TEST_EQ(stream.str(), "In line 2:\nError! Expecting: \"bar\" here:\nfoo  foo\n_____^_\n");
+}
+
 int main() {
     test("\n");
     test("\r");
     test("\r\n");
+
+    test_line_break_first("\n");
+    test_line_break_first("\r");
+    test_line_break_first("\r\n");
+
 
     return boost::report_errors();
 }


### PR DESCRIPTION
When the first line of input would be an empty line, `error_handler` would
fail to properly report an error due to a bug in `get_line_start` method.
Corner case check has been added to fix this.

Example:
```
std::string input = R"(
        var x int = 1 ** 2; 
)";
```
Expected:
```
In line 2:
Error! Expecting primary_expression here:
       var x int = 1 ** 2;
______________________^_
```
Produced:
```
In line 2:
Error! Expecting primary_expression here:

^_
```