### PR TITLE
Avoid some of the deprecated copy warnings

### DIFF
--- a/include/boost/spirit/home/qi/action/action.hpp
+++ b/include/boost/spirit/home/qi/action/action.hpp
@@ -139,6 +139,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(action& operator= (action const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        action(const action&) = default;
+#endif
     };
 }}}
 

--- a/include/boost/spirit/home/qi/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/qi/auxiliary/attr.hpp
@@ -75,6 +75,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(attr_parser& operator= (attr_parser const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        attr_parser(const attr_parser&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
+++ b/include/boost/spirit/home/qi/auxiliary/attr_cast.hpp
@@ -116,6 +116,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(attr_cast_parser& operator= (attr_cast_parser const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        attr_cast_parser(const attr_cast_parser&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/detail/alternative_function.hpp
+++ b/include/boost/spirit/home/qi/detail/alternative_function.hpp
@@ -176,6 +176,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(alternative_function& operator= (alternative_function const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        alternative_function(const alternative_function&) = default;
+#endif
     };
 
     template <typename Iterator, typename Context, typename Skipper>
@@ -203,6 +206,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(alternative_function& operator= (alternative_function const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        alternative_function(const alternative_function&) = default;
+#endif
     };
 
 }}}}

--- a/include/boost/spirit/home/qi/detail/expect_function.hpp
+++ b/include/boost/spirit/home/qi/detail/expect_function.hpp
@@ -98,6 +98,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(expect_function& operator= (expect_function const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        expect_function(const expect_function&) = default;
+#endif
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/fail_function.hpp
+++ b/include/boost/spirit/home/qi/detail/fail_function.hpp
@@ -52,6 +52,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(fail_function& operator= (fail_function const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        fail_function(const fail_function&) = default;
+#endif
     };
 }}}}
 

--- a/include/boost/spirit/home/qi/detail/pass_container.hpp
+++ b/include/boost/spirit/home/qi/detail/pass_container.hpp
@@ -356,6 +356,9 @@ namespace boost { namespace spirit { namespace qi { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(pass_container& operator= (pass_container const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        pass_container(const pass_container&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/directive/omit.hpp
+++ b/include/boost/spirit/home/qi/directive/omit.hpp
@@ -72,6 +72,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(omit_directive& operator= (omit_directive const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        omit_directive(const omit_directive&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/directive/repeat.hpp
+++ b/include/boost/spirit/home/qi/directive/repeat.hpp
@@ -93,6 +93,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(exact_iterator& operator= (exact_iterator const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        exact_iterator(const exact_iterator&) = default;
+#endif
     };
 
     template <typename T>
@@ -112,6 +115,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(finite_iterator& operator= (finite_iterator const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        finite_iterator(const finite_iterator&) = default;
+#endif
     };
 
     template <typename T>
@@ -208,6 +214,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(repeat_parser& operator= (repeat_parser const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        repeat_parser(const repeat_parser&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/qi/string/lit.hpp
+++ b/include/boost/spirit/home/qi/string/lit.hpp
@@ -120,6 +120,9 @@ namespace boost { namespace spirit { namespace qi
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(literal_string& operator= (literal_string const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        literal_string(const literal_string&) = default;
+#endif
     };
 
     template <typename String, bool no_attribute>

--- a/include/boost/spirit/home/support/nonterminal/expand_arg.hpp
+++ b/include/boost/spirit/home/support/nonterminal/expand_arg.hpp
@@ -80,6 +80,9 @@ namespace boost { namespace spirit { namespace detail
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(expand_arg& operator= (expand_arg const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        expand_arg(const expand_arg&) = default;
+#endif
     };
 
 }}}

--- a/include/boost/spirit/home/support/terminal.hpp
+++ b/include/boost/spirit/home/support/terminal.hpp
@@ -490,6 +490,9 @@ namespace boost { namespace spirit
 
         // silence MSVC warning C4512: assignment operator could not be generated
         BOOST_DELETED_FUNCTION(terminal& operator= (terminal const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        terminal(const terminal&) = default;
+#endif
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -547,6 +550,9 @@ namespace boost { namespace spirit
 
             // silence MSVC warning C4512: assignment operator could not be generated
             BOOST_DELETED_FUNCTION(stateful_tag& operator= (stateful_tag const&))
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            stateful_tag(const stateful_tag&) = default;
+#endif
         };
     }
 

--- a/include/boost/spirit/home/support/unused.hpp
+++ b/include/boost/spirit/home/support/unused.hpp
@@ -27,6 +27,8 @@ namespace boost { namespace spirit
     struct unused_type
     {
         BOOST_DEFAULTED_FUNCTION(unused_type(), {})
+        BOOST_DEFAULTED_FUNCTION(unused_type(const unused_type& ), {})
+        BOOST_DEFAULTED_FUNCTION(unused_type& operator=(const unused_type& ), { return *this; })
 
         template <typename T>
         unused_type(T const&)

--- a/include/boost/spirit/home/support/unused.hpp
+++ b/include/boost/spirit/home/support/unused.hpp
@@ -27,8 +27,6 @@ namespace boost { namespace spirit
     struct unused_type
     {
         BOOST_DEFAULTED_FUNCTION(unused_type(), {})
-        BOOST_DEFAULTED_FUNCTION(unused_type(const unused_type& ), {})
-        BOOST_DEFAULTED_FUNCTION(unused_type& operator=(const unused_type& ), { return *this; })
 
         template <typename T>
         unused_type(T const&)


### PR DESCRIPTION
The patch fixes only some of the warnings. Remaining warnings could be located via `./b2 libs/spirit/test/ cxxstd=17 "cxxflags=-Werror=deprecated-copy" toolset=clang-15 -j4`