### PR TITLE
X3: Warn about future C++17 requirement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,7 @@ init:
   - set B2_ARGS=link=shared threading=multi variant=release
                 address-model=%ADDRMDL% toolset=%TOOLSET%
                 define=BOOST_ALL_NO_LIB
+                define=BOOST_SPIRIT_X3_HIDE_CXX17_WARNING
 
 before_build:
   - set PATH=%BOOST_ROOT%;C:\Python36-x64\Scripts;%PATH%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,6 @@ jobs:
 
           echo '==================================> SCRIPT'
 
-          b2 link=shared threading=multi variant=release,sanitize toolset=$TRAVIS_COMPILER cxxstd=$STD $STDLIB warnings=extra warnings-as-errors=on
+          b2 link=shared threading=multi variant=release,sanitize toolset=$TRAVIS_COMPILER cxxstd=$STD $STDLIB warnings=extra warnings-as-errors=on define=BOOST_SPIRIT_X3_HIDE_CXX17_WARNING
 
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,3 +152,4 @@ script:
   - b2 link=shared threading=multi variant=release,sanitize
       toolset=$TRAVIS_COMPILER cxxstd=$STD $STDLIB
       warnings=extra warnings-as-errors=on
+      define=BOOST_SPIRIT_X3_HIDE_CXX17_WARNING

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ executable.
 
 The newest Spirit shines faster compile times. Currently only a parser framework.
 
-Requires C++14 compiler (GCC 5, Clang 3.6, VS 2015 Update 3).
+*WARNING*: C++14 compilers support will be dropped soon.
+
+Spirit X3 in Boost 1.81 (scheduled to November 2022) will use C++17 features.
+
+Supported compilers will be:
+* Clang 4 (currently 3.6)
+* GCC 7 (currently 5)
+* VS 2017 v15.8 (currently 2015 U3)
 
 ### Spirit V2 (2nd generation)
 

--- a/doc/x3/spirit_x3.qbk
+++ b/doc/x3/spirit_x3.qbk
@@ -208,6 +208,15 @@
 This is the documentation of the newest version of __spirit__ (currently,
 __version__).
 
+*WARNING*: C++14 compilers support will be dropped soon.
+
+Spirit X3 in Boost 1.81 (scheduled to November 2022) will use C++17 features.
+
+Supported compilers will be:
+* Clang 4 (currently 3.6)
+* GCC 7 (currently 5)
+* VS 2017 v15.8 (currently 2015 U3)
+
 [include preface.qbk]
 [include introduction.qbk]
 [include include.qbk]s

--- a/include/boost/spirit/home/x3.hpp
+++ b/include/boost/spirit/home/x3.hpp
@@ -11,6 +11,40 @@
 #pragma once
 #endif
 
+#if !defined BOOST_SPIRIT_X3_HIDE_CXX17_WARNING && !( true \
+  && defined __cpp_if_constexpr && __cpp_if_constexpr >= 201606 \
+  && defined __cpp_inline_variables && __cpp_inline_variables >= 201606 \
+  && defined __cpp_fold_expressions && __cpp_fold_expressions >= 201603 \
+  && defined __cpp_variadic_using && __cpp_variadic_using >= 201611 \
+  && (defined __cpp_template_auto && __cpp_template_auto >= 201606 \
+      || defined __cpp_nontype_template_parameter_auto && __cpp_nontype_template_parameter_auto >= 201606) \
+  && defined __cpp_nontype_template_args && __cpp_nontype_template_args >= 201411 \
+)
+# define BOOST_SPIRIT_X3_STRINGIZE_IMPL(x) #x
+# define BOOST_SPIRIT_X3_STRINGIZE(x) BOOST_SPIRIT_X3_STRINGIZE_IMPL(x)
+# if defined __GNUC__ || defined __clang__
+#  warning "Spirit X3 will soon use C++17 features which your compiler does not support"
+#  warning "Minimal supported compiler versions: Clang 4 / GCC 7 / MSC 1915 (VS 2017 v15.8)"
+#  if defined __clang__
+#   pragma message "This compiler seems to be Clang " BOOST_SPIRIT_X3_STRINGIZE(__clang_major__)
+#  else
+#   pragma message "This compiler seems to be GCC " BOOST_SPIRIT_X3_STRINGIZE(__GNUC__)
+#  endif
+#  warning "Define BOOST_SPIRIT_X3_HIDE_CXX17_WARNING to hide the warning"
+# elif defined _MSC_VER
+#  pragma message (__FILE__ "(" BOOST_SPIRIT_X3_STRINGIZE(__LINE__) "): warning: Spirit X3 will soon use C++17 features which your compiler does not support" )
+#  pragma message (__FILE__ "(" BOOST_SPIRIT_X3_STRINGIZE(__LINE__) "): warning: Minimal supported compiler versions: Clang 4 / GCC 7 / MSC 1915 (VS 2017 v15.8)" )
+#  pragma message (__FILE__ "(" BOOST_SPIRIT_X3_STRINGIZE(__LINE__) "): warning: This compiler seems to be MSC " BOOST_SPIRIT_X3_STRINGIZE(_MSC_VER) )
+#  pragma message (__FILE__ "(" BOOST_SPIRIT_X3_STRINGIZE(__LINE__) "): warning: Define BOOST_SPIRIT_X3_HIDE_CXX17_WARNING to hide the warning" )
+# else
+#  pragma message "warning: Spirit X3 will soon use C++17 features which your compiler does not support"
+#  pragma message "warning: Minimal supported compiler versions: Clang 4 / GCC 7 / MSC 1915 (VS 2017 v15.8)"
+#  pragma message "warning: Define BOOST_SPIRIT_X3_HIDE_CXX17_WARNING to hide the warning"
+# endif
+# undef BOOST_SPIRIT_X3_STRINGIZE
+# undef BOOST_SPIRIT_X3_STRINGIZE_IMPL
+#endif
+
 #include <boost/spirit/home/x3/auxiliary.hpp>
 #include <boost/spirit/home/x3/char.hpp>
 #include <boost/spirit/home/x3/directive.hpp>


### PR DESCRIPTION
I plan to keep the warning for two releases before starting to utilize C++17 features.

Since Boost 1.81 (scheduled to November 2022) supported compilers will be:
* Clang 4 (currently 3.6)
* GCC 7 (currently 5)
* VS 2017 (currently 2015)