### PR TITLE
Modernize `x3::skip`

### DIFF
--- a/include/boost/spirit/home/x3/directive/skip.hpp
+++ b/include/boost/spirit/home/x3/directive/skip.hpp
@@ -1,7 +1,7 @@
 /*=============================================================================
     Copyright (c) 2001-2014 Joel de Guzman
     Copyright (c) 2013 Agustin Berge
-    Copyright (c) 2024 Nana Sakisaka
+    Copyright (c) 2024-2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,67 +14,94 @@
 #include <boost/spirit/home/x3/support/expectation.hpp>
 #include <boost/spirit/home/x3/core/skip_over.hpp>
 #include <boost/spirit/home/x3/core/parser.hpp>
-#include <boost/utility/enable_if.hpp>
 
-namespace boost { namespace spirit { namespace x3
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x3
 {
     template <typename Subject>
     struct reskip_directive : unary_parser<Subject, reskip_directive<Subject>>
     {
-        typedef unary_parser<Subject, reskip_directive<Subject>> base_type;
-        static bool const is_pass_through_unary = true;
-        static bool const handles_container = Subject::handles_container;
+        using base_type = unary_parser<Subject, reskip_directive<Subject>>;
+        static constexpr bool is_pass_through_unary = true;
+        static constexpr bool handles_container = Subject::handles_container;
 
-        constexpr reskip_directive(Subject const& subject)
-          : base_type(subject) {}
+        template <typename SubjectT>
+            requires
+                (!std::is_same_v<std::remove_cvref_t<SubjectT>, reskip_directive>) &&
+                std::is_constructible_v<Subject, SubjectT>
+        constexpr reskip_directive(SubjectT&& subject)
+            noexcept(std::is_nothrow_constructible_v<Subject, SubjectT>)
+            : base_type(std::forward<SubjectT>(subject))
+        {}
 
-        template <typename Iterator, typename Context
-          , typename RContext, typename Attribute>
-        typename disable_if<has_skipper<Context>, bool>::type
-        parse(Iterator& first, Iterator const& last
-          , Context& context, RContext& rcontext, Attribute& attr) const
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+            requires has_skipper_v<Context>
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute>)
         {
-            auto const& skipper =
-                detail::get_unused_skipper(x3::get<skipper_tag>(context));
+            static_assert(Parsable<Subject, It, Se, Context, RContext, Attribute>);
+            return this->subject.parse(first, last, context, rcontext, attr);
+        }
 
-            auto const local_ctx = make_context<skipper_tag>(skipper, context);
+    private:
+        template <typename Context>
+        using context_t = x3::context<
+            skipper_tag,
+            decltype(detail::get_unused_skipper(x3::get<skipper_tag>(std::declval<Context const&>()))),
+            Context
+        >;
+
+    public:
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+            requires (!has_skipper_v<Context>)
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+            // never noexcept (requires expectation failure modification)
+        {
+            static_assert(Parsable<Subject, It, Se, context_t<Context>, RContext, Attribute>);
+
+            auto const& skipper = detail::get_unused_skipper(x3::get<skipper_tag>(context));
+
+            auto const local_ctx = x3::make_context<skipper_tag>(skipper, context);
             bool const r = this->subject.parse(first, last, local_ctx, rcontext, attr);
 
         #if !BOOST_SPIRIT_X3_THROW_EXPECTATION_FAILURE
-            if (has_expectation_failure(local_ctx))
+            if (x3::has_expectation_failure(local_ctx))
             {
-                set_expectation_failure(get_expectation_failure(local_ctx), context);
+                x3::set_expectation_failure(x3::get_expectation_failure(local_ctx), context);
             }
         #endif
 
             return r;
-        }
-        template <typename Iterator, typename Context
-          , typename RContext, typename Attribute>
-        typename enable_if<has_skipper<Context>, bool>::type
-        parse(Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr) const
-        {
-            return this->subject.parse(first, last, context, rcontext, attr);
         }
     };
 
     template <typename Subject, typename Skipper>
     struct skip_directive : unary_parser<Subject, skip_directive<Subject, Skipper>>
     {
-        typedef unary_parser<Subject, skip_directive<Subject, Skipper>> base_type;
-        static bool const is_pass_through_unary = true;
-        static bool const handles_container = Subject::handles_container;
+        using base_type = unary_parser<Subject, skip_directive<Subject, Skipper>>;
+        static constexpr bool is_pass_through_unary = true;
+        static constexpr bool handles_container = Subject::handles_container;
 
-        constexpr skip_directive(Subject const& subject, Skipper const& skipper)
-          : base_type(subject)
-          , skipper(skipper)
+        template <typename SubjectT, typename SkipperT>
+            requires std::is_constructible_v<Subject, SubjectT> && std::is_constructible_v<Skipper, SkipperT>
+        constexpr skip_directive(SubjectT&& subject, SkipperT&& skipper)
+            noexcept(std::is_nothrow_constructible_v<Subject, SubjectT> && std::is_nothrow_constructible_v<Skipper, SkipperT>)
+            : base_type(std::forward<SubjectT>(subject))
+            , skipper_(skipper)
         {}
 
-        template <typename Iterator, typename RContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , unused_type const&, RContext& rcontext, Attribute& attr) const
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename RContext, typename Attribute>
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, unused_type const&, RContext& rcontext, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, x3::context<skipper_tag, Skipper>, RContext, Attribute>)
         {
+            static_assert(Parsable<Subject, It, Se, x3::context<skipper_tag, Skipper>, RContext, Attribute>);
+
             // It is perfectly fine to omit the expectation_failure context
             // even in non-throwing mode if and only if the skipper itself
             // is expectation-less.
@@ -94,73 +121,126 @@ namespace boost { namespace spirit { namespace x3
             // Anyways, we don't need to repack the expectation context
             // into our brand new skipper context, in contrast to the
             // repacking process done in `x3::skip_over`.
-            return this->subject.parse(first, last,
-                make_context<skipper_tag>(skipper), rcontext, attr);
+            return this->subject.parse(
+                first, last, x3::make_context<skipper_tag>(skipper_), rcontext, attr
+            );
         }
 
-        template <typename Iterator, typename Context, typename RContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& attr) const
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+            // never noexcept (requires expectation failure modification)
         {
+            static_assert(Parsable<Subject, It, Se, x3::context<skipper_tag, Context>, RContext, Attribute>);
+
         #if BOOST_SPIRIT_X3_THROW_EXPECTATION_FAILURE
-            return this->subject.parse(first, last, make_context<skipper_tag>(skipper, context), rcontext, attr);
+            return this->subject.parse(first, last, x3::make_context<skipper_tag>(skipper_, context), rcontext, attr);
 
         #else
             static_assert(
                 !std::is_same_v<expectation_failure_t<Context>, unused_type>,
                 "Context type was not specified for x3::expectation_failure_tag. "
                 "You probably forgot: `x3::with<x3::expectation_failure_tag>(failure)[p]`. "
-                "Note that you must also bind the context to your skipper.");
+                "Note that you must also bind the context to your skipper."
+            );
 
             // This logic is heavily related to the instantiation chain;
             // see `x3::skip_over` for details.
-            auto const local_ctx = make_context<skipper_tag>(skipper, context);
+            auto const local_ctx = x3::make_context<skipper_tag>(skipper_, context);
             bool const r = this->subject.parse(first, last, local_ctx, rcontext, attr);
 
-            if (has_expectation_failure(local_ctx))
+            if (x3::has_expectation_failure(local_ctx))
             {
-                set_expectation_failure(get_expectation_failure(local_ctx), context);
+                x3::set_expectation_failure(x3::get_expectation_failure(local_ctx), context);
             }
             return r;
         #endif
         }
 
-        Skipper const skipper;
+    private:
+        Skipper skipper_;
     };
 
-    struct reskip_gen
+    namespace detail
     {
-        template <typename Skipper>
-        struct skip_gen
+        template <X3Subject Skipper>
+        struct skip_gen_impl
         {
-            constexpr skip_gen(Skipper const& skipper)
-              : skipper_(skipper) {}
+            // Unreference rvalue reference, but hold lvalue reference as-is
+            using skipper_type = std::conditional_t<
+                std::is_rvalue_reference_v<Skipper>,
+                std::remove_reference_t<Skipper>,
+                Skipper
+            >;
 
-            template <typename Subject>
-            constexpr skip_directive<typename extension::as_parser<Subject>::value_type, Skipper>
-            operator[](Subject const& subject) const
+            template <typename SkipperT>
+                requires std::is_same_v<std::remove_cvref_t<SkipperT>, std::remove_cvref_t<Skipper>>
+            constexpr skip_gen_impl(SkipperT&& skipper)
+                noexcept(std::is_nothrow_constructible_v<skipper_type, SkipperT>)
+                : skipper_(std::forward<SkipperT>(skipper))
+            {}
+
+            template <X3Subject Subject>
+            [[nodiscard]] constexpr skip_directive<as_parser_plain_t<Subject>, std::remove_cvref_t<Skipper>>
+            operator[](Subject&& subject) const
+                noexcept(
+                    is_parser_nothrow_castable_v<Subject> &&
+                    std::is_nothrow_constructible_v<
+                        skip_directive<as_parser_plain_t<Subject>, std::remove_cvref_t<Skipper>>,
+                        as_parser_t<Subject>,
+                        skipper_type const&
+                    >
+                )
             {
-                return { as_parser(subject), skipper_ };
+                return { as_parser(std::forward<Subject>(subject)), skipper_ };
             }
 
-            Skipper skipper_;
+        private:
+            skipper_type skipper_;
         };
 
-        template <typename Skipper>
-        constexpr skip_gen<Skipper> const operator()(Skipper const& skipper) const
+        struct skip_gen
         {
-            return { skipper };
-        }
+            template <X3Subject Skipper>
+            [[nodiscard]]
+            static constexpr skip_gen_impl<as_parser_t<Skipper>>
+            operator()(Skipper&& skipper)
+                noexcept(
+                    is_parser_nothrow_castable_v<Skipper> &&
+                    std::is_nothrow_constructible_v<skip_gen_impl<as_parser_t<Skipper>>, as_parser_t<Skipper>>
+                )
+            {
+                return { as_parser(std::forward<Skipper>(skipper)) };
+            }
 
-        template <typename Subject>
-        constexpr reskip_directive<typename extension::as_parser<Subject>::value_type>
-        operator[](Subject const& subject) const
+            template <typename Subject>
+            [[nodiscard, deprecated("Use `x3::reskip[p]`.")]]
+            /* static */ constexpr reskip_directive<as_parser_plain_t<Subject>>
+            operator[](Subject&& subject) const // MSVC 2022 bug: cannot define `static operator[]` even in C++26 mode
+                noexcept(is_parser_nothrow_constructible_v<reskip_directive<as_parser_plain_t<Subject>>, Subject>)
+            {
+                return { as_parser(std::forward<Subject>(subject)) };
+            }
+        };
+
+        struct reskip_gen
         {
-            return { as_parser(subject) };
-        }
-    };
+            template <X3Subject Subject>
+            [[nodiscard]]
+            /* static */ constexpr reskip_directive<as_parser_plain_t<Subject>>
+            operator[](Subject&& subject) const // MSVC 2022 bug: cannot define `static operator[]` even in C++26 mode
+                noexcept(is_parser_nothrow_constructible_v<reskip_directive<as_parser_plain_t<Subject>>, Subject>)
+            {
+                return { as_parser(std::forward<Subject>(subject)) };
+            }
+        };
+    } // detail
 
