### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ target_link_libraries(boost_spirit
     Boost::proto
     Boost::range
     Boost::smart_ptr
-    Boost::static_assert
     Boost::thread
     Boost::throw_exception
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -36,7 +36,6 @@ constant boost_dependencies :
     /boost/range//boost_range
     /boost/regex//boost_regex
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/thread//boost_thread
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.