### PR TITLE
X3: Return back iterator pre-skipping for `on_success` handler

### DIFF
--- a/doc/x3/tutorial/annotation.qbk
+++ b/doc/x3/tutorial/annotation.qbk
@@ -115,6 +115,9 @@ successful parse without polluting the grammar. Like semantic actions,
 But, unlike semantic actions, `on_success` handlers are cleanly separated
 from the actual grammar.
 
+[*Note:] an `on_success` handler recieves a pre-skipped iterator even when
+the rule definition disables pre-skipping via `no_skip` directive.
+
 [heading Annotation Handler]
 
 As discussed, we annotate the AST with its position in the input stream with

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -171,6 +171,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
           , Context const& context, ActualAttribute& attr
           , mpl::true_ /* Has on_success handler */)
         {
+            x3::skip_over(before, after, context);
             bool pass = true;
             ID().on_success(
                 before

--- a/test/x3/rule4.cpp
+++ b/test/x3/rule4.cpp
@@ -43,6 +43,18 @@ struct my_rule_class
     }
 };
 
+struct on_success_gets_preskipped_iterator
+{
+    static bool ok;
+
+    template <typename Iterator, typename Attribute, typename Context>
+    void on_success(Iterator before, Iterator& after, Attribute&, Context const&)
+    {
+        ok = ('b' == *before) && (++before == after);
+    }
+};
+bool on_success_gets_preskipped_iterator::ok = false;
+
 struct on_success_advance_iterator
 {
     template <typename Iterator, typename Attribute, typename Context>
@@ -139,6 +151,13 @@ main()
         BOOST_TEST(!test("[123,456]", r));
 
         BOOST_TEST(got_it == 1);
+    }
+
+    { // on_success gets pre-skipped iterator
+        auto r = rule<on_success_gets_preskipped_iterator, char const*>()
+            = lit("b");
+        BOOST_TEST(test("a b", 'a' >> r, lit(' ')));
+        BOOST_TEST(on_success_gets_preskipped_iterator::ok);
     }
 
     { // on_success handler mutable 'after' iterator


### PR DESCRIPTION
Reverts the wrong part of #686. Fixes a half of #712 (`positions.position_of()`/`annotation.cpp` example part).