### PR TITLE
Modernize `x3::matches`

### DIFF
--- a/include/boost/spirit/home/x3/directive/matches.hpp
+++ b/include/boost/spirit/home/x3/directive/matches.hpp
@@ -2,7 +2,7 @@
     Copyright (c) 2015 Mario Lang
     Copyright (c) 2001-2011 Hartmut Kaiser
     Copyright (c) 2017 wanghan02
-    Copyright (c) 2024 Nana Sakisaka
+    Copyright (c) 2024-2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,45 +15,64 @@
 #include <boost/spirit/home/x3/support/expectation.hpp>
 #include <boost/spirit/home/x3/support/unused.hpp>
 
-namespace boost { namespace spirit { namespace x3
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x3
 {
     template <typename Subject>
     struct matches_directive : unary_parser<Subject, matches_directive<Subject>>
     {
         using base_type = unary_parser<Subject, matches_directive<Subject>>;
-        static bool const has_attribute = true;
+        static constexpr bool has_attribute = true;
         using attribute_type = bool;
 
-        constexpr matches_directive(Subject const& subject) : base_type(subject) {}
+        template <typename SubjectT>
+            requires std::is_constructible_v<Subject, SubjectT>
+        constexpr matches_directive(SubjectT&& subject)
+            noexcept(std::is_nothrow_constructible_v<Subject, SubjectT>)
+            : base_type(std::forward<SubjectT>(subject))
+        {}
 
-        template <typename Iterator, typename Context
-          , typename RContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr) const
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+            noexcept(
+                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type> &&
+                noexcept(traits::move_to(std::declval<bool const&>(), attr))
+            )
         {
-            bool const result = this->subject.parse(
-                    first, last, context, rcontext, unused);
+            bool const matched = this->subject.parse(first, last, context, rcontext, unused);
 
         #if !BOOST_SPIRIT_X3_THROW_EXPECTATION_FAILURE
-            if (has_expectation_failure(context)) return false;
+            if (x3::has_expectation_failure(context)) return false;
         #endif
 
-            traits::move_to(result, attr);
+            traits::move_to(matched, attr);
             return true;
         }
     };
 
-    struct matches_gen
+    namespace detail
     {
-        template <typename Subject>
-        constexpr matches_directive<typename extension::as_parser<Subject>::value_type>
-        operator[](Subject const& subject) const
+        struct matches_gen
         {
-            return { as_parser(subject) };
-        }
-    };
+            template <X3Subject Subject>
+            [[nodiscard]] constexpr matches_directive<as_parser_plain_t<Subject>>
+            operator[](Subject&& subject) const
+                noexcept(is_parser_nothrow_constructible_v<matches_directive<as_parser_plain_t<Subject>>, Subject>)
+            {
+                return { as_parser(std::forward<Subject>(subject)) };
+            }
+        };
+    } // detail
 
-    constexpr auto matches = matches_gen{};
-}}}
+    inline namespace cpos
+    {
+        inline constexpr detail::matches_gen matches{};
+    } // cpos
+
+} // boost::spirit::x3
 
 #endif

--- a/test/x3/matches.cpp
+++ b/test/x3/matches.cpp
@@ -1,16 +1,18 @@
 /*=============================================================================
     Copyright (c) 2001-2015 Joel de Guzman
     Copyright (c) 2001-2010 Hartmut Kaiser
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#include <boost/spirit/home/x3.hpp>
-#include <iostream>
 #include "test.hpp"
 
-int
-main()
+#include <boost/spirit/home/x3.hpp>
+
+#include <iostream>
+
+int main()
 {
     using spirit_test::test;
     using spirit_test::test_attr;


### PR DESCRIPTION
Part of #809 

Use concepts in `x3::matches`. It is now a CPO that inhibits ADL.