### PR TITLE
Modernize `x3::confix`

### DIFF
--- a/include/boost/spirit/home/x3/directive/confix.hpp
+++ b/include/boost/spirit/home/x3/directive/confix.hpp
@@ -2,7 +2,7 @@
     Copyright (c) 2009 Chris Hoeppler
     Copyright (c) 2014 Lee Clagett
     Copyright (c) 2017 wanghan02
-    Copyright (c) 2024 Nana Sakisaka
+    Copyright (c) 2024-2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,82 +13,124 @@
 
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/support/expectation.hpp>
+#include <boost/spirit/home/x3/support/unused.hpp>
 
-namespace boost { namespace spirit { namespace x3
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x3
 {
     template<typename Prefix, typename Subject, typename Postfix>
     struct confix_directive :
         unary_parser<Subject, confix_directive<Prefix, Subject, Postfix>>
     {
-        typedef unary_parser<
-            Subject, confix_directive<Prefix, Subject, Postfix>> base_type;
-        static bool const is_pass_through_unary = true;
-        static bool const handles_container = Subject::handles_container;
+        using base_type = unary_parser<Subject, confix_directive<Prefix, Subject, Postfix>>;
+        static constexpr bool is_pass_through_unary = true;
+        static constexpr bool handles_container = Subject::handles_container;
 
-        constexpr confix_directive(Prefix const& prefix
-                         , Subject const& subject
-                         , Postfix const& postfix) :
-            base_type(subject),
-            prefix(prefix),
-            postfix(postfix)
+        template <typename PrefixT, typename SubjectT, typename PostfixT>
+            requires
+                std::is_constructible_v<Prefix, PrefixT> &&
+                std::is_constructible_v<Subject, SubjectT> &&
+                std::is_constructible_v<Postfix, PostfixT>
+        constexpr confix_directive(PrefixT&& prefix, SubjectT&& subject, PostfixT&& postfix)
+            noexcept(
+                std::is_nothrow_constructible_v<Prefix, PrefixT> &&
+                std::is_nothrow_constructible_v<Subject, SubjectT> &&
+                std::is_nothrow_constructible_v<Postfix, PostfixT>
+            )
+            : base_type(std::forward<SubjectT>(subject))
+            , prefix_(std::forward<PrefixT>(prefix))
+            , postfix_(std::forward<PostfixT>(postfix))
         {
         }
 
-        template<typename Iterator, typename Context
-                 , typename RContext, typename Attribute>
-        bool parse(
-            Iterator& first, Iterator const& last
-            , Context const& context, RContext& rcontext, Attribute& attr) const
+        template<std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        [[nodiscard]] constexpr bool
+        parse(
+            It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr
+        ) const noexcept(
+            std::is_nothrow_copy_assignable_v<It> &&
+            is_nothrow_parsable_v<Prefix, It, Se, Context, RContext, unused_type> &&
+            is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute> &&
+            is_nothrow_parsable_v<Postfix, It, Se, Context, RContext, unused_type>
+        )
         {
-            Iterator save = first;
+            It const saved_first = first;
 
-            if (!(prefix.parse(first, last, context, rcontext, unused) &&
+            if (!(prefix_.parse(first, last, context, rcontext, unused) &&
                   this->subject.parse(first, last, context, rcontext, attr) &&
-                  postfix.parse(first, last, context, rcontext, unused)))
-            {
+                  postfix_.parse(first, last, context, rcontext, unused))
+            ) {
             #if !BOOST_SPIRIT_X3_THROW_EXPECTATION_FAILURE
-                if (has_expectation_failure(context))
+                if (x3::has_expectation_failure(context))
                 {
                     // don't rollback iterator (mimicking exception-like behavior)
                     return false;
                 }
             #endif
 
-                first = save;
+                first = saved_first;
                 return false;
             }
 
             return true;
         }
 
-        Prefix prefix;
-        Postfix postfix;
+    private:
+        Prefix prefix_;
+        Postfix postfix_;
     };
 
-    template<typename Prefix, typename Postfix>
-    struct confix_gen
+    namespace detail
     {
-        template<typename Subject>
-        constexpr confix_directive<
-            Prefix, typename extension::as_parser<Subject>::value_type, Postfix>
-        operator[](Subject const& subject) const
+        template <X3Subject Prefix, X3Subject Postfix>
+        struct [[nodiscard]] confix_gen
         {
-            return { prefix, as_parser(subject), postfix };
-        }
+            template <X3Subject Subject>
+            [[nodiscard]] constexpr confix_directive<Prefix, as_parser_plain_t<Subject>, Postfix>
+            operator[](Subject&& subject) const
+                noexcept(
+                    is_parser_nothrow_castable_v<Subject> &&
+                    std::is_nothrow_constructible_v<
+                        confix_directive<Prefix, as_parser_plain_t<Subject>, Postfix>,
+                        Prefix const&,
+                        as_parser_t<Subject>,
+                        Postfix const&
+                    >
+                )
+            {
+                return { prefix, as_parser(std::forward<Subject>(subject)), postfix };
+            }
 
-        Prefix prefix;
-        Postfix postfix;
-    };
+            Prefix prefix;
+            Postfix postfix;
+        };
 
+        struct confix_fn
+        {
+            template <X3Subject Prefix, X3Subject Postfix>
+            static constexpr confix_gen<as_parser_plain_t<Prefix>, as_parser_plain_t<Postfix>>
+            operator()(Prefix&& prefix, Postfix&& postfix)
+                noexcept(
+                    is_parser_nothrow_castable_v<Prefix> &&
+                    is_parser_nothrow_castable_v<Postfix> &&
+                    std::is_nothrow_constructible_v<
+                        detail::confix_gen<as_parser_plain_t<Prefix>, as_parser_plain_t<Postfix>>,
+                        as_parser_t<Prefix>, as_parser_t<Postfix>
+                    >
+                )
+            {
+                return { as_parser(std::forward<Prefix>(prefix)), as_parser(std::forward<Postfix>(postfix)) };
+            }
+        };
+    } // detail
 
-    template<typename Prefix, typename Postfix>
-    constexpr confix_gen<typename extension::as_parser<Prefix>::value_type,
-               typename extension::as_parser<Postfix>::value_type>
-    confix(Prefix const& prefix, Postfix const& postfix)
+    namespace cpos
     {
-        return { as_parser(prefix), as_parser(postfix) };
-    }
-
-}}}
+        inline constexpr detail::confix_fn confix{};
+    } // cpos
+} // boost::spirit::x3
 
 #endif

