### PR TITLE
Deprecate Phoenix transition headers

### DIFF
--- a/doc/faq.qbk
+++ b/doc/faq.qbk
@@ -113,15 +113,6 @@ Again, don't use any of the header files underneath the boost/spirit/home
 directory directly, always include files from the boost/spirit/include 
 directory.
 
-The last bit missing is __phoenix__ (which currently still lives under the 
-Spirit umbrella, but already has been accepted as a Boost library, so it will 
-move away). __phoenix__ is a library allowing to write functional style C++, 
-which is interesting in itself, but as it initially has been developed for 
-Spirit, it is nicely integrated and very useful when it comes to writing 
-semantic actions. I think using the boost/spirit/include/phoenix_... headers 
-will be safe in the future as well, as we will probably redirect to the 
-Boost.Phoenix headers as soon as these are available.
-
 
 [heading Why doesn't my symbol table work in a `no_case` directive?]
 

--- a/doc/structure.qbk
+++ b/doc/structure.qbk
@@ -20,7 +20,6 @@ support classes are placed:
 * Qi
 * Karma
 * Lex
-* Phoenix
 * Support
 
 The top Spirit directory is:
@@ -71,7 +70,6 @@ sub-library name:
 * karma_
 * lex_
 * phoenix1_
-* phoenix_
 * qi_
 * support_
 
@@ -86,7 +84,6 @@ include:
 * <boost/spirit/include/karma.hpp>
 * <boost/spirit/include/lex.hpp>
 * <boost/spirit/include/phoenix1.hpp>
-* <boost/spirit/include/phoenix.hpp>
 * <boost/spirit/include/qi.hpp>
 * <boost/spirit/include/support.hpp>
 
@@ -98,14 +95,13 @@ is the /real/ home of Spirit. It is the place where the various sub-libraries
 actually exist. The home directory contains:
 
     [classic]   [karma]     [lex]
-    [phoenix]   [qi]        [support]
+    [qi]        [support]
 
 As usual, these directories have their corresponding include files:
 
 * <boost/spirit/home/classic.hpp>
 * <boost/spirit/home/karma.hpp>
 * <boost/spirit/home/lex.hpp>
-* <boost/spirit/home/phoenix.hpp>
 * <boost/spirit/home/qi.hpp>
 * <boost/spirit/home/support.hpp>
 

--- a/example/karma/calc2_ast.hpp
+++ b/example/karma/calc2_ast.hpp
@@ -19,9 +19,9 @@
 #define SPIRIT_EXAMPLE_CALC2_AST_APR_30_2008_1011AM
 
 #include <boost/variant.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/statement.hpp>
 #include <boost/spirit/include/karma_domain.hpp>
 #include <boost/spirit/include/support_attributes_fwd.hpp>
 

--- a/example/karma/calc2_ast_vm.hpp
+++ b/example/karma/calc2_ast_vm.hpp
@@ -19,9 +19,9 @@
 #define SPIRIT_EXAMPLE_CALC2_AST_APR_30_2008_1011AM
 
 #include <boost/variant.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/statement.hpp>
 #include <boost/spirit/include/karma_domain.hpp>
 #include <boost/spirit/include/support_attributes_fwd.hpp>
 

--- a/example/karma/classify_char.cpp
+++ b/example/karma/classify_char.cpp
@@ -13,8 +13,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <iostream>

--- a/example/karma/complex_number.cpp
+++ b/example/karma/complex_number.cpp
@@ -14,8 +14,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <iostream>

--- a/example/karma/complex_number_adapt.cpp
+++ b/example/karma/complex_number_adapt.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/fusion/include/adapt_adt.hpp>
 #include <boost/spirit/include/support_adapt_adt_attributes.hpp>

--- a/example/karma/complex_number_easier.cpp
+++ b/example/karma/complex_number_easier.cpp
@@ -14,8 +14,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <iostream>

--- a/example/karma/generate_code.cpp
+++ b/example/karma/generate_code.cpp
@@ -12,7 +12,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/karma/key_value_sequence.cpp
+++ b/example/karma/key_value_sequence.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/spirit/include/karma.hpp>
 #include <boost/spirit/include/karma_stream.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <iostream>

--- a/example/karma/mini_xml_karma.cpp
+++ b/example/karma/mini_xml_karma.cpp
@@ -16,11 +16,11 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 

--- a/example/karma/quoted_strings.cpp
+++ b/example/karma/quoted_strings.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <boost/spirit/include/karma.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/stl.hpp>
 
 namespace client
 {

--- a/example/karma/reference.cpp
+++ b/example/karma/reference.cpp
@@ -9,8 +9,8 @@
 //[reference_karma_includes
 #include <boost/spirit/include/karma.hpp>
 #include <boost/spirit/include/support_utree.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/proto/deep_copy.hpp>
 #include <iostream>

--- a/example/lex/example2.cpp
+++ b/example/lex/example2.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <fstream>

--- a/example/lex/example4.cpp
+++ b/example/lex/example4.cpp
@@ -23,7 +23,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <fstream>

--- a/example/lex/example5.cpp
+++ b/example/lex/example5.cpp
@@ -25,7 +25,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <fstream>

--- a/example/lex/example6.cpp
+++ b/example/lex/example6.cpp
@@ -27,7 +27,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <fstream>

--- a/example/lex/lexer_debug_support.cpp
+++ b/example/lex/lexer_debug_support.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/spirit/include/lex_lexertl.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 
 namespace lex = boost::spirit::lex;
 namespace qi = boost::spirit::qi;

--- a/example/lex/print_number_tokenids.cpp
+++ b/example/lex/print_number_tokenids.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/lex/print_numbers.cpp
+++ b/example/lex/print_numbers.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/lex/reference.cpp
+++ b/example/lex/reference.cpp
@@ -7,8 +7,8 @@
 =============================================================================*/
 //[reference_lex_includes
 #include <boost/spirit/include/lex.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <iostream>
 #include <string>
 //]

--- a/example/lex/static_lexer/word_count_lexer_tokens.hpp
+++ b/example/lex/static_lexer/word_count_lexer_tokens.hpp
@@ -6,9 +6,9 @@
 #if !defined(SPIRIT_LEXER_EXAMPLE_WORD_COUNT_LEXER_TOKENS_FEB_10_2008_0739PM)
 #define SPIRIT_LEXER_EXAMPLE_WORD_COUNT_LEXER_TOKENS_FEB_10_2008_0739PM
 
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/core.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lex/static_lexer/word_count_static.cpp
+++ b/example/lex/static_lexer/word_count_static.cpp
@@ -18,9 +18,9 @@
 //[wc_static_include
 #include <boost/spirit/include/lex_static_lexertl.hpp>
 //]
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/lex/strip_comments.cpp
+++ b/example/lex/strip_comments.cpp
@@ -35,8 +35,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/lex/strip_comments_lexer.cpp
+++ b/example/lex/strip_comments_lexer.cpp
@@ -34,9 +34,9 @@
 // #define BOOST_SPIRIT_LEXERTL_DEBUG
 
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/core.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/lex/word_count.cpp
+++ b/example/lex/word_count.cpp
@@ -37,9 +37,9 @@
 //[wcp_includes
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/stl/container.hpp>
 //]
 
 #include <iostream>

--- a/example/lex/word_count_lexer.cpp
+++ b/example/lex/word_count_lexer.cpp
@@ -34,10 +34,10 @@
 
 //[wcl_includes
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_algorithm.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/stl/algorithm.hpp>
+#include <boost/phoenix/core.hpp>
 //]
 
 #include <iostream>

--- a/example/qi/calc_utree.cpp
+++ b/example/qi/calc_utree.cpp
@@ -20,8 +20,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/support_utree.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/calc_utree_ast.cpp
+++ b/example/qi/calc_utree_ast.cpp
@@ -20,8 +20,8 @@
 
 #include <boost/spirit/include/support_utree.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/compiler_tutorial/calc3.cpp
+++ b/example/qi/compiler_tutorial/calc3.cpp
@@ -23,7 +23,7 @@
 #define BOOST_SPIRIT_NO_PREDEFINED_TERMINALS
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/compiler_tutorial/calc5.cpp
+++ b/example/qi/compiler_tutorial/calc5.cpp
@@ -40,7 +40,7 @@
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/foreach.hpp>
 
 #include <iostream>

--- a/example/qi/compiler_tutorial/calc6.cpp
+++ b/example/qi/compiler_tutorial/calc6.cpp
@@ -43,7 +43,7 @@
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/foreach.hpp>
 
 #include <iostream>

--- a/example/qi/compiler_tutorial/calc7/compiler.hpp
+++ b/example/qi/compiler_tutorial/calc7/compiler.hpp
@@ -12,9 +12,9 @@
 #include <vector>
 #include <map>
 #include <boost/function.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 namespace client { namespace code_gen
 {

--- a/example/qi/compiler_tutorial/calc7/expression_def.hpp
+++ b/example/qi/compiler_tutorial/calc7/expression_def.hpp
@@ -7,7 +7,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 
 namespace client { namespace parser
 {

--- a/example/qi/compiler_tutorial/calc8/compiler.hpp
+++ b/example/qi/compiler_tutorial/calc8/compiler.hpp
@@ -12,9 +12,9 @@
 #include <vector>
 #include <map>
 #include <boost/function.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 namespace client { namespace code_gen
 {

--- a/example/qi/compiler_tutorial/calc8/expression_def.hpp
+++ b/example/qi/compiler_tutorial/calc8/expression_def.hpp
@@ -7,7 +7,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 
 namespace client { namespace parser
 {

--- a/example/qi/compiler_tutorial/conjure1/compiler.hpp
+++ b/example/qi/compiler_tutorial/conjure1/compiler.hpp
@@ -13,9 +13,9 @@
 #include <map>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 namespace client { namespace code_gen
 {

--- a/example/qi/compiler_tutorial/conjure1/expression_def.hpp
+++ b/example/qi/compiler_tutorial/conjure1/expression_def.hpp
@@ -7,7 +7,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 
 namespace client { namespace parser
 {

--- a/example/qi/compiler_tutorial/conjure2/compiler.hpp
+++ b/example/qi/compiler_tutorial/conjure2/compiler.hpp
@@ -13,9 +13,9 @@
 #include <map>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 namespace client { namespace code_gen
 {

--- a/example/qi/compiler_tutorial/conjure2/expression_def.hpp
+++ b/example/qi/compiler_tutorial/conjure2/expression_def.hpp
@@ -8,7 +8,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/spirit/include/lex_plain_token.hpp>
 
 namespace client { namespace parser

--- a/example/qi/compiler_tutorial/conjure3/compiler.hpp
+++ b/example/qi/compiler_tutorial/conjure3/compiler.hpp
@@ -14,9 +14,9 @@
 
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 
 #include <llvm/DerivedTypes.h>

--- a/example/qi/compiler_tutorial/conjure3/expression_def.hpp
+++ b/example/qi/compiler_tutorial/conjure3/expression_def.hpp
@@ -8,7 +8,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/spirit/include/lex_plain_token.hpp>
 
 namespace client { namespace parser

--- a/example/qi/compiler_tutorial/mini_c/compiler.hpp
+++ b/example/qi/compiler_tutorial/mini_c/compiler.hpp
@@ -13,9 +13,9 @@
 #include <map>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 namespace client { namespace code_gen
 {

--- a/example/qi/compiler_tutorial/mini_c/expression_def.hpp
+++ b/example/qi/compiler_tutorial/mini_c/expression_def.hpp
@@ -7,7 +7,7 @@
 #include "expression.hpp"
 #include "error_handler.hpp"
 #include "annotation.hpp"
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/function.hpp>
 
 namespace client { namespace parser
 {

--- a/example/qi/complex_number.cpp
+++ b/example/qi/complex_number.cpp
@@ -14,8 +14,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/employee.cpp
+++ b/example/qi/employee.cpp
@@ -14,9 +14,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/fusion/include/io.hpp>
 

--- a/example/qi/expect.cpp
+++ b/example/qi/expect.cpp
@@ -10,7 +10,7 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/spirit/home/qi.hpp>
 #include <boost/spirit/home/qi/nonterminal/grammar.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/foreach.hpp>
 
 namespace qi = boost::spirit::qi;

--- a/example/qi/mini_xml1.cpp
+++ b/example/qi/mini_xml1.cpp
@@ -13,10 +13,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/foreach.hpp>

--- a/example/qi/mini_xml2.cpp
+++ b/example/qi/mini_xml2.cpp
@@ -13,10 +13,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/foreach.hpp>

--- a/example/qi/mini_xml3.cpp
+++ b/example/qi/mini_xml3.cpp
@@ -13,11 +13,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl.hpp>
+#include <boost/phoenix/object.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/foreach.hpp>

--- a/example/qi/nabialek.cpp
+++ b/example/qi/nabialek.cpp
@@ -17,7 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <iostream>
 #include <string>
 

--- a/example/qi/num_list2.cpp
+++ b/example/qi/num_list2.cpp
@@ -15,9 +15,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/num_list3.cpp
+++ b/example/qi/num_list3.cpp
@@ -15,9 +15,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/num_list4.cpp
+++ b/example/qi/num_list4.cpp
@@ -15,9 +15,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/porting_guide_qi.cpp
+++ b/example/qi/porting_guide_qi.cpp
@@ -7,7 +7,7 @@
 =============================================================================*/
 //[porting_guide_qi_includes
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <iostream>
 #include <string>
 #include <algorithm>

--- a/example/qi/reference.cpp
+++ b/example/qi/reference.cpp
@@ -13,8 +13,8 @@
 //[reference_includes
 #include <boost/spirit/include/support_utree.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/assert.hpp>
 #include <boost/predef/other/endian.h>

--- a/example/qi/roman.cpp
+++ b/example/qi/roman.cpp
@@ -15,7 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/example/qi/sum.cpp
+++ b/example/qi/sum.cpp
@@ -15,8 +15,8 @@
 
 //[tutorial_adder_includes
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <iostream>
 #include <string>
 //]

--- a/example/support/utree/utf8_parser.hpp
+++ b/example/support/utree/utf8_parser.hpp
@@ -16,10 +16,10 @@
 #include <boost/regex/pending/unicode_iterator.hpp>
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/stl/container.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/spirit/include/support_utree.hpp>
 
 namespace utf8

--- a/include/boost/spirit/include/phoenix.hpp
+++ b/include/boost/spirit/include/phoenix.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX
 #define BOOST_SPIRIT_INCLUDE_PHOENIX
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix.hpp>")
+
 #include <boost/phoenix.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_algorithm.hpp
+++ b/include/boost/spirit/include/phoenix_algorithm.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_ALGORITHM
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_ALGORITHM
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/stl/algorithm.hpp>")
+
 #include <boost/phoenix/stl/algorithm.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_bind.hpp
+++ b/include/boost/spirit/include/phoenix_bind.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_BIND
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_BIND
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/bind.hpp>")
+
 #include <boost/phoenix/bind.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_container.hpp
+++ b/include/boost/spirit/include/phoenix_container.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_CONTAINER
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_CONTAINER
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/stl/container.hpp>")
+
 #include <boost/phoenix/stl/container.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_core.hpp
+++ b/include/boost/spirit/include/phoenix_core.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_CORE
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_CORE
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/core.hpp>")
+
 #include <boost/phoenix/core.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_function.hpp
+++ b/include/boost/spirit/include/phoenix_function.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_FUNCTION
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_FUNCTION
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/function.hpp>")
+
 #include <boost/phoenix/function.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_fusion.hpp
+++ b/include/boost/spirit/include/phoenix_fusion.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_FUSION
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_FUSION
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/fusion.hpp>")
+
 #include <boost/phoenix/fusion.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_limits.hpp
+++ b/include/boost/spirit/include/phoenix_limits.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_LIMITS
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_LIMITS
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/core/limits.hpp>")
+
 #include <boost/phoenix/core/limits.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_object.hpp
+++ b/include/boost/spirit/include/phoenix_object.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_OBJECT
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_OBJECT
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/object.hpp>")
+
 #include <boost/phoenix/object.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_operator.hpp
+++ b/include/boost/spirit/include/phoenix_operator.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_OPERATOR
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_OPERATOR
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/operator.hpp>")
+
 #include <boost/phoenix/operator.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_scope.hpp
+++ b/include/boost/spirit/include/phoenix_scope.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_SCOPE
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_SCOPE
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/scope.hpp>")
+
 #include <boost/phoenix/scope.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_statement.hpp
+++ b/include/boost/spirit/include/phoenix_statement.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_STATEMENT
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_STATEMENT
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/statement.hpp>")
+
 #include <boost/phoenix/statement.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_stl.hpp
+++ b/include/boost/spirit/include/phoenix_stl.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_STL
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_STL
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/stl.hpp>")
+
 #include <boost/phoenix/stl.hpp>
 #endif

--- a/include/boost/spirit/include/phoenix_version.hpp
+++ b/include/boost/spirit/include/phoenix_version.hpp
@@ -8,5 +8,8 @@
 =============================================================================*/
 #ifndef BOOST_SPIRIT_INCLUDE_PHOENIX_VERSION
 #define BOOST_SPIRIT_INCLUDE_PHOENIX_VERSION
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("<boost/phoenix/version.hpp>")
+
 #include <boost/phoenix/version.hpp>
 #endif

--- a/repository/example/karma/calc2_ast.hpp
+++ b/repository/example/karma/calc2_ast.hpp
@@ -19,9 +19,9 @@
 #define SPIRIT_EXAMPLE_CALC2_AST_APR_30_2008_1011AM
 
 #include <boost/variant.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/statement.hpp>
 #include <boost/spirit/home/karma/domain.hpp>
 #include <boost/spirit/include/support_attributes_fwd.hpp>
 

--- a/repository/example/karma/mini_xml_karma_sr.cpp
+++ b/repository/example/karma/mini_xml_karma_sr.cpp
@@ -19,12 +19,12 @@
 //[mini_xml_karma_sr_includes
 #include <boost/spirit/include/karma.hpp>
 #include <boost/spirit/repository/include/karma_subrule.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
 //]
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 

--- a/repository/example/qi/advance.cpp
+++ b/repository/example/qi/advance.cpp
@@ -7,7 +7,7 @@
 
 //[qi_advance_includes
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/spirit/repository/include/qi_advance.hpp>
 //]
 

--- a/repository/example/qi/derived.cpp
+++ b/repository/example/qi/derived.cpp
@@ -7,11 +7,11 @@
 =============================================================================*/
 //[reference_includes
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/fusion.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/repository/include/qi_kwd.hpp>
 #include <boost/spirit/repository/include/qi_keywords.hpp>

--- a/repository/example/qi/keywords.cpp
+++ b/repository/example/qi/keywords.cpp
@@ -7,8 +7,8 @@
 =============================================================================*/
 //[reference_includes
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/repository/include/qi_kwd.hpp>
 #include <boost/spirit/repository/include/qi_keywords.hpp>

--- a/repository/example/qi/mini_xml2_sr.cpp
+++ b/repository/example/qi/mini_xml2_sr.cpp
@@ -16,11 +16,11 @@
 //[mini_xml2_sr_includes
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/repository/include/qi_subrule.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 //]
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/foreach.hpp>

--- a/repository/test/karma/subrule.cpp
+++ b/repository/test/karma/subrule.cpp
@@ -13,10 +13,10 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
+#include <boost/phoenix/fusion.hpp>
 
 #include "test.hpp"
 

--- a/repository/test/qi/advance.cpp
+++ b/repository/test/qi/advance.cpp
@@ -16,7 +16,7 @@
 #include <boost/spirit/include/qi_numeric.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_string.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/assign/std/list.hpp>
 #include "test.hpp"

--- a/repository/test/qi/confix.cpp
+++ b/repository/test/qi/confix.cpp
@@ -14,10 +14,10 @@
 #include <boost/spirit/include/qi_numeric.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_string.hpp>
-#include <boost/spirit/include/phoenix_bind.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/bind.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include "test.hpp"

--- a/repository/test/qi/keywords.cpp
+++ b/repository/test/qi/keywords.cpp
@@ -16,9 +16,9 @@
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 #include <vector>
 #include <string>

--- a/repository/test/qi/seek.cpp
+++ b/repository/test/qi/seek.cpp
@@ -15,8 +15,8 @@
 #include <boost/spirit/include/qi_eoi.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <vector>
 #include "test.hpp"

--- a/repository/test/qi/subrule.cpp
+++ b/repository/test/qi/subrule.cpp
@@ -14,10 +14,10 @@
 #include <boost/spirit/include/qi_auxiliary.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_bind.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/bind.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/karma/attribute.cpp
+++ b/test/karma/attribute.cpp
@@ -5,8 +5,6 @@
 
 #include <boost/spirit/include/karma_attr_cast.hpp>
 
-#include <boost/spirit/include/phoenix_limits.hpp>
-
 #include <boost/fusion/include/struct.hpp>
 #include <boost/fusion/include/nview.hpp>
 

--- a/test/karma/binary3.cpp
+++ b/test/karma/binary3.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/predef/other/endian.h>
 

--- a/test/karma/bool.cpp
+++ b/test/karma/bool.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/karma_operator.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/char1.cpp
+++ b/test/karma/char1.cpp
@@ -9,9 +9,9 @@
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/char2.cpp
+++ b/test/karma/char2.cpp
@@ -9,9 +9,9 @@
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/char3.cpp
+++ b/test/karma/char3.cpp
@@ -9,9 +9,9 @@
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/columns.cpp
+++ b/test/karma/columns.cpp
@@ -13,7 +13,7 @@
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/core.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/debug.cpp
+++ b/test/karma/debug.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/karma_auxiliary.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/karma/eps.cpp
+++ b/test/karma/eps.cpp
@@ -10,7 +10,7 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_operator.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/core.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/karma/format_manip.cpp
+++ b/test/karma/format_manip.cpp
@@ -9,8 +9,8 @@
 #include <boost/spirit/include/karma_format.hpp>
 #include <boost/spirit/include/karma_format_auto.hpp>
 #include <boost/spirit/include/karma_stream.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <sstream>

--- a/test/karma/int1.cpp
+++ b/test/karma/int1.cpp
@@ -10,8 +10,8 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/bool.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_numeric.hpp>

--- a/test/karma/int2.cpp
+++ b/test/karma/int2.cpp
@@ -10,8 +10,8 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/bool.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_numeric.hpp>

--- a/test/karma/int3.cpp
+++ b/test/karma/int3.cpp
@@ -10,8 +10,8 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/bool.hpp>
 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_numeric.hpp>

--- a/test/karma/kleene.cpp
+++ b/test/karma/kleene.cpp
@@ -18,8 +18,8 @@
 #include <boost/assign/std/vector.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/fusion/include/vector.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include "test.hpp"

--- a/test/karma/lazy.cpp
+++ b/test/karma/lazy.cpp
@@ -13,8 +13,8 @@
 // #include <boost/spirit/include/karma_nonterminal.hpp>
 // #include <boost/spirit/include/karma_operator.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/karma/list.cpp
+++ b/test/karma/list.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_auxiliary.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <boost/assign/std/vector.hpp>

--- a/test/karma/lit.cpp
+++ b/test/karma/lit.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/karma_generate.hpp>
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/omit.cpp
+++ b/test/karma/omit.cpp
@@ -7,8 +7,8 @@
 
 #include <boost/spirit/include/karma.hpp>
 #include <boost/fusion/include/std_pair.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/karma/optional.cpp
+++ b/test/karma/optional.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_int.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/karma/pattern1.cpp
+++ b/test/karma/pattern1.cpp
@@ -10,9 +10,9 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/pattern2.cpp
+++ b/test/karma/pattern2.cpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/pattern3.cpp
+++ b/test/karma/pattern3.cpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/include/karma_numeric.hpp>
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/pattern4.cpp
+++ b/test/karma/pattern4.cpp
@@ -11,8 +11,8 @@
 #include <boost/spirit/include/karma_nonterminal.hpp>
 #include <boost/spirit/include/karma_action.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/pch.hpp
+++ b/test/karma/pch.hpp
@@ -8,8 +8,8 @@
 
 #include <boost/spirit/include/karma.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>

--- a/test/karma/plus.cpp
+++ b/test/karma/plus.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/assign/std/vector.hpp>
 #include <boost/fusion/include/vector.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include "test.hpp"

--- a/test/karma/real3.cpp
+++ b/test/karma/real3.cpp
@@ -8,8 +8,8 @@
 
 #include <boost/spirit/include/version.hpp>
 #include <boost/spirit/include/karma_phoenix_attributes.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef BOOST_SPIRIT_NO_MATH_REAL_CONCEPT

--- a/test/karma/regression_semantic_action_attribute.cpp
+++ b/test/karma/regression_semantic_action_attribute.cpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 #include <boost/spirit/include/karma.hpp> 
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/repeat1.cpp
+++ b/test/karma/repeat1.cpp
@@ -19,8 +19,8 @@
 #include <boost/spirit/include/support_argument.hpp>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/karma/repeat2.cpp
+++ b/test/karma/repeat2.cpp
@@ -19,8 +19,8 @@
 #include <boost/spirit/include/support_argument.hpp>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/karma/sequence2.cpp
+++ b/test/karma/sequence2.cpp
@@ -16,9 +16,9 @@
 #include <boost/spirit/include/karma_auxiliary.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
 #include <boost/spirit/include/support_unused.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/fusion/include/vector.hpp>
 
 #include "test.hpp"

--- a/test/karma/stream.cpp
+++ b/test/karma/stream.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_string.hpp>
 #include <boost/spirit/include/karma_directive.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 

--- a/test/karma/wstream.cpp
+++ b/test/karma/wstream.cpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/include/karma_directive.hpp>
 
 #include <boost/cstdint.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <cwchar>
 #include <streambuf>
 #include <iostream>

--- a/test/lex/dedent_handling_phoenix.cpp
+++ b/test/lex/dedent_handling_phoenix.cpp
@@ -5,9 +5,9 @@
 
 #include <boost/spirit/include/lex.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 #include <iostream>

--- a/test/lex/lexer_state_switcher.cpp
+++ b/test/lex/lexer_state_switcher.cpp
@@ -5,8 +5,8 @@
 
 #include <boost/spirit/include/lex_lexertl.hpp>
 
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/lex/pch.hpp
+++ b/test/lex/pch.hpp
@@ -8,8 +8,8 @@
 
 #include <boost/spirit/include/lex.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <string>
 #include <iostream>

--- a/test/lex/regression_file_iterator3.cpp
+++ b/test/lex/regression_file_iterator3.cpp
@@ -12,9 +12,9 @@
 #include <boost/spirit/include/lex_lexertl.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include <sstream>
 

--- a/test/lex/regression_less_8563.cpp
+++ b/test/lex/regression_less_8563.cpp
@@ -6,8 +6,8 @@
 #include <boost/spirit/include/lex_lexertl.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <fstream>
 

--- a/test/lex/regression_wide.cpp
+++ b/test/lex/regression_wide.cpp
@@ -10,8 +10,8 @@
 #include <string>
 
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/function.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/lex/regression_word_count.cpp
+++ b/test/lex/regression_word_count.cpp
@@ -10,7 +10,7 @@
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_grammar.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/lex/set_token_value.cpp
+++ b/test/lex/set_token_value.cpp
@@ -5,9 +5,9 @@
 
 #include <boost/spirit/include/lex_lexertl.hpp>
 
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/lex/set_token_value_phoenix.cpp
+++ b/test/lex/set_token_value_phoenix.cpp
@@ -7,8 +7,8 @@
 #include <boost/spirit/include/lex_lexertl.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_function.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/function.hpp>
 #include <boost/phoenix/operator/self.hpp>
 #include <string>
 #include <iostream>

--- a/test/lex/string_token_id.cpp
+++ b/test/lex/string_token_id.cpp
@@ -11,7 +11,7 @@
 #include <boost/spirit/include/qi_grammar.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/test/lex/token_iterpair.cpp
+++ b/test/lex/token_iterpair.cpp
@@ -7,9 +7,9 @@
 #include <boost/spirit/include/lex_lexertl_position_token.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 namespace lex = boost::spirit::lex;
 namespace phoenix = boost::phoenix;

--- a/test/lex/token_moretypes.cpp
+++ b/test/lex/token_moretypes.cpp
@@ -7,9 +7,9 @@
 #include <boost/spirit/include/lex_lexertl_position_token.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 #include <boost/spirit/include/qi_numeric.hpp>
 
 namespace spirit = boost::spirit;

--- a/test/lex/token_omit.cpp
+++ b/test/lex/token_omit.cpp
@@ -7,9 +7,9 @@
 #include <boost/spirit/include/lex_lexertl_position_token.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 
 namespace lex = boost::spirit::lex;
 namespace phoenix = boost::phoenix;

--- a/test/lex/token_onetype.cpp
+++ b/test/lex/token_onetype.cpp
@@ -7,9 +7,9 @@
 #include <boost/spirit/include/lex_lexertl_position_token.hpp>
 
 #include <boost/core/lightweight_test.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/stl/container.hpp>
 #include <boost/spirit/include/qi_numeric.hpp>
 
 namespace spirit = boost::spirit;

--- a/test/qi/actions2.cpp
+++ b/test/qi/actions2.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/detail/workaround.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_bind.hpp>
+#include <boost/phoenix/bind.hpp>
 #include <string>
 #include "test.hpp"
 

--- a/test/qi/alternative.cpp
+++ b/test/qi/alternative.cpp
@@ -17,8 +17,8 @@
 #include <boost/spirit/include/qi_auxiliary.hpp>
 #include <boost/spirit/include/qi_rule.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant.hpp>
 #include <boost/assert.hpp>

--- a/test/qi/attr.cpp
+++ b/test/qi/attr.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_numeric.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <iostream>

--- a/test/qi/attribute1.cpp
+++ b/test/qi/attribute1.cpp
@@ -7,8 +7,6 @@
 =============================================================================*/
 #include <boost/spirit/include/qi_attr_cast.hpp>
 
-#include <boost/spirit/include/phoenix_limits.hpp>
-
 #include <boost/fusion/include/struct.hpp>
 #include <boost/fusion/include/nview.hpp>
 

--- a/test/qi/attribute2.cpp
+++ b/test/qi/attribute2.cpp
@@ -5,8 +5,6 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#include <boost/spirit/include/phoenix_limits.hpp>
-
 #include <boost/fusion/include/struct.hpp>
 #include <boost/fusion/include/nview.hpp>
 

--- a/test/qi/char1.cpp
+++ b/test/qi/char1.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/qi_char.hpp>
 
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/char2.cpp
+++ b/test/qi/char2.cpp
@@ -8,8 +8,8 @@
 #include <boost/spirit/include/qi_char.hpp> // not qi_lit.hpp!
 
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/char_class.cpp
+++ b/test/qi/char_class.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/spirit/include/support_attributes.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/static_assert.hpp>
 

--- a/test/qi/debug.cpp
+++ b/test/qi/debug.cpp
@@ -13,10 +13,10 @@
 #include <boost/spirit/include/qi_auxiliary.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_bind.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/bind.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/qi/difference.cpp
+++ b/test/qi/difference.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/encoding.cpp
+++ b/test/qi/encoding.cpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/include/qi_string.hpp>
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/end.cpp
+++ b/test/qi/end.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_auxiliary.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/eps.cpp
+++ b/test/qi/eps.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/spirit/include/qi_lazy.hpp>
 #include <boost/spirit/include/qi_not_predicate.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/core.hpp>
 #include <iostream>
 #include "test.hpp"
 

--- a/test/qi/expect.cpp
+++ b/test/qi/expect.cpp
@@ -19,9 +19,9 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/expectd.cpp
+++ b/test/qi/expectd.cpp
@@ -16,9 +16,9 @@
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/grammar.cpp
+++ b/test/qi/grammar.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_numeric.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/int.hpp
+++ b/test/qi/int.hpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <climits>
 
 #include "test.hpp"

--- a/test/qi/kleene.cpp
+++ b/test/qi/kleene.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/lazy.cpp
+++ b/test/qi/lazy.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/list.cpp
+++ b/test/qi/list.cpp
@@ -13,10 +13,10 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/stl/container.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <vector>

--- a/test/qi/lit1.cpp
+++ b/test/qi/lit1.cpp
@@ -9,8 +9,8 @@
 
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/lit2.cpp
+++ b/test/qi/lit2.cpp
@@ -11,8 +11,8 @@
 #include <boost/spirit/include/qi_string.hpp>
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/match_manip.hpp
+++ b/test/qi/match_manip.hpp
@@ -18,9 +18,9 @@
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_stream.hpp>
 #include <boost/spirit/include/qi_match_auto.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_statement.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/statement.hpp>
 
 #include <string>
 #include <sstream>

--- a/test/qi/no_case.cpp
+++ b/test/qi/no_case.cpp
@@ -10,8 +10,8 @@
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_string.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/omit.cpp
+++ b/test/qi/omit.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_numeric.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/optional.cpp
+++ b/test/qi/optional.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/adapted/struct.hpp>
 
 #include <iostream>

--- a/test/qi/pch.hpp
+++ b/test/qi/pch.hpp
@@ -8,8 +8,8 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>

--- a/test/qi/permutation.cpp
+++ b/test/qi/permutation.cpp
@@ -15,8 +15,8 @@
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/optional.hpp>
 
 #include <string>

--- a/test/qi/plus.cpp
+++ b/test/qi/plus.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include <string>

--- a/test/qi/regression_binary_action.cpp
+++ b/test/qi/regression_binary_action.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_omit.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/predef/other/endian.h>
 #include "test.hpp"

--- a/test/qi/regression_lazy_repeat.cpp
+++ b/test/qi/regression_lazy_repeat.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/core.hpp>
 
 #include "test.hpp"
 

--- a/test/qi/regression_one_element_fusion_sequence.cpp
+++ b/test/qi/regression_one_element_fusion_sequence.cpp
@@ -12,8 +12,8 @@
 #include <boost/spirit/include/qi_symbols.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <string>
 
 int main() 

--- a/test/qi/repeat.cpp
+++ b/test/qi/repeat.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <vector>

--- a/test/qi/rule2.cpp
+++ b/test/qi/rule2.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/qi/rule3.cpp
+++ b/test/qi/rule3.cpp
@@ -13,8 +13,8 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/qi/rule4.cpp
+++ b/test/qi/rule4.cpp
@@ -13,10 +13,10 @@
 #include <boost/spirit/include/qi_directive.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/qi_action.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_bind.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/bind.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <string>

--- a/test/qi/sequence.cpp
+++ b/test/qi/sequence.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <string>
 #include <iostream>

--- a/test/qi/sequential_or.cpp
+++ b/test/qi/sequential_or.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/support_argument.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/optional.hpp>
 
 #include <string>

--- a/test/qi/skip.cpp
+++ b/test/qi/skip.cpp
@@ -9,7 +9,7 @@
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_lexeme.hpp>
 #include <boost/spirit/include/qi_operator.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/phoenix/core.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/symbols1.cpp
+++ b/test/qi/symbols1.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <boost/core/lightweight_test_trait.hpp>
 

--- a/test/qi/symbols2.cpp
+++ b/test/qi/symbols2.cpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_nonterminal.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iostream>
 #include "test.hpp"

--- a/test/qi/terminal_ex.cpp
+++ b/test/qi/terminal_ex.cpp
@@ -8,8 +8,8 @@
 
 #include <boost/spirit/include/qi_operator.hpp>
 #include <boost/spirit/include/qi_char.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include <iterator>
 #include "test.hpp"

--- a/test/qi/uint.hpp
+++ b/test/qi/uint.hpp
@@ -14,8 +14,8 @@
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_action.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #include "test.hpp"
 #include <climits>

--- a/test/support/regression_multi_pass_error_handler.cpp
+++ b/test/support/regression_multi_pass_error_handler.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/spirit/include/support_multi_pass.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <sstream>

--- a/workbench/qi/attr_vs_actions.cpp
+++ b/workbench/qi/attr_vs_actions.cpp
@@ -4,10 +4,10 @@
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/fusion/include/io.hpp>
 

--- a/workbench/qi/keywords.cpp
+++ b/workbench/qi/keywords.cpp
@@ -13,11 +13,11 @@
 
 #include "../measure.hpp"
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
-#include <boost/spirit/include/phoenix_container.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl/container.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/fusion/include/io.hpp>
 #include <boost/spirit/include/qi_permutation.hpp>

--- a/workbench/unicode/create_tables.cpp
+++ b/workbench/unicode/create_tables.cpp
@@ -5,7 +5,7 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/cstdint.hpp>


### PR DESCRIPTION
There is no purpose in these transition headers, Phoenix V2 was removed 8 years ago.