### PR TITLE
Fix missing includes for karma/binary

### DIFF
--- a/include/boost/spirit/home/karma/binary/binary.hpp
+++ b/include/boost/spirit/home/karma/binary/binary.hpp
@@ -22,6 +22,7 @@
 #include <boost/spirit/home/karma/detail/extract_from.hpp>
 #include <boost/spirit/home/support/unused.hpp>
 #include <boost/spirit/home/support/container.hpp>
+#include <boost/core/scoped_enum.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/at.hpp>
 #include <boost/mpl/or.hpp>


### PR DESCRIPTION
Previosuly, scoped_enum was included into karma's binary.hpp through boost/endian/detail/order.hpp. Since Boost 1.84.0 that file stopped using scoped enum and switched to use plain enum class instead; so it needs to be added here.