### PR TITLE
Update sexpr_parser.hpp

### DIFF
--- a/example/support/utree/sexpr_parser.hpp
+++ b/example/support/utree/sexpr_parser.hpp
@@ -152,8 +152,9 @@ template <typename Iterator, typename ErrorHandler = error_handler<Iterator> >
 struct parser : qi::grammar<Iterator, utree(), whitespace<Iterator> >
 {
     qi::rule<Iterator, utree(), whitespace<Iterator> >
-        start, element, list;
-
+        start, element;
+    qi::rule<Iterator, utree::list_type(), whitespace<Iterator> >
+        list;
     qi::rule<Iterator, utree()>
         atom;
 


### PR DESCRIPTION
updated rule for list - to have it captured in utree::list_type - and thus preserve the actual structure of the parsing tree