### PR TITLE
X3: Fix `on_success` dispatcher inverted iterator const/mutability

### DIFF
--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -117,7 +117,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
             decltype(void(
                 std::declval<ID>().on_success(
                     std::declval<Iterator&>()
-                  , std::declval<Iterator>()
+                  , std::declval<Iterator&>()
                   , std::declval<Attribute&>()
                   , std::declval<Context>()
                 )
@@ -158,7 +158,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& /* first */, Iterator const& /* last */
+            Iterator& /* before */, Iterator& /* after */
           , Context const& /* context */, ActualAttribute& /* attr */
           , mpl::false_ /* No on_success handler */ )
         {
@@ -167,14 +167,14 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
 
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& first, Iterator const& last
+            Iterator& before, Iterator& after
           , Context const& context, ActualAttribute& attr
           , mpl::true_ /* Has on_success handler */)
         {
             bool pass = true;
             ID().on_success(
-                first
-              , last
+                before
+              , after
               , attr
               , make_context<parse_pass_context_tag>(pass, context)
             );

--- a/test/x3/rule4.cpp
+++ b/test/x3/rule4.cpp
@@ -43,6 +43,31 @@ struct my_rule_class
     }
 };
 
+struct on_success_advance_iterator
+{
+    template <typename Iterator, typename Attribute, typename Context>
+    void on_success(Iterator const&, Iterator& after, Attribute&, Context const&)
+    {
+        ++after;
+    }
+};
+struct on_success_advance_iterator_mutref
+{
+    template <typename Iterator, typename Attribute, typename Context>
+    void on_success(Iterator&, Iterator& after, Attribute&, Context const&)
+    {
+        ++after;
+    }
+};
+struct on_success_advance_iterator_byval
+{
+    template <typename Iterator, typename Attribute, typename Context>
+    void on_success(Iterator, Iterator& after, Attribute&, Context const&)
+    {
+        ++after;
+    }
+};
+
 int
 main()
 {
@@ -114,6 +139,18 @@ main()
         BOOST_TEST(!test("[123,456]", r));
 
         BOOST_TEST(got_it == 1);
+    }
+
+    { // on_success handler mutable 'after' iterator
+        auto r1 = rule<on_success_advance_iterator, char const*>()
+            = lit("ab");
+        BOOST_TEST(test("abc", r1));
+        auto r2 = rule<on_success_advance_iterator_mutref, char const*>()
+            = lit("ab");
+        BOOST_TEST(test("abc", r2));
+        auto r3 = rule<on_success_advance_iterator_byval, char const*>()
+            = lit("ab");
+        BOOST_TEST(test("abc", r3));
     }
 
     {


### PR DESCRIPTION
Instead of usual `[current, end)` pair it receives `[before, current)` pair.

Fixes https://github.com/boostorg/spirit/issues/703#issuecomment-1011021773