### PR TITLE
Initialize variable n in parse function

### DIFF
--- a/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
+++ b/include/boost/spirit/home/qi/numeric/detail/real_impl.hpp
@@ -206,7 +206,7 @@ namespace boost { namespace spirit { namespace qi  { namespace detail
             bool neg = p.parse_sign(first, last);
 
             // Now attempt to parse an integer
-            T n;
+            T n = 0;
 
             typename traits::real_accumulator<T>::type acc_n = 0;
             bool got_a_number = p.parse_n(first, last, acc_n);


### PR DESCRIPTION
This PR intents to prevent a maybe uninitialized warning that appear with recent versions of gcc (11 and 12).