### PR TITLE
prefer auto to Rng::(const_)?iterator for generic String

### DIFF
--- a/include/boost/spirit/home/x3/string/detail/string_parse.hpp
+++ b/include/boost/spirit/home/x3/string/detail/string_parse.hpp
@@ -37,8 +37,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
       , Iterator& first, Iterator const& last, Attribute& attr, CaseCompareFunc const& compare)
     {
         Iterator i = first;
-        typename String::const_iterator stri = str.begin();
-        typename String::const_iterator str_last = str.end();
+        auto stri = str.begin();
+        auto const str_last = str.end();
 
         for (; stri != str_last; ++stri, ++i)
             if (i == last || (compare(*stri, *i) != 0))
@@ -68,9 +68,9 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         String const& ucstr, String const& lcstr
       , Iterator& first, Iterator const& last, Attribute& attr)
     {
-        typename String::const_iterator uc_i = ucstr.begin();
-        typename String::const_iterator uc_last = ucstr.end();
-        typename String::const_iterator lc_i = lcstr.begin();
+        auto uc_i = ucstr.begin();
+        auto const uc_last = ucstr.end();
+        auto lc_i = lcstr.begin();
         Iterator i = first;
 
         for (; uc_i != uc_last; ++uc_i, ++lc_i, ++i)

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -14,6 +14,7 @@
 #include <boost/fusion/include/deque.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/type_traits/make_void.hpp>
+#include <boost/range/iterator.hpp>
 
 #include <vector>
 #include <string>
@@ -33,7 +34,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
         template <typename T>
         struct is_container_impl<T, void_t<
-            typename T::value_type, typename T::iterator,
+            typename T::value_type, typename boost::range_iterator<T>::type,
             typename T::size_type, typename T::reference> > : mpl::true_ {};
 
         template <typename T, typename Enabler = void>

--- a/include/boost/spirit/home/x3/support/traits/string_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/string_traits.hpp
@@ -133,21 +133,19 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
 
     // Implementation for containers (includes basic_string).
     template <typename T, typename Str>
-    inline typename Str::const_iterator get_string_begin(Str const& str)
+    inline auto get_string_begin(Str const& str) -> decltype(str.begin())
     { return str.begin(); }
 
     template <typename T, typename Str>
-    inline typename Str::iterator
-    get_string_begin(Str& str)
+    inline auto get_string_begin(Str& str) -> decltype(str.begin())
     { return str.begin(); }
 
     template <typename T, typename Str>
-    inline typename Str::const_iterator get_string_end(Str const& str)
+    inline auto get_string_end(Str const& str) -> decltype(str.end())
     { return str.end(); }
 
     template <typename T, typename Str>
-    inline typename Str::iterator
-    get_string_end(Str& str)
+    inline auto get_string_end(Str& str) -> decltype(str.end())
     { return str.end(); }
 }}}}
 


### PR DESCRIPTION
1. c++20 ranges library does not require a range to have member type/alias iterator/const_iterator.
2. boost range library uses `typename boost::range_iterator<Rng>::type` instead of `Rng::iterator` because a customized Rng may not have member type/alias iterator/const_iterator. e.g. `std::pair<It, It>`.

Therefore for generic String type, `auto` is better than `Rng::(const_)?iterator`.
