### PR TITLE
X3: Constrain `operator>`

### DIFF
--- a/include/boost/spirit/home/x3/operator/sequence.hpp
+++ b/include/boost/spirit/home/x3/operator/sequence.hpp
@@ -59,6 +59,7 @@ namespace boost { namespace spirit { namespace x3
 
     template <typename Left, typename Right>
     constexpr auto operator>(Left const& left, Right const& right)
+      -> decltype(left >> expect[right])
     {
         return left >> expect[right];
     }

--- a/test/x3/Jamfile
+++ b/test/x3/Jamfile
@@ -94,6 +94,7 @@ run omit.cpp ;
 run optional.cpp ;
 run plus.cpp ;
 run with.cpp ;
+run operators_adl.cpp ;
 
 run raw.cpp ;
 run real1.cpp ;

--- a/test/x3/operators_adl.cpp
+++ b/test/x3/operators_adl.cpp
@@ -1,0 +1,49 @@
+/*=============================================================================
+    Copyright (c) 2024 Nikita Kniazev
+
+    Use, modification and distribution is subject to the Boost Software
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/home/x3.hpp>
+
+#define OP(x) \
+template <typename P> \
+auto adl_checker_impl(P& p, int) -> decltype(void(x)) { \
+    static_assert(sizeof(P) == 0, #x " is unconstrained"); \
+}
+
+template <typename T>
+auto adl_checker_impl(T&, long) {}
+
+OP(p >> p)
+#if defined(_MSC_VER) && _MSC_VER >= 1910
+OP(p > p)
+OP(p | p)
+OP(p - p)
+OP(p % p)
+OP(-p)
+OP(!p)
+OP(*p)
+OP(+p)
+//OP(&p)
+#endif
+
+template <typename P>
+void adl_checker(P& p)
+{
+    adl_checker_impl(p, 0);
+}
+
+namespace boost { namespace spirit { namespace x3 {
+    struct test_base {};
+}}}
+
+struct not_a_parser : boost::spirit::x3::test_base {};
+
+int main()
+{
+    not_a_parser test;
+    adl_checker(test);
+}


### PR DESCRIPTION
It might be instantiated for user types inherited from classes in our namespace.

Fixes #782