### PR TITLE
X3: error_handler should not skip whitespaces

### DIFF
--- a/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
+++ b/include/boost/spirit/home/x3/support/utility/error_reporting.hpp
@@ -64,8 +64,6 @@ namespace boost { namespace spirit { namespace x3
         void print_file_line(std::size_t line) const;
         void print_line(Iterator line_start, Iterator last) const;
         void print_indicator(Iterator& line_start, Iterator last, char ind) const;
-        void skip_whitespace(Iterator& err_pos, Iterator last) const;
-        void skip_non_whitespace(Iterator& err_pos, Iterator last) const;
         Iterator get_line_start(Iterator first, Iterator pos) const;
         std::size_t position(Iterator i) const;
 
@@ -123,34 +121,6 @@ namespace boost { namespace spirit { namespace x3
         }
     }
 
-    template <typename Iterator>
-    void error_handler<Iterator>::skip_whitespace(Iterator& err_pos, Iterator last) const
-    {
-        // make sure err_pos does not point to white space
-        while (err_pos != last)
-        {
-            char c = *err_pos;
-            if (std::isspace(c))
-                ++err_pos;
-            else
-                break;
-        }
-    }
-
-    template <typename Iterator>
-    void error_handler<Iterator>::skip_non_whitespace(Iterator& err_pos, Iterator last) const
-    {
-        // make sure err_pos does not point to white space
-        while (err_pos != last)
-        {
-            char c = *err_pos;
-            if (std::isspace(c))
-                break;
-            else
-                ++err_pos;
-        }
-    }
-
     template <class Iterator>
     inline Iterator error_handler<Iterator>::get_line_start(Iterator first, Iterator pos) const
     {
@@ -194,9 +164,6 @@ namespace boost { namespace spirit { namespace x3
         Iterator first = pos_cache.first();
         Iterator last = pos_cache.last();
 
-        // make sure err_pos does not point to white space
-        skip_whitespace(err_pos, last);
-
         print_file_line(position(err_pos));
         err_out << error_message << std::endl;
 
@@ -212,9 +179,6 @@ namespace boost { namespace spirit { namespace x3
     {
         Iterator first = pos_cache.first();
         Iterator last = pos_cache.last();
-
-        // make sure err_pos does not point to white space
-        skip_whitespace(err_first, last);
 
         print_file_line(position(err_first));
         err_out << error_message << std::endl;

--- a/test/x3/error_handler.cpp
+++ b/test/x3/error_handler.cpp
@@ -46,6 +46,16 @@ void test(std::string const& line_break) {
     x3::phrase_parse(begin, end, parser, x3::space);
 
     BOOST_TEST_EQ(stream.str(), "In line 2:\nError! Expecting: \"bar\" here:\n  foo\n__^_\n");
+
+{ // TODO: cleanup when error_handler is reenterable
+    std::stringstream stream;
+    x3::error_handler<std::string::const_iterator> error_handler{ begin, end, stream };
+
+    auto const parser = x3::with<x3::error_handler_tag>(std::ref(error_handler))[test_rule];
+    x3::parse(begin, end, parser);
+
+    BOOST_TEST_CSTR_EQ(stream.str().c_str(), "In line 1:\nError! Expecting: \"bar\" here:\nfoo\n___^_\n");
+}
 }
 
 void test_line_break_first(std::string const& line_break) {


### PR DESCRIPTION
A skipper does this already and Spirit usually does not roll back skipper work. When there is no skipper, skipping whitespaces is absolutely wrong thing to do. For example, an error points to an end of the word where an additional input is expected, but there are whitespaces after it.

The `skip_whitespace`/`skip_non_whitespace` were removed since they are not used anymore, and because they are also could trigger UB on a particular input due to unsafe `std::isspace` usage.

Fixes #546.