--- a/include/boost/spirit/home/x3/directive/confix.hpp
+++ b/include/boost/spirit/home/x3/directive/confix.hpp
@@ -127,7 +127,7 @@ namespace boost::spirit::x3
         };
     } // detail
 
-    namespace cpos
+    inline namespace cpos
     {
         inline constexpr detail::confix_fn confix{};
     } // cpos

--- a/test/x3/confix.cpp
+++ b/test/x3/confix.cpp
@@ -1,10 +1,13 @@
 /*=============================================================================
     Copyright (c) 2009 Chris Hoeppler
     Copyright (c) 2014 Lee Clagett
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
+
+#include "test.hpp"
 
 #include <boost/spirit/home/x3/char.hpp>
 #include <boost/spirit/home/x3/core.hpp>
@@ -12,8 +15,6 @@
 #include <boost/spirit/home/x3/operator.hpp>
 #include <boost/spirit/home/x3/string.hpp>
 #include <boost/spirit/home/x3/directive/confix.hpp>
-
-#include "test.hpp"
 
 int main()
 {
@@ -25,7 +26,7 @@ int main()
     BOOST_SPIRIT_ASSERT_CONSTEXPR_CTORS(x3::confix("/*", "*/"));
 
     {
-        const auto comment = x3::confix("/*", "*/");
+        constexpr auto comment = x3::confix("/*", "*/");
 
         BOOST_TEST(test_failure("/abcdef*/", comment["abcdef"]));
         BOOST_TEST(test_failure("/* abcdef*/", comment["abcdef"]));
@@ -35,18 +36,18 @@ int main()
         {
             unsigned value = 0;
             BOOST_TEST(
-                test_attr(" /* 123 */ ", comment[x3::uint_], value, x3::space));
+                test_attr(" /* 123 */ ", comment[x3::uint_], value, x3::standard::space));
             BOOST_TEST(value == 123);
 
             using x3::_attr;
             value = 0;
-            const auto lambda = [&value](auto& ctx ){ value = _attr(ctx) + 1; };
+            auto const lambda = [&value](auto& ctx) { value = _attr(ctx) + 1; };
             BOOST_TEST(test_attr("/*123*/", comment[x3::uint_][lambda], value));
             BOOST_TEST(value == 124);
         }
     }
     {
-        const auto array = x3::confix('[', ']');
+        constexpr auto array = x3::confix('[', ']');
 
         {
             std::vector<unsigned> values;


### PR DESCRIPTION
Part of #809 

Use concepts to constrain `x3::confix`. It is now a CPO that inhibits ADL.