### PR TITLE
Cease dependence on Foreach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(boost_spirit
     Boost::config
     Boost::core
     Boost::endian
-    Boost::foreach
     Boost::function
     Boost::function_types
     Boost::fusion

--- a/include/boost/spirit/home/karma/detail/string_generate.hpp
+++ b/include/boost/spirit/home/karma/detail/string_generate.hpp
@@ -12,6 +12,8 @@
 
 #include <boost/spirit/home/support/char_class.hpp>
 #include <boost/spirit/home/karma/detail/generate_to.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 
 namespace boost { namespace spirit { namespace karma { namespace detail
 {

--- a/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
+++ b/include/boost/spirit/home/lex/lexer/lexertl/lexer.hpp
@@ -25,8 +25,6 @@
 #include <boost/spirit/home/support/detail/lexer/debug.hpp>
 #endif
 
-#include <boost/foreach.hpp>
-
 #include <iterator> // for std::iterator_traits
 
 namespace boost { namespace spirit { namespace lex { namespace lexertl
@@ -302,13 +300,14 @@ namespace boost { namespace spirit { namespace lex { namespace lexertl
             if (state == all_states_id) {
                 // add the action to all known states
                 typedef typename
-                    basic_rules_type::string_size_t_map::value_type
-                state_type;
+                    basic_rules_type::string_size_t_map::const_iterator
+                state_iterator;
 
                 std::size_t states = rules_.statemap().size();
-                BOOST_FOREACH(state_type const& s, rules_.statemap()) {
+                for (state_iterator it = rules_.statemap().begin(),
+                                    end = rules_.statemap().end(); it != end; ++it) {
                     for (std::size_t j = 0; j < states; ++j)
-                        actions_.add_action(unique_id + j, s.second, wrapper_type::call(act));
+                        actions_.add_action(unique_id + j, it->second, wrapper_type::call(act));
                 }
             }
             else {

--- a/include/boost/spirit/home/qi/string/tst_map.hpp
+++ b/include/boost/spirit/home/qi/string/tst_map.hpp
@@ -133,11 +133,12 @@ namespace boost { namespace spirit { namespace qi
 
         void clear()
         {
-            BOOST_FOREACH(typename map_type::value_type& x, map)
+            typedef typename map_type::iterator iter_t;
+            for (iter_t it = map.begin(), end = map.end(); it != end; ++it)
             {
-                node::destruct_node(x.second.root, this);
-                if (x.second.data)
-                    this->delete_data(x.second.data);
+                node::destruct_node(it->second.root, this);
+                if (it->second.data)
+                    this->delete_data(it->second.data);
             }
             map.clear();
         }
@@ -145,12 +146,13 @@ namespace boost { namespace spirit { namespace qi
         template <typename F>
         void for_each(F f) const
         {
-            BOOST_FOREACH(typename map_type::value_type const& x, map)
+            typedef typename map_type::const_iterator iter_t;
+            for (iter_t it = map.begin(), end = map.end(); it != end; ++it)
             {
-                std::basic_string<Char> s(1, x.first);
-                node::for_each(x.second.root, s, f);
-                if (x.second.data)
-                    f(s, *x.second.data);
+                std::basic_string<Char> s(1, it->first);
+                node::for_each(it->second.root, s, f);
+                if (it->second.data)
+                    f(s, *it->second.data);
             }
         }
 
@@ -168,12 +170,13 @@ namespace boost { namespace spirit { namespace qi
 
         void copy(tst_map const& rhs)
         {
-            BOOST_FOREACH(typename map_type::value_type const& x, rhs.map)
+            typedef typename map_type::const_iterator iter_t;
+            for (iter_t it = rhs.map.begin(), end = rhs.map.end(); it != end; ++it)
             {
-                map_data xx = {node::clone_node(x.second.root, this), 0};
-                if (x.second.data)
-                    xx.data = data_pool.construct(*x.second.data);
-                map[x.first] = xx;
+                map_data xx = {node::clone_node(it->second.root, this), 0};
+                if (it->second.data)
+                    xx.data = data_pool.construct(*it->second.data);
+                map[it->first] = xx;
             }
         }
 
@@ -181,9 +184,10 @@ namespace boost { namespace spirit { namespace qi
         {
             if (this != &rhs)
             {
-                BOOST_FOREACH(typename map_type::value_type& x, map)
+                typedef typename map_type::const_iterator iter_t;
+                for (iter_t it = map.begin(), end = map.end(); it != end; ++it)
                 {
-                    node::destruct_node(x.second.root, this);
+                    node::destruct_node(it->second.root, this);
                 }
                 map.clear();
                 copy(rhs);

--- a/include/boost/spirit/home/support/info.hpp
+++ b/include/boost/spirit/home/support/info.hpp
@@ -14,7 +14,6 @@
 #include <boost/variant/variant.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/foreach.hpp>
 #include <boost/spirit/home/support/utf8.hpp>
 #include <list>
 #include <iterator>
@@ -106,10 +105,11 @@ namespace boost { namespace spirit
         void operator()(std::list<info> const& l) const
         {
             callback.element(tag, "", depth);
-            BOOST_FOREACH(info const& what, l)
+            for (std::list<info>::const_iterator it = l.begin(),
+                                                 end = l.end(); it != end; ++it)
             {
                 boost::apply_visitor(
-                    this_type(callback, what.tag, depth+1), what.value);
+                    this_type(callback, it->tag, depth+1), it->value);
             }
         }
 

--- a/include/boost/spirit/home/support/utf8.hpp
+++ b/include/boost/spirit/home/support/utf8.hpp
@@ -12,9 +12,9 @@
 #endif
 
 #include <boost/cstdint.hpp>
-#include <boost/foreach.hpp>
 #include <boost/regex/pending/unicode_iterator.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
+#include <iterator>
 #include <string>
 
 namespace boost { namespace spirit
@@ -61,9 +61,10 @@ namespace boost { namespace spirit
         insert_iter out_iter(result);
         utf8_output_iterator<insert_iter> utf8_iter(out_iter);
         typedef typename make_unsigned<Char>::type UChar;
-        BOOST_FOREACH(Char ch, str)
+        for (Char const* ptr = str.data(),
+                       * end = ptr + str.size(); ptr < end; ++ptr)
         {
-            *utf8_iter++ = (UChar)ch;
+            *utf8_iter++ = (UChar)*ptr;
         }
         return result;
     }

--- a/include/boost/spirit/repository/home/qi/operator/keywords.hpp
+++ b/include/boost/spirit/repository/home/qi/operator/keywords.hpp
@@ -24,7 +24,6 @@
 #include <boost/fusion/include/value_at.hpp>
 #include <boost/fusion/include/mpl.hpp>
 #include <boost/optional.hpp>
-#include <boost/foreach.hpp>
 #include <boost/array.hpp>
 #include <boost/spirit/home/qi/string/symbols.hpp>
 #include <boost/spirit/home/qi/string/lit.hpp>
@@ -281,9 +280,9 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                   {
                     first = save;
                     // Check that we are leaving the keywords parser in a successful state
-                    BOOST_FOREACH(bool &valid,flags)
+                    for(typename flags_type::size_type i = 0, size = flags.size(); i < size; ++i)
                     {
-                      if(!valid)
+                      if(!flags[i])
                       {
                         return false;
                       }
@@ -362,9 +361,9 @@ namespace boost { namespace spirit { namespace repository { namespace qi
                   {
                     first = save;
                     // Check that we are leaving the keywords parser in a successful state
-                    BOOST_FOREACH(bool &valid,flags)
+                    for(typename flags_type::size_type i = 0, size = flags.size(); i < size; ++i)
                     {
-                      if(!valid)
+                      if(!flags[i])
                       {
                         return false;
                       }

--- a/test/karma/test.hpp
+++ b/test/karma/test.hpp
@@ -13,7 +13,6 @@
 #include <iomanip>
 #include <typeinfo>
 
-#include <boost/foreach.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_what.hpp>
 
@@ -55,7 +54,8 @@ namespace spirit_test
         else if (generated != expected)
         {
             std::cerr << "in " << func << ": generated \"";
-            BOOST_FOREACH(typename boost::make_unsigned<Char>::type c, generated) {
+            for (std::size_t i = 0, len = generated.size(); i < len; ++i) {
+                typename boost::make_unsigned<Char>::type c(generated[i]);
                 if (c >= 32 && c < 127)
                     std::cerr << static_cast<char>(static_cast<unsigned char>(c));
                 else
@@ -76,8 +76,8 @@ namespace spirit_test
                  std::memcmp(generated.c_str(), expected.c_str(), generated.size()))
         {
             std::cerr << "in " << func << ": generated \"";
-            BOOST_FOREACH(int c, generated)
-                std::cerr << "\\x" << std::hex << std::setfill('0') << std::setw(2) << c;
+            for (std::size_t i = 0, len = generated.size(); i < len; ++i)
+                std::cerr << "\\x" << std::hex << std::setfill('0') << std::setw(2) << +generated[i];
             std::cerr << "\"" << std::endl;
         }
     }

--- a/test/lex/set_token_value.cpp
+++ b/test/lex/set_token_value.cpp
@@ -8,7 +8,6 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_container.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/foreach.hpp>
 
 using namespace boost::spirit;
 
@@ -115,13 +114,13 @@ template <typename Token>
 inline 
 bool test_tokens(token_data const* d, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (d->id == -1)
             return false;           // reached end of expected data
 
-        typename Token::token_value_type const& value (t.value());
-        if (t.id() != static_cast<std::size_t>(d->id))        // token id must match
+        typename Token::token_value_type const& value (tokens[i].value());
+        if (tokens[i].id() != static_cast<std::size_t>(d->id))        // token id must match
             return false;
         if (value.which() != 1)     // must have an integer value 
             return false;

--- a/test/lex/token_iterpair.cpp
+++ b/test/lex/token_iterpair.cpp
@@ -100,12 +100,12 @@ template <typename Token>
 inline bool 
 test_token_ids(int const* ids, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*ids == -1)
             return false;           // reached end of expected data
 
-        if (t.id() != static_cast<std::size_t>(*ids))        // token id must match
+        if (tokens[i].id() != static_cast<std::size_t>(*ids))        // token id must match
             return false;
         ++ids;
     }
@@ -117,12 +117,12 @@ template <typename Token>
 inline bool 
 test_token_states(std::size_t const* states, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*states == std::size_t(-1))
             return false;           // reached end of expected data
 
-        if (t.state() != *states)            // token state must match
+        if (tokens[i].state() != *states)            // token state must match
             return false;
         ++states;
     }
@@ -141,7 +141,7 @@ inline bool
 test_token_positions(Iterator begin, position_type const* positions, 
     std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (positions->begin == std::size_t(-1) && 
             positions->end == std::size_t(-1))
@@ -149,7 +149,7 @@ test_token_positions(Iterator begin, position_type const* positions,
             return false;           // reached end of expected data
         }
 
-        boost::iterator_range<Iterator> matched = t.matched();
+        boost::iterator_range<Iterator> matched = tokens[i].matched();
         std::size_t start = std::distance(begin, matched.begin());
         std::size_t end = std::distance(begin, matched.end());
 

--- a/test/lex/token_moretypes.cpp
+++ b/test/lex/token_moretypes.cpp
@@ -102,12 +102,12 @@ template <typename Token>
 inline bool 
 test_token_ids(int const* ids, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*ids == -1)
             return false;           // reached end of expected data
 
-        if (t.id() != static_cast<std::size_t>(*ids))        // token id must match
+        if (tokens[i].id() != static_cast<std::size_t>(*ids))        // token id must match
             return false;
 
         ++ids;
@@ -121,12 +121,12 @@ template <typename Token>
 inline bool 
 test_token_states(std::size_t const* states, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*states == std::size_t(-1))
             return false;           // reached end of expected data
 
-        if (t.state() != *states)            // token state must match
+        if (tokens[i].state() != *states)            // token state must match
             return false;
 
         ++states;
@@ -146,7 +146,7 @@ inline bool
 test_token_positions(Iterator begin, position_type const* positions, 
     std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (positions->begin == std::size_t(-1) && 
             positions->end == std::size_t(-1))
@@ -154,7 +154,7 @@ test_token_positions(Iterator begin, position_type const* positions,
             return false;           // reached end of expected data
         }
 
-        boost::iterator_range<Iterator> matched = t.matched();
+        boost::iterator_range<Iterator> matched = tokens[i].matched();
         std::size_t start = std::distance(begin, matched.begin());
         std::size_t end = std::distance(begin, matched.end());
 
@@ -174,14 +174,14 @@ template <typename T, typename Token>
 inline bool 
 test_token_values(boost::optional<T> const* values, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (values->is_initialized() && values->get() == 0)
             return false;               // reached end of expected data
 
         if (values->is_initialized()) {
             T val;
-            spirit::traits::assign_to(t, val);
+            spirit::traits::assign_to(tokens[i], val);
             if (val != values->get())   // token value must match
                 return false;
         }

--- a/test/lex/token_omit.cpp
+++ b/test/lex/token_omit.cpp
@@ -100,12 +100,12 @@ template <typename Token>
 inline bool 
 test_token_ids(int const* ids, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*ids == -1)
             return false;           // reached end of expected data
 
-        if (t.id() != static_cast<std::size_t>(*ids))        // token id must match
+        if (tokens[i].id() != static_cast<std::size_t>(*ids))        // token id must match
             return false;
 
         ++ids;
@@ -119,12 +119,12 @@ template <typename Token>
 inline bool 
 test_token_states(std::size_t const* states, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*states == std::size_t(-1))
             return false;           // reached end of expected data
 
-        if (t.state() != *states)            // token state must match
+        if (tokens[i].state() != *states)            // token state must match
             return false;
 
         ++states;
@@ -144,7 +144,7 @@ inline bool
 test_token_positions(Iterator begin, position_type const* positions, 
     std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (positions->begin == std::size_t(-1) && 
             positions->end == std::size_t(-1))
@@ -152,7 +152,7 @@ test_token_positions(Iterator begin, position_type const* positions,
             return false;           // reached end of expected data
         }
 
-        boost::iterator_range<Iterator> matched = t.matched();
+        boost::iterator_range<Iterator> matched = tokens[i].matched();
         std::size_t start = std::distance(begin, matched.begin());
         std::size_t end = std::distance(begin, matched.end());
 

--- a/test/lex/token_onetype.cpp
+++ b/test/lex/token_onetype.cpp
@@ -102,12 +102,12 @@ template <typename Token>
 inline bool 
 test_token_ids(int const* ids, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*ids == -1)
             return false;           // reached end of expected data
 
-        if (t.id() != static_cast<std::size_t>(*ids))        // token id must match
+        if (tokens[i].id() != static_cast<std::size_t>(*ids))        // token id must match
             return false;
 
         ++ids;
@@ -121,12 +121,12 @@ template <typename Token>
 inline bool 
 test_token_states(std::size_t const* states, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*states == std::size_t(-1))
             return false;           // reached end of expected data
 
-        if (t.state() != *states)            // token state must match
+        if (tokens[i].state() != *states)            // token state must match
             return false;
 
         ++states;
@@ -146,7 +146,7 @@ inline bool
 test_token_positions(Iterator begin, position_type const* positions, 
     std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (positions->begin == std::size_t(-1) && 
             positions->end == std::size_t(-1))
@@ -154,7 +154,7 @@ test_token_positions(Iterator begin, position_type const* positions,
             return false;           // reached end of expected data
         }
 
-        boost::iterator_range<Iterator> matched = t.matched();
+        boost::iterator_range<Iterator> matched = tokens[i].matched();
         std::size_t start = std::distance(begin, matched.begin());
         std::size_t end = std::distance(begin, matched.end());
 
@@ -174,13 +174,13 @@ template <typename Token>
 inline bool 
 test_token_values(double const* values, std::vector<Token> const& tokens)
 {
-    BOOST_FOREACH(Token const& t, tokens)
+    for (std::size_t i = 0, len = tokens.size(); i < len; ++i)
     {
         if (*values == 0.0)
             return false;               // reached end of expected data
 
         double val;
-        spirit::traits::assign_to(t, val);
+        spirit::traits::assign_to(tokens[i], val);
         if (val != *values)             // token value must match
             return false;
 


### PR DESCRIPTION
I have not touch examples because they are not affecting Spirit usage and testing dependencies, and modernizing them also seems like a waste of time when we encourage to start new projects with X3 instead of Qi.