### PR TITLE
Proper double-precision floating point hex representation of 1.0 for …

### DIFF
--- a/test/qi/binary.cpp
+++ b/test/qi/binary.cpp
@@ -97,7 +97,7 @@ int main()
             qword(0x0102030405060708LL)));
 #endif
         BOOST_TEST(binary_test("\x3f\x80\x00\x00", 4, bin_float(1.0f)));
-        BOOST_TEST(binary_test("\x3f\x80\x00\x00\x00\x00\x00\x00", 8,
+        BOOST_TEST(binary_test("\x3f\xf0\x00\x00\x00\x00\x00\x00", 8,
             bin_double(1.0)));
 #endif
     }

--- a/test/x3/binary.cpp
+++ b/test/x3/binary.cpp
@@ -137,7 +137,7 @@ int main()
             qword(0x0102030405060708LL)));
 #endif
         BOOST_TEST(binary_test("\x3f\x80\x00\x00", 4, bin_float(1.0f)));
-        BOOST_TEST(binary_test("\x3f\x80\x00\x00\x00\x00\x00\x00", 8,
+        BOOST_TEST(binary_test("\x3f\xf0\x00\x00\x00\x00\x00\x00", 8,
             bin_double(1.0)));
 #endif
     }


### PR DESCRIPTION
Proper double-precision floating point hex representation of 1.0 for big-endian tests

Fixes #673
