### PR TITLE
Fix: correctly count consecutive empty lines with line_pos_iterator

### DIFF
--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -37,12 +37,20 @@ namespace boost { namespace spirit
         std::size_t position() const;
 
     private:
+
+        enum class newline_type : unsigned char {
+            unknown = 0,
+            unix,
+            windows
+        };
+
         friend class boost::iterator_core_access;
 
         void increment();
 
         std::size_t line; // The line position.
         typename std::iterator_traits<Iterator>::value_type prev;
+        newline_type nltype = newline_type::unknown;
     };
     //]
 
@@ -68,14 +76,31 @@ namespace boost { namespace spirit
       
         switch (ref) {
           case '\r':
+            switch (nltype) {
+              case newline_type::unix:
             if (prev != '\n')
               ++line;
             break;
+              case newline_type::unknown:
+                  nltype = newline_type::windows;
+              default:
+                  ++line;
+            }
+            break;
           case '\n':
+            switch (nltype) {
+                case newline_type::windows:
             if (prev != '\r')
               ++line;
             break;
+                case newline_type::unknown:
+                    nltype = newline_type::unix;
+                default:
+                ++line;
+            }
+            break;
           default:
+            nltype = newline_type::unknown;
             break;
         }
       

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -50,17 +50,17 @@ namespace boost { namespace spirit
 
         std::size_t line; // The line position.
         typename std::iterator_traits<Iterator>::value_type prev;
-        newline_type nltype = unknown;
+        newline_type nltype;
     };
     //]
 
     template <class Iterator>
     line_pos_iterator<Iterator>::line_pos_iterator() :
-        line_pos_iterator::iterator_adaptor_(), line(1), prev(0) { }
+        line_pos_iterator::iterator_adaptor_(), line(1), prev(0), nltype(unknown) { }
 
     template <class Iterator>
     line_pos_iterator<Iterator>::line_pos_iterator(Iterator base) :
-        line_pos_iterator::iterator_adaptor_(base), line(1), prev(0) { }
+        line_pos_iterator::iterator_adaptor_(base), line(1), prev(0), nltype(unknown) { }
 
     template <class Iterator>
     std::size_t line_pos_iterator<Iterator>::position() const

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace spirit
 
     private:
 
-        enum class newline_type : unsigned char {
+        enum newline_type {
             unknown = 0,
             unix,
             windows
@@ -50,7 +50,7 @@ namespace boost { namespace spirit
 
         std::size_t line; // The line position.
         typename std::iterator_traits<Iterator>::value_type prev;
-        newline_type nltype = newline_type::unknown;
+        newline_type nltype = unknown;
     };
     //]
 
@@ -77,30 +77,32 @@ namespace boost { namespace spirit
         switch (ref) {
           case '\r':
             switch (nltype) {
-              case newline_type::unix:
+              case unix:
             if (prev != '\n')
               ++line;
             break;
-              case newline_type::unknown:
-                  nltype = newline_type::windows;
+              case unknown:
+                  nltype = windows;
+                  BOOST_FALLTHROUGH;
               default:
                   ++line;
             }
             break;
           case '\n':
             switch (nltype) {
-                case newline_type::windows:
+                case windows:
             if (prev != '\r')
               ++line;
             break;
-                case newline_type::unknown:
-                    nltype = newline_type::unix;
+                case unknown:
+                    nltype = unix;
+                    BOOST_FALLTHROUGH;
                 default:
                 ++line;
             }
             break;
           default:
-            nltype = newline_type::unknown;
+            nltype = unknown;
             break;
         }
       

--- a/test/support/regression_line_pos_iterator.cpp
+++ b/test/support/regression_line_pos_iterator.cpp
@@ -124,23 +124,64 @@ void testLRorCR_foo_bar(std::string const& line_break) {
     test(input, validations);
 }
 
+// Multiple Empty Lines
+
+void  testMultipleEmptyLines(std::string const& line_break) {
+    std::string const input = "foo" + line_break + "bar"
+                            + line_break + line_break + "foo"
+                            + line_break + line_break + line_break + "bar";
+    validations const validations = boost::assign::list_of<validation>
+        (1,1,"foo")(1,2,"foo")(1,3,"foo")(1,4,"foo")
+        (2,1,"bar")(2,2,"bar")(2,3,"bar")(2,4,"bar")
+        (3,1,"")
+        (4,1,"foo")(4,2,"foo")(4,3,"foo")(4,4,"foo")
+        (5,1,"")
+        (6,1,"")
+        (7,1,"bar")(7,2,"bar")(7,3,"bar");
+    test(input, validations);
+}
+
+void  testMultipleEmptyLinesRN(std::string const& line_break) {
+    std::string const input = "foo" + line_break + "bar"
+                            + line_break + line_break + "foo"
+                            + line_break + line_break + line_break + "bar";
+    validations const validations = boost::assign::list_of<validation>
+        (1,1,"foo")(1,2,"foo")(1,3,"foo")(1,4,"foo")
+        (2,1,"")(2,1,"bar")(2,2,"bar")(2,3,"bar")(2,4,"bar")
+        (3,1,"")(3,1,"")
+        (4,1,"")(4,1,"foo")(4,2,"foo")(4,3,"foo")(4,4,"foo")
+        (5,1,"")(5,1,"")
+        (6,1,"")(6,1,"")
+        (7,1,"")(7,1,"bar")(7,2,"bar")(7,3,"bar");
+    test(input, validations);
+}
+
 int main()
 {
+    // Windows, DOS, TOS and most other early non-Unix and non-IBM operating systems
     testLRandCR("\r\n");
     testLRandCR_foo_bar_git("\r\n");
     testLRandCR_bar_git("\r\n");
     testLRandCR_foo_bar("\r\n");
 
+    // Acorn BBC and RISC OS spooled text output
     testLRandCR("\n\r");
     testLRandCR_foo_bar_git("\n\r");
     testLRandCR_bar_git("\n\r");
     testLRandCR_foo_bar("\n\r");
 
+    testMultipleEmptyLines("\r");
+    testMultipleEmptyLines("\n");
+    testMultipleEmptyLinesRN("\r\n");
+    testMultipleEmptyLinesRN("\n\r");
+
+    // classic Mac OS, C64 ...
     testLRorCR("\r");
     testLRorCR_foo_bar_git("\r");
     testLRorCR_bar_git("\r");
     testLRorCR_foo_bar("\r");
 
+    // Unix and Unix-like systems (Linux, macOS, Amiga...)
     testLRorCR("\n");
     testLRorCR_foo_bar_git("\n");
     testLRorCR_bar_git("\n");


### PR DESCRIPTION
Bugfix for: line_pos_iterator in spirit loses count of some lines when they are multiple consecutive empty lines and the newline-type is `\r\n` or `\n\r`