### PR TITLE
Karma: fix off by factor 10 error when rounding to integer

### DIFF
--- a/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
+++ b/include/boost/spirit/home/karma/numeric/detail/real_utils.hpp
@@ -136,7 +136,7 @@ namespace boost { namespace spirit { namespace karma
             {
                 fractional_part = floor(fractional_part - precexp);
                 integer_part += 1;    // handle rounding overflow
-                if (integer_part >= 10.)
+                if (integer_part >= 10. && 0 == (Policies::fmtflags::fixed & flags))
                 {
                     integer_part /= 10.;
                     ++dim;

--- a/test/karma/real1.cpp
+++ b/test/karma/real1.cpp
@@ -145,6 +145,12 @@ int main()
         BOOST_TEST(test("1234.5000", trail_zeros(1234.5)));
         BOOST_TEST(test("12342.0000", trail_zeros(12342.)));
         BOOST_TEST(test("1.2342e05", trail_zeros(123420.)));
+
+        // Regression tests for issue #688
+        BOOST_TEST(test("10.0000", trail_zeros(9.99999)));
+        BOOST_TEST(test("103.0000", trail_zeros(102.99999)));
+        BOOST_TEST(test("-10.0000", trail_zeros(-9.99999)));
+        BOOST_TEST(test("-103.0000", trail_zeros(-102.99999)));
     }
 
     {


### PR DESCRIPTION
This fixes issue #688. There's some code that divides the integer part
by 10 and increases dim to compensate for it. This code is not
applicable to fixed notation, however, since dim is disregarded in that
case, causing the result to be off by a factor 10.

We can fix this by checking if we're not using fixed notation first,
before doing the division.

Added a few tests to check for this regression.