### PR TITLE
Prevent error C2589 when min, max was defined.

### DIFF
--- a/include/boost/spirit/home/support/char_set/range_functions.hpp
+++ b/include/boost/spirit/home/support/char_set/range_functions.hpp
@@ -50,11 +50,11 @@ namespace boost { namespace spirit { namespace support { namespace detail
         typedef std::numeric_limits<value_type> limits;
 
         value_type decr_first =
-            range.first == limits::min()
+            range.first == (limits::min)()
             ? range.first : range.first-1;
 
         value_type incr_last =
-            range.last == limits::max()
+            range.last == (limits::max)()
             ? range.last : range.last+1;
 
         return (decr_first <= other.last) && (incr_last >= other.first);


### PR DESCRIPTION
On Windows/MSVC, the following codes will repro error C2589:

```cpp
#include <boost/regex.hpp>
#include <boost/spirit/include/phoenix_bind.hpp>
#include <boost/spirit/include/phoenix_operator.hpp>
#include <boost/spirit/include/qi.hpp>

int main() {}
```