-    constexpr auto skip = reskip_gen{};
-}}}
+    inline namespace cpos
+    {
+        inline constexpr detail::skip_gen skip{};
+        inline constexpr detail::reskip_gen reskip{};
+    }
+} // boost::spirit::x3
 
 #endif

--- a/test/x3/skip.cpp
+++ b/test/x3/skip.cpp
@@ -1,24 +1,25 @@
 /*=============================================================================
     Copyright (c) 2001-2015 Joel de Guzman
     Copyright (c) 2013 Agustin Berge
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
+#include "test.hpp"
+
 #include <boost/spirit/home/x3.hpp>
 
 #include <iostream>
-#include "test.hpp"
 
-int
-main()
+int main()
 {
     using spirit_test::test;
     using spirit_test::test_attr;
-    using boost::spirit::x3::ascii::space;
-    using boost::spirit::x3::ascii::space_type;
-    using boost::spirit::x3::ascii::char_;
-    using boost::spirit::x3::ascii::alpha;
+    using boost::spirit::x3::standard::space;
+    using boost::spirit::x3::standard::space_type;
+    using boost::spirit::x3::standard::char_;
+    using boost::spirit::x3::standard::alpha;
     using boost::spirit::x3::lexeme;
     using boost::spirit::x3::skip;
     using boost::spirit::x3::lit;
@@ -29,13 +30,15 @@ main()
         BOOST_TEST((test("a b c d", skip(space)[*char_])));
     }
 
-    { // test attribute
+    {
+        // test attribute
         std::string s;
         BOOST_TEST((test_attr("a b c d", skip(space)[*char_], s)));
         BOOST_TEST(s == "abcd");
     }
 
-    { // reskip
+    {
+        // reskip
         BOOST_TEST((test("ab c d", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));
         BOOST_TEST((test("abcd", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));
         BOOST_TEST(!(test("a bcd", lexeme[lit('a') >> 'b' >> skip[lit('c') >> 'd']], space)));


### PR DESCRIPTION
Part of #809 

## Summary
- Use concepts in `x3::skip`.
- Make `x3::skip` a CPO that inhibits ADL.
- `x3::reskip[...]` new API that has the same effect as `x3::skip[...]`.
- `x3::skip[...]`: deprecated in favor of `x3::reskip[...]`.

## Renaming `skip[p]` to `reskip[p]`
 I suspect that the issue like #797 is happening because people think `x3::skip` does "skip" something, but actually it does **"reskip"** in certain cases. 

- `skip(skipper)[p]`  => Use `skipper` for `p`.
- `no_skip[skip[p]]` => Re-establish the skipper inhibited by `no_skip`.

IMHO, the second API should definitely be named "reskip" instead of just "skip". This PR deprecates the `operator[]` for this case, and adds the brand new `reskip[...]` for this purpose:

- `no_skip[skip[p]]` => `[[deprecated]]`, but retains the same functionality for now.
- `no_skip[reskip[p]]` => Re-establish the skipper inhibited by `no_skip`.

We should accept the fact that we named it poorly. I guess we should've done this fix many years ago. To be honest, I remember that I got confused with this naming when I started using Qi. I believe now is the time to fix.

### Success chance of renaming
I'm not entirely sure how people feel about this change. It's possible that some people rather think "skip" is more intuitive than "reskip". If such complaints emerge, we can undeprecate the rename. (Note: even the C++ standard sometimes do undeprecate features.)

## Documentation
I understand this change requires documentation. But I have tons of work for #809, and I plan to documentation work at the very last stage of modernization. Meanwhile, compiler will emit the helpful warning that says users should migrate to `x3::reskip`, thanks to the `[[deprecated]]` attribute.