### PR TITLE
line_pos_iterator now detecs underlying bidirectional iterator

### DIFF
--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -38,8 +38,7 @@ namespace boost { namespace spirit
     public:
         line_pos_iterator();
 
-        explicit line_pos_iterator(Iterator);
-        explicit line_pos_iterator(line_pos_iterator, Iterator);
+        explicit line_pos_iterator(Iterator, std::size_t line_start = 1);
 
         std::size_t position() const;
 
@@ -59,16 +58,8 @@ namespace boost { namespace spirit
         line_pos_iterator::iterator_adaptor_(), line(1), prev_n(), prev_r() { }
 
     template <class Iterator>
-    line_pos_iterator<Iterator>::line_pos_iterator(Iterator base) :
-        line_pos_iterator::iterator_adaptor_(base), line(1), prev_n(), prev_r() { }
-
-
-    template <class Iterator>
-    line_pos_iterator<Iterator>::line_pos_iterator(line_pos_iterator line_data, Iterator base) :
-        line_pos_iterator::iterator_adaptor_(base)
-        , line(line_data.line)
-        , prev_n(), prev_r()
-    { }
+    line_pos_iterator<Iterator>::line_pos_iterator(Iterator base, std::size_t line_start /* = 1 */ ) :
+        line_pos_iterator::iterator_adaptor_(base), line(line_start), prev_n(), prev_r() { }
 
     template <class Iterator>
     std::size_t line_pos_iterator<Iterator>::position() const
@@ -210,7 +201,7 @@ namespace boost { namespace spirit
         template <class Iterator, class IteratorBound>
         inline line_pos_iterator<Iterator> make_first_iterator_type(line_pos_iterator<Iterator> type_and_line, IteratorBound base_iterator)
         {
-            return line_pos_iterator<Iterator>(type_and_line, base_iterator);
+            return line_pos_iterator<Iterator>(base_iterator, type_and_line.position());
         }
 
 

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -3,6 +3,7 @@
     Copyright (c) 2010      Bryce Lelbach
     Copyright (c) 2014      Tomoki Imai
     Copyright (c) 2023      Kniazev Nikita
+    Copyright (c) 2023      Tobias Loew
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +12,7 @@
 #if !defined(BOOST_SPIRIT_SUPPORT_LINE_POS_ITERATOR)
 #define BOOST_SPIRIT_SUPPORT_LINE_POS_ITERATOR
 
+#include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
@@ -76,30 +78,46 @@ namespace boost { namespace spirit
         ++this->base_reference();
     }
 
+
+    template<typename Iterator>
+    struct line_pos_base_iterator_type {
+        typedef Iterator type;
+    };
+
+    template<typename Iterator>
+    struct line_pos_base_iterator_type< line_pos_iterator<Iterator> > {
+        typedef Iterator type;
+    };
+
+
+
     //[line_pos_iterator_utilities
     //`[heading get_line]
     template <class Iterator>
     inline std::size_t get_line(Iterator);
+
+    template <class Iterator>
+    inline std::size_t get_line(line_pos_iterator<Iterator>);
     /*`Get the line position. Returns -1 if Iterator is not a
        `line_pos_iterator`. */
 
     //`[heading get_line_start]
-    template <class Iterator>
-    inline Iterator get_line_start(Iterator lower_bound, Iterator current); 
+    template <class Iterator, class IteratorBound>
+    inline typename line_pos_base_iterator_type<Iterator>::type get_line_start(IteratorBound lower_bound, Iterator current);
     /*`Get an iterator to the beginning of the line. Applicable to any
        iterator. */
 
     //`[heading get_current_line]
-    template <class Iterator>
-    inline iterator_range<Iterator>
-    get_current_line(Iterator lower_bound, Iterator current,
-                     Iterator upper_bound); 
+    template <class Iterator, class IteratorBound>
+    inline iterator_range<typename line_pos_base_iterator_type<Iterator>::type>
+    get_current_line(IteratorBound lower_bound, Iterator current,
+        IteratorBound upper_bound);
     /*`Get an `iterator_range` containing the current line. Applicable to any
        iterator. */ 
 
     //`[heading get_column]
-    template <class Iterator>
-    inline std::size_t get_column(Iterator lower_bound, Iterator current,
+    template <class Iterator, class IteratorBound>
+    inline std::size_t get_column(IteratorBound lower_bound, Iterator current,
                                   std::size_t tabs = 4); 
     /*`Get the current column. Applicable to any iterator. */ 
     //]
@@ -115,56 +133,137 @@ namespace boost { namespace spirit
     {
         return i.position();
     }
-    
-    template <class Iterator>
-    inline Iterator get_line_start(Iterator lower_bound, Iterator current)
-    {
-        Iterator latest = lower_bound;
-        bool prev_was_newline = false;
-        for (Iterator i = lower_bound; i != current; ++i) {
-            if (prev_was_newline) {
-                latest = i;
+
+
+    namespace impl {
+
+        template<typename Iterator>
+        struct line_pos_base_iterator_category {
+            typedef typename boost::iterators::iterator_category<
+                typename line_pos_base_iterator_type<Iterator>::type
+            >::type type;
+        };
+
+
+        template<typename Iterator>
+        inline typename line_pos_base_iterator_type<Iterator>::type
+            get_line_pos_base_iterator(Iterator it)
+        {
+            return it;
+        }
+
+        template<typename Iterator>
+        inline typename line_pos_base_iterator_type<Iterator>::type
+            get_line_pos_base_iterator(line_pos_iterator<Iterator> it)
+        {
+            return it.base();
+        }
+
+
+        // get_line_start for forward iterators: forward linear search starting from lower-bound
+        // complexity: linear in length of [lower_bound, current)
+        template <class Iterator>
+        inline Iterator get_line_start(
+                Iterator lower_bound,
+                Iterator current, 
+                std::forward_iterator_tag
+            )
+        {
+            Iterator latest = lower_bound;
+            bool prev_was_newline = false;
+            for (Iterator i = lower_bound; i != current; ++i) {
+                if (prev_was_newline) {
+                    latest = i;
+                }
+                prev_was_newline = (*i == '\r') || (*i == '\n');
             }
-            prev_was_newline = (*i == '\r') || (*i == '\n');
+            if (prev_was_newline) {
+                latest = current;
+            }
+            return latest;
         }
-        if (prev_was_newline) {
-            latest = current;
+
+
+        // get_line_start for forward iterators: backard linear search starting from current
+        // complexity: linear in avarage line-length
+        template <class Iterator>
+        inline Iterator get_line_start(
+                Iterator lower_bound,
+                Iterator current,
+                std::bidirectional_iterator_tag
+        )
+        {
+            if (current == lower_bound) {
+                return current;
+            }
+            else {
+                for (typename line_pos_base_iterator_type<Iterator>::type i = std::prev(current); i != lower_bound; --i) {
+                    if ((*i == '\r') || (*i == '\n')) {
+                        return std::next(i);
+                    }
+                }
+                if ((*lower_bound == '\r') || (*lower_bound == '\n')) {
+                    return std::next(lower_bound);
+                }
+                else {
+                    return lower_bound;
+                }
+            }
         }
-        return latest;
     }
 
-    template <class Iterator>
-    inline Iterator get_line_end(Iterator current, Iterator upper_bound)
+
+
+
+    template <class Iterator, class IteratorBound>
+    inline typename line_pos_base_iterator_type<Iterator>::type get_line_start(IteratorBound lower_bound, Iterator current)
     {
-        for (Iterator i = current; i != upper_bound; ++i) {
+        return impl::get_line_start(
+            impl::get_line_pos_base_iterator(lower_bound),
+            impl::get_line_pos_base_iterator(current),
+            typename impl::line_pos_base_iterator_category<Iterator>::type()
+        );
+    }
+
+
+
+    template <class Iterator, class IteratorBound>
+    inline typename line_pos_base_iterator_type<Iterator>::type get_line_end(Iterator current, IteratorBound upper_bound)
+    {
+        typename line_pos_base_iterator_type<Iterator>::type upper_bound_base = impl::get_line_pos_base_iterator(upper_bound);
+        for (typename line_pos_base_iterator_type<Iterator>::type i = impl::get_line_pos_base_iterator(current);
+            i != upper_bound_base; ++i) {
             if ((*i == '\n') || (*i == '\r')) {
                 return i;
             }
         }
-        return upper_bound;
+        return upper_bound_base;
     }
 
     
-    template <class Iterator>
-    inline iterator_range<Iterator>
-    get_current_line(Iterator lower_bound,
-                     Iterator current,
-                     Iterator upper_bound)
+    template <class Iterator, class IteratorBound>
+    inline iterator_range<typename line_pos_base_iterator_type<Iterator>::type>
+        get_current_line(IteratorBound lower_bound, Iterator current,
+            IteratorBound upper_bound)
     {
-        Iterator first = get_line_start(lower_bound, current);
-        Iterator last = get_line_end(current, upper_bound);
-        return iterator_range<Iterator>(first, last);
+        typename line_pos_base_iterator_type<Iterator>::type current_base = impl::get_line_pos_base_iterator(current);
+
+        typename line_pos_base_iterator_type<Iterator>::type first = get_line_start(impl::get_line_pos_base_iterator(lower_bound), current_base);
+        typename line_pos_base_iterator_type<Iterator>::type last = get_line_end(current_base, impl::get_line_pos_base_iterator(upper_bound));
+        return iterator_range<typename line_pos_base_iterator_type<Iterator>::type>(first, last);
     }
     
-    template <class Iterator>
-    inline std::size_t get_column(Iterator lower_bound,
+    template <class Iterator, class IteratorBound>
+    inline std::size_t get_column(IteratorBound lower_bound,
                                   Iterator current,
                                   std::size_t tabs)
     {
+        typename line_pos_base_iterator_type<Iterator>::type current_base = impl::get_line_pos_base_iterator(current);
+
         std::size_t column = 1;
-        Iterator first = get_line_start(lower_bound, current);
+        typename line_pos_base_iterator_type<Iterator>::type first = get_line_start(lower_bound, current_base);
       
-        for (Iterator i = first; i != current; ++i) {
+        for (typename line_pos_base_iterator_type<Iterator>::type i = first; i != current_base; ++i) {
           switch (*i) {
             case '\t':
               column += tabs - (column - 1) % tabs;

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -239,13 +239,11 @@ namespace boost { namespace spirit
     }
 
     template <class Iterator>
-    std::size_t get_column(line_pos_iterator<Iterator> lower_bound,
-                           line_pos_iterator<Iterator> current,
-                           std::size_t tabs)
+    inline std::size_t get_column(line_pos_iterator<Iterator> lower_bound,
+                                  line_pos_iterator<Iterator> current,
+                                  std::size_t tabs = 4)
     {
-        // No need in line number counting because it will be the same
-        Iterator it = get_column(lower_bound.base(), current.base(), tabs);
-        return line_pos_iterator<Iterator>(it, current.position());
+        return get_column(lower_bound.base(), current.base(), tabs);
     }
 
 }}

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -239,13 +239,13 @@ namespace boost { namespace spirit
 
 
     template <class Iterator>
-    inline iterator_range<line_pos_iterator<Iterator>>
+    inline iterator_range<line_pos_iterator<Iterator> >
         get_current_line(line_pos_iterator<Iterator> lower_bound, line_pos_iterator<Iterator> current,
             line_pos_iterator<Iterator> upper_bound)
     {
         // No need in line number counting because it will be the same
         iterator_range<Iterator> range = get_current_line(lower_bound.base(), current.base(), upper_bound.base());
-        return iterator_range<line_pos_iterator<Iterator>>(
+        return iterator_range<line_pos_iterator<Iterator> >(
             line_pos_iterator<Iterator>(range.begin(), current.position()),
             line_pos_iterator<Iterator>(range.end(), current.position())
         );

--- a/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
+++ b/include/boost/spirit/home/support/iterators/line_pos_iterator.hpp
@@ -15,6 +15,7 @@
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/range/iterator_range_core.hpp>
+#include <boost/next_prior.hpp>
 
 namespace boost { namespace spirit
 {
@@ -197,13 +198,13 @@ namespace boost { namespace spirit
                 return current;
             }
             else {
-                for (typename line_pos_base_iterator_type<Iterator>::type i = std::prev(current); i != lower_bound; --i) {
+                for (typename line_pos_base_iterator_type<Iterator>::type i = boost::prior(current); i != lower_bound; --i) {
                     if ((*i == '\r') || (*i == '\n')) {
-                        return std::next(i);
+                        return boost::next(i);
                     }
                 }
                 if ((*lower_bound == '\r') || (*lower_bound == '\n')) {
-                    return std::next(lower_bound);
+                    return boost::next(lower_bound);
                 }
                 else {
                     return lower_bound;

--- a/test/support/line_pos_iterator.cpp
+++ b/test/support/line_pos_iterator.cpp
@@ -1,6 +1,5 @@
 //  Copyright (c) 2014 Tomoki Imai
 //  Copyright (c) 2023 Nikita Knizev
-//  Copyright (c) 2023 Tobias Loew
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -42,22 +41,12 @@ void test(std::string const& input, validations const& validations, bool singlec
         if (expected->inside_newline && singlechar_newline)
             if (++expected == validations.end())
                 break;
-        {
-            boost::iterator_range<pos_iterator_t> const range = get_current_line(input_begin, position, input_end);
-            std::string const current(range.begin(), range.end());
+        boost::iterator_range<pos_iterator_t> const range = get_current_line(input_begin, position, input_end);
+        std::string const current(range.begin(), range.end());
 
-            BOOST_TEST_EQ(expected->line, get_line(position));
-            BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
-            BOOST_TEST_EQ(expected->current, current);
-        }
-        {
-            boost::iterator_range<std::string::const_iterator> const range = get_current_line_base(input_begin, position, input_end);
-            std::string const current(range.begin(), range.end());
-
-            BOOST_TEST_EQ(expected->line, get_line(position));
-            BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
-            BOOST_TEST_EQ(expected->current, current);
-        }
+        BOOST_TEST_EQ(expected->line, get_line(position));
+        BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
+        BOOST_TEST_EQ(expected->current, current);
     }
     if (expected != validations.end() && expected->inside_newline && singlechar_newline)
         ++expected;

--- a/test/support/line_pos_iterator.cpp
+++ b/test/support/line_pos_iterator.cpp
@@ -42,12 +42,22 @@ void test(std::string const& input, validations const& validations, bool singlec
         if (expected->inside_newline && singlechar_newline)
             if (++expected == validations.end())
                 break;
-        boost::iterator_range<std::string::const_iterator> const range = get_current_line(input_begin, position, input_end);
-        std::string const current(range.begin(), range.end());
+        {
+            boost::iterator_range<pos_iterator_t> const range = get_current_line(input_begin, position, input_end);
+            std::string const current(range.begin(), range.end());
 
-        BOOST_TEST_EQ(expected->line, get_line(position));
-        BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
-        BOOST_TEST_EQ(expected->current, current);
+            BOOST_TEST_EQ(expected->line, get_line(position));
+            BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
+            BOOST_TEST_EQ(expected->current, current);
+        }
+        {
+            boost::iterator_range<std::string::const_iterator> const range = get_current_line_base(input_begin, position, input_end);
+            std::string const current(range.begin(), range.end());
+
+            BOOST_TEST_EQ(expected->line, get_line(position));
+            BOOST_TEST_EQ(expected->column, get_column(input_begin, position));
+            BOOST_TEST_EQ(expected->current, current);
+        }
     }
     if (expected != validations.end() && expected->inside_newline && singlechar_newline)
         ++expected;

--- a/test/support/line_pos_iterator.cpp
+++ b/test/support/line_pos_iterator.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Tomoki Imai
 //  Copyright (c) 2023 Nikita Knizev
+//  Copyright (c) 2023 Tobias Loew
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying 
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -41,7 +42,7 @@ void test(std::string const& input, validations const& validations, bool singlec
         if (expected->inside_newline && singlechar_newline)
             if (++expected == validations.end())
                 break;
-        boost::iterator_range<pos_iterator_t> const range = get_current_line(input_begin, position, input_end);
+        boost::iterator_range<std::string::const_iterator> const range = get_current_line(input_begin, position, input_end);
         std::string const current(range.begin(), range.end());
 
         BOOST_TEST_EQ(expected->line, get_line(position));


### PR DESCRIPTION
line_pos_iterator now detecs underlying bidirectional iterator and uses iterator-tag dispatching to select appropriate implementations of get_line_start (for bidirectional-iterators: linear-complexity in line-length).
Breaking change: all functions now return underlying iterators instead of line_pos_iterators. But, since they are only used to get the bounds for the current line, returning a full line_pos_iterator seems unnecessary.