### PR TITLE
X3: Remove forced iterator rollback in rule

### DIFF
--- a/example/x3/rexpr/rexpr_full/test/parse_rexpr_test.cpp
+++ b/example/x3/rexpr/rexpr_full/test/parse_rexpr_test.cpp
@@ -62,9 +62,11 @@ auto parse = [](std::string const& source, fs::path input_path)-> std::string
 };
 
 int num_files_tested = 0;
+int num_tests_failed = 0;
 auto compare = [](fs::path input_path, fs::path expect_path)
 {
-   testing::compare(input_path, expect_path, parse);
+   if (!testing::compare(input_path, expect_path, parse))
+       ++num_tests_failed;
    ++num_files_tested;
 };
 
@@ -82,5 +84,5 @@ int main(int argc, char* argv[])
     if (r == 0)
         std::cout << num_files_tested << " files tested." << std::endl;
     std::cout << "===================================================================================================" << std::endl;
-    return r;
+    return num_tests_failed;
 }

--- a/example/x3/rexpr/rexpr_full/test/testing.hpp
+++ b/example/x3/rexpr/rexpr_full/test/testing.hpp
@@ -233,8 +233,8 @@ namespace boost { namespace spirit { namespace x3 { namespace testing
         auto result = compare(output, expected, re_prefix, re_suffix);
         if (!result.full_match)
         {
-            std::cout << "=============================================" << std::endl;
-            std::cout << "==== Mismatch Found:" << std::endl;
+            std::cerr << "=============================================" << std::endl;
+            std::cerr << "==== Mismatch Found:" << std::endl;
             int line = 1;
             int col = 1;
             for (auto i = output.begin(); i != result.pos; ++i)

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -207,9 +207,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
                 is_same<parse_rule_result, default_parse_rule_result>
             is_default_parse_rule;
 
-            Iterator i = first;
+            Iterator start = first;
             bool r = rhs.parse(
-                i
+                first
               , last
               , make_rule_context<ID>(rhs, context, std::conditional_t<skip_definition_injection, mpl::false_, is_default_parse_rule>())
               , rcontext
@@ -218,14 +218,10 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
             if (r)
             {
-                auto first_ = first;
-                x3::skip_over(first_, last, context);
-                r = call_on_success(first_, i, context, attr
+                r = call_on_success(start, first, context, attr
                   , has_on_success<ID, Iterator, Context, ActualAttribute>());
             }
 
-            if (r)
-                first = i;
             return r;
         }
 

--- a/test/x3/error_handler.cpp
+++ b/test/x3/error_handler.cpp
@@ -27,12 +27,15 @@ struct error_handler_base
     }
 };
 
+struct test_inner_rule_class;
 struct test_rule_class : x3::annotate_on_success, error_handler_base {};
 
+x3::rule<test_inner_rule_class> const test_inner_rule = "\"bar\"";
 x3::rule<test_rule_class> const test_rule;
-auto const test_rule_def = x3::lit("foo") > x3::lit("bar") > x3::lit("git");
+auto const test_inner_rule_def = x3::lit("bar");
+auto const test_rule_def = x3::lit("foo") > test_inner_rule > x3::lit("git");
 
-BOOST_SPIRIT_DEFINE(test_rule)
+BOOST_SPIRIT_DEFINE(test_inner_rule, test_rule)
 
 void test(std::string const& line_break) {
     std::string const input("foo" + line_break + "  foo" + line_break + "git");


### PR DESCRIPTION
Removes inconsistency when a parser part is factorized into a rule.

Fixes regression introduced in #670.