### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/doc/qi/directive.qbk
+++ b/doc/qi/directive.qbk
@@ -728,9 +728,9 @@ a: Unused --> hold[a]: Unused``]]
 
 [note The `hold[]` directive uses `swap()` to implement the rollback/commit 
       semantics for the attribute. For this reason the attribute type needs to
-      to be usable with `boost::swap` (needs to either define a proper overload
-      for `swap(attribute_type&, attribute_type&)` or expose a member function
-      `attribute_type::swap(attribute_type&)`.]
+      to be usable with `boost::core::invoke_swap` (needs to define a proper overload
+      for `swap(attribute_type&, attribute_type&)` or be both move-constructible
+      and move-assignable.]
 
 [heading Complexity]
 

--- a/include/boost/spirit/home/classic/tree/common.hpp
+++ b/include/boost/spirit/home/classic/tree/common.hpp
@@ -519,7 +519,6 @@ namespace impl {
     {
         using std::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
-        using boost::swap;
         swap(t1, t2);
     }
 }
@@ -1044,7 +1043,6 @@ struct infix_node_op
         typedef typename MatchT::container_t::value_type value_t;
 
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // copying the tree nodes is expensive, since it may copy a whole
@@ -1096,7 +1094,6 @@ struct discard_first_node_op
         typedef typename MatchT::container_t::value_type value_t;
 
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // copying the tree nodes is expensive, since it may copy a whole
@@ -1160,7 +1157,6 @@ struct discard_last_node_op
         typedef typename MatchT::container_t::value_type value_t;
 
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // copying the tree nodes is expensive, since it may copy a whole
@@ -1220,7 +1216,6 @@ struct inner_node_op
         typedef typename MatchT::container_t::value_type value_t;
 
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // copying the tree nodes is expensive, since it may copy a whole
@@ -1543,7 +1538,6 @@ struct tree_parse_info
         , trees()
     {
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // use auto_ptr like ownership for the trees data member
@@ -1563,7 +1557,6 @@ struct tree_parse_info
         , trees()
     {
         using std::swap;
-        using boost::swap;
         using BOOST_SPIRIT_CLASSIC_NS::swap;
 
         // use auto_ptr like ownership for the trees data member

--- a/include/boost/spirit/home/support/attributes.hpp
+++ b/include/boost/spirit/home/support/attributes.hpp
@@ -41,7 +41,8 @@
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/mpl/equal.hpp>
 #include <boost/proto/traits.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/invoke_swap.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/range/range_fwd.hpp>
 #include <boost/config.hpp>
@@ -990,7 +991,7 @@ namespace boost { namespace spirit { namespace traits
     template <typename T>
     void swap_impl(T& a, T& b)
     {
-        boost::swap(a, b);
+        boost::core::invoke_swap(a, b);
     }
 
     template <typename A>

--- a/include/boost/spirit/home/support/iterators/detail/buf_id_check_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/buf_id_check_policy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/config.hpp>
 #include <boost/throw_exception.hpp>
 #include <exception>    // for std::exception
@@ -51,7 +52,7 @@ namespace boost { namespace spirit { namespace iterator_policies
 
             void swap(unique& x)
             {
-                boost::swap(buf_id, x.buf_id);
+                boost::core::invoke_swap(buf_id, x.buf_id);
             }
 
             // called to verify that everything is ok.

--- a/include/boost/spirit/home/support/iterators/detail/fixed_size_queue_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/fixed_size_queue_policy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
 #include <boost/spirit/home/support/iterators/detail/fixed_size_queue.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/assert.hpp>
 #include <cstdlib>
 
@@ -45,7 +46,7 @@ namespace boost { namespace spirit { namespace iterator_policies
 
             void swap(unique& x)
             {
-                boost::swap(queued_position, x.queued_position);
+                boost::core::invoke_swap(queued_position, x.queued_position);
             }
 
             //  This is called when the iterator is dereferenced. It's a 

--- a/include/boost/spirit/home/support/iterators/detail/functor_input_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/functor_input_policy.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace spirit { namespace iterator_policies
@@ -46,7 +47,7 @@ namespace boost { namespace spirit { namespace iterator_policies
 
             void swap(unique& x)
             {
-                boost::swap(ftor, x.ftor);
+                boost::core::invoke_swap(ftor, x.ftor);
             }
 
         public:

--- a/include/boost/spirit/home/support/iterators/detail/split_functor_input_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/split_functor_input_policy.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/assert.hpp>
 #include <boost/type_traits/is_empty.hpp>
 
@@ -126,7 +127,7 @@ namespace boost { namespace spirit { namespace iterator_policies
 
             void swap(unique& x)
             {
-                boost::swap(ftor, x.ftor);
+                boost::core::invoke_swap(ftor, x.ftor);
             }
 
         public:

--- a/include/boost/spirit/home/support/iterators/detail/split_std_deque_policy.hpp
+++ b/include/boost/spirit/home/support/iterators/detail/split_std_deque_policy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/spirit/home/support/iterators/multi_pass_fwd.hpp>
 #include <boost/spirit/home/support/iterators/detail/multi_pass.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/assert.hpp>
 #include <vector>
 
@@ -42,7 +43,7 @@ namespace boost { namespace spirit { namespace iterator_policies
 
             void swap(unique& x)
             {
-                boost::swap(queued_position, x.queued_position);
+                boost::core::invoke_swap(queued_position, x.queued_position);
             }
 
             // This is called when the iterator is dereferenced.  It's a 

--- a/include/boost/spirit/home/support/iterators/multi_pass.hpp
+++ b/include/boost/spirit/home/support/iterators/multi_pass.hpp
@@ -14,6 +14,7 @@
 #include <boost/spirit/home/support/iterators/detail/combine_policies.hpp>
 #include <boost/limits.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/utility/base_from_member.hpp>
 
 namespace boost { namespace spirit
@@ -92,7 +93,7 @@ namespace boost { namespace spirit
 
         void swap(multi_pass& x)
         {
-            boost::swap(this->member, x.member);
+            boost::core::invoke_swap(this->member, x.member);
             this->policies_base_type::swap(x);
         }
 

--- a/include/boost/spirit/home/support/iterators/multi_pass_fwd.hpp
+++ b/include/boost/spirit/home/support/iterators/multi_pass_fwd.hpp
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <boost/spirit/home/support/multi_pass_wrapper.hpp>
-#include <boost/swap.hpp>
 
 namespace boost { namespace spirit {
 


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement, where needed.

Removed `using boost::swap` in `common.hpp`, since this is not the intended usage of Boost.Swap, and doing so did not add anything to the existing code (which already did `using std::swap`).

Corrected documentation re. compatibility with `boost::swap`/`boost::core::invoke_swap`. It does not (and never did) use member `swap()` functions, but simply forwards to either `std::swap` or the user-defined free function overload (which, in turn, may forward to the member `swap()`).