### PR TITLE
Fix swapped parameters to `is_substitute`

### DIFF
--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -20,22 +20,22 @@
 
 namespace boost { namespace spirit { namespace qi { namespace detail
 {
-    template <typename Variant, typename Expected>
+    template <typename Variant, typename T>
     struct find_substitute
     {
-        // Get the type from the variant that can be a substitute for Expected.
-        // If none is found, just return Expected
+        // Get the type from the Variant that can be a substitute for T.
+        // If none is found, just return T
 
         typedef Variant variant_type;
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename mpl::find<types, Expected>::type iter_1;
+        typedef typename mpl::find<types, T>::type iter_1;
 
         typedef typename
             mpl::eval_if<
                 is_same<iter_1, end>,
-                mpl::find_if<types, traits::is_substitute<mpl::_1, Expected> >,
+                mpl::find_if<types, traits::is_substitute<T, mpl::_1> >,
                 mpl::identity<iter_1>
             >::type
         iter;
@@ -43,7 +43,7 @@ namespace boost { namespace spirit { namespace qi { namespace detail
         typedef typename
             mpl::eval_if<
                 is_same<iter, end>,
-                mpl::identity<Expected>,
+                mpl::identity<T>,
                 mpl::deref<iter>
             >::type
         type;

--- a/include/boost/spirit/home/x3/support/traits/variant_find_substitute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/variant_find_substitute.hpp
@@ -13,22 +13,22 @@
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
-    template <typename Variant, typename Attribute>
+    template <typename Variant, typename T>
     struct variant_find_substitute
     {
-        // Get the type from the variant that can be a substitute for Attribute.
-        // If none is found, just return Attribute
+        // Get the type from the Variant that can be a substitute for T.
+        // If none is found, just return T
 
         typedef Variant variant_type;
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename mpl::find<types, Attribute>::type iter_1;
+        typedef typename mpl::find<types, T>::type iter_1;
 
         typedef typename
             mpl::eval_if<
                 is_same<iter_1, end>,
-                mpl::find_if<types, traits::is_substitute<mpl::_1, Attribute> >,
+                mpl::find_if<types, traits::is_substitute<T, mpl::_1> >,
                 mpl::identity<iter_1>
             >::type
         iter;
@@ -36,7 +36,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         typedef typename
             mpl::eval_if<
                 is_same<iter, end>,
-                mpl::identity<Attribute>,
+                mpl::identity<T>,
                 mpl::deref<iter>
             >::type
         type;

--- a/include/boost/spirit/home/x3/support/traits/variant_has_substitute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/variant_has_substitute.hpp
@@ -13,22 +13,22 @@
 
 namespace boost { namespace spirit { namespace x3 { namespace traits
 {
-    template <typename Variant, typename Attribute>
+    template <typename Variant, typename T>
     struct variant_has_substitute_impl
     {
-        // Find a type from the variant that can be a substitute for Attribute.
+        // Find a type from the Variant that can be a substitute for T.
         // return true_ if one is found, else false_
 
         typedef Variant variant_type;
         typedef typename variant_type::types types;
         typedef typename mpl::end<types>::type end;
 
-        typedef typename mpl::find<types, Attribute>::type iter_1;
+        typedef typename mpl::find<types, T>::type iter_1;
 
         typedef typename
             mpl::eval_if<
                 is_same<iter_1, end>,
-                mpl::find_if<types, traits::is_substitute<mpl::_1, Attribute>>,
+                mpl::find_if<types, traits::is_substitute<T, mpl::_1>>,
                 mpl::identity<iter_1>
             >::type
         iter;
@@ -36,15 +36,15 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
         typedef mpl::not_<is_same<iter, end>> type;
     };
 
-    template <typename Variant, typename Attribute>
+    template <typename Variant, typename T>
     struct variant_has_substitute
-        : variant_has_substitute_impl<Variant, Attribute>::type {};
+        : variant_has_substitute_impl<Variant, T>::type {};
 
-    template <typename Attribute>
-    struct variant_has_substitute<unused_type, Attribute> : mpl::true_ {};
+    template <typename T>
+    struct variant_has_substitute<unused_type, T> : mpl::true_ {};
 
-    template <typename Attribute>
-    struct variant_has_substitute<unused_type const, Attribute> : mpl::true_ {};
+    template <typename T>
+    struct variant_has_substitute<unused_type const, T> : mpl::true_ {};
 
 }}}}
 

--- a/test/x3/alternative.cpp
+++ b/test/x3/alternative.cpp
@@ -274,5 +274,27 @@ main()
         BOOST_TEST_EQ(s, "abcbbcd");
     }
 
+    { // conversion between alternatives
+        struct X {};
+        struct Y {};
+        struct Z {};
+        boost::variant<X, Y, Z> v;
+        boost::variant<Y, X> x{X{}};
+        v = x; // boost::variant supports that convertion
+        auto const p = 'x' >> attr(x) | 'z' >> attr(Z{});
+        BOOST_TEST(test_attr("z", p, v));
+        BOOST_TEST(boost::get<Z>(&v) != nullptr);
+        BOOST_TEST(test_attr("x", p, v));
+        BOOST_TEST(boost::get<X>(&v) != nullptr);
+    }
+
+    { // regression test for #679
+        using Qaz = std::vector<boost::variant<int>>;
+        using Foo = std::vector<boost::variant<Qaz, int>>;
+        using Bar = std::vector<boost::variant<Foo, int>>;
+        Bar x;
+        BOOST_TEST(test_attr("abaabb", +('a' >> attr(Foo{}) | 'b' >> attr(int{})), x));
+    }
+
     return boost::report_errors();
 }


### PR DESCRIPTION
It seems that confusion in template parameters naming lead to mistakenly swapped types to `is_substitute`. The code to X3 have been brought from Qi with the same mistake, but I do not know how to trigger it in Qi.

Fixes #701
Fixes